### PR TITLE
perf: add release profile with LTO and single codegen unit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,3 +74,7 @@ async-stream = "0.3"
 # Utilities
 uuid = { version = "1", features = ["v4"] }
 chrono = { version = "0.4", features = ["serde"] }
+
+[profile.release]
+lto = "thin"
+codegen-units = 1


### PR DESCRIPTION
## Summary

- Enables `lto = "thin"` for cross-crate inlining in release builds
- Sets `codegen-units = 1` to allow LLVM whole-program optimization

These settings improve all Rust-side overhead (tokenization, sampling logic, cache management, HTTP handling) without affecting GPU kernel performance. Build times for release will increase but runtime performance improves.

## Test plan

- [ ] Verify `cargo build --release` completes successfully
- [ ] Compare binary size before/after (expect slightly smaller)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release build configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->