### PR TITLE
perf: use async_eval to pipeline GPU execution in decode loop

### DIFF
--- a/crates/mlx-engine/src/simple.rs
+++ b/crates/mlx-engine/src/simple.rs
@@ -5,7 +5,7 @@ use mlx_models::{AnyCache, AnyModel, sample};
 use mlx_rs::{
     Array,
     ops::indexing::{IndexOp, NewAxis},
-    transforms::eval,
+    transforms::{async_eval, eval},
 };
 use tokenizers::Tokenizer;
 
@@ -316,13 +316,10 @@ impl SimpleEngine {
                 temperature,
                 top_p,
             )?;
+            async_eval([&current_token]).map_err(EngineError::Mlx)?;
 
             let token_id: u32 = current_token.item();
             tokens.push(token_id);
-
-            if tokens.len() % 32 == 0 {
-                eval([&current_token]).map_err(EngineError::Mlx)?;
-            }
 
             let completion_len = Self::completion_len(&tokens)?;
             let text = self.decode_tokens(&tokens)?;
@@ -428,13 +425,10 @@ impl SimpleEngine {
                 temperature,
                 top_p,
             )?;
+            async_eval([&current_token]).map_err(EngineError::Mlx)?;
 
             let token_id: u32 = current_token.item();
             all_tokens.push(token_id);
-
-            if all_tokens.len() % 32 == 0 {
-                eval([&current_token]).map_err(EngineError::Mlx)?;
-            }
 
             let completion_len = Self::completion_len(&all_tokens)?;
 


### PR DESCRIPTION
## Summary

- Replaces the periodic `eval`-every-32-tokens pattern with `async_eval` after each decode step
- Submits the computation graph to the GPU immediately after construction, allowing CPU work (tokenizer decode, stop-sequence checks) to overlap with GPU execution
- Removes unnecessary periodic `eval` calls that accumulated lazy ops (no longer needed since each step now triggers async evaluation)
- Preserves synchronous `eval` in `run_prefill` where the KV cache must be materialized before prefix cache storage

This is the pattern recommended by Apple's "Writing Fast MLX" guide for maximizing GPU utilization during autoregressive generation.

## Test plan

- [ ] All existing tests pass (`cargo test -- --test-threads=1`)
- [ ] Benchmark tok/s before and after on a real model

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved token generation efficiency by restructuring the evaluation approach during text generation to enhance performance and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->