### PR TITLE
feat: prompt to download missing HF models via huggingface-cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,6 +186,7 @@ jobs:
 
             depends_on :macos
             depends_on arch: :arm64
+            depends_on "huggingface-cli"
 
             url "https://github.com/panbanda/mlx-server/releases/download/${TAG}/mlx-server_${VERSION}_aarch64-apple-darwin.tar.gz"
             sha256 "${DARWIN_ARM64_SHA}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "mlx-engine"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "minijinja",
  "mlx-models",
@@ -1406,7 +1406,7 @@ dependencies = [
 
 [[package]]
 name = "mlx-models"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "mlx-rs",
  "mlx-sys",

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ brew tap panbanda/mlx-server
 brew install mlx-server
 ```
 
-**Build from source** (requires Rust 1.85.0+ and Xcode Command Line Tools):
+**Build from source** (requires Rust 1.85.0+, Xcode Command Line Tools, and `huggingface-cli`):
 
 ```bash
 cargo build --release
@@ -39,7 +39,15 @@ mlx-server --model ~/dev/models/My-Custom-Model
 mlx-server --model mlx-community/Llama-3.1-8B-Instruct-4bit --model mlx-community/Qwen3-Coder-Next-4bit
 ```
 
-The `--model` flag accepts HuggingFace model IDs (`org/name`) or local directory paths. HuggingFace IDs are resolved from the local cache at `~/.cache/huggingface/hub/` (or `$HF_HUB_CACHE` if set, else `$HF_HOME/hub`). Download models first with `huggingface-cli download`.
+The `--model` flag accepts HuggingFace model IDs (`org/name`) or local directory paths. HuggingFace IDs are resolved from the local cache at `~/.cache/huggingface/hub/` (or `$HF_HUB_CACHE` if set, else `$HF_HOME/hub`).
+
+If a model ID is not found in the cache and stdin is a terminal, the server will prompt to download it:
+
+```
+Model 'mlx-community/Llama-3.1-8B-Instruct-4bit' not found in HuggingFace cache. Download now? [y/N]
+```
+
+In non-interactive mode (piped or scripted), startup fails immediately with a hint to run `huggingface-cli download org/name` manually.
 
 Models must be in **MLX safetensors format**. Pre-quantized weights are available from [mlx-community](https://huggingface.co/mlx-community) on HuggingFace. To convert your own:
 

--- a/crates/mlx-server/src/lib.rs
+++ b/crates/mlx-server/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod anthropic_adapter;
 pub mod config;
 pub mod error;
+pub mod model_download;
 pub mod model_resolver;
 pub mod routes;
 pub mod state;

--- a/crates/mlx-server/src/main.rs
+++ b/crates/mlx-server/src/main.rs
@@ -25,7 +25,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         tracing::info!(model = %model_path, "Resolving model path");
         let resolved = match model_resolver::resolve(model_path) {
             Ok(path) => path,
-            Err(_) if model_resolver::is_hf_model_id(model_path) => {
+            Err(resolve_err) if model_resolver::is_hf_model_id(model_path) => {
+                tracing::debug!(error = %resolve_err, "model not in cache; attempting download");
                 let is_interactive = std::io::stdin().is_terminal();
                 model_download::offer_download(
                     model_path,

--- a/crates/mlx-server/src/main.rs
+++ b/crates/mlx-server/src/main.rs
@@ -5,7 +5,9 @@ use std::sync::Arc;
 
 use mlx_engine::simple::SimpleEngine;
 
-use mlx_server::{build_router, config::ServerConfig, model_download, model_resolver, state::AppState};
+use mlx_server::{
+    build_router, config::ServerConfig, model_download, model_resolver, state::AppState,
+};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -38,7 +40,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         if status.success() {
                             Ok(())
                         } else {
-                            Err(format!("huggingface-cli download failed for '{model_path}'"))
+                            Err(format!(
+                                "huggingface-cli download failed for '{model_path}'"
+                            ))
                         }
                     },
                 )?;

--- a/crates/mlx-server/src/model_download.rs
+++ b/crates/mlx-server/src/model_download.rs
@@ -1,0 +1,134 @@
+use std::io::{BufRead, Write};
+
+/// Prompt the user to confirm downloading `model_id`, then call `run_download`.
+///
+/// - `is_interactive`: if `false`, returns an error immediately with a hint to
+///   run `huggingface-cli download` manually (e.g. when stdin is not a TTY).
+/// - `out`: where the prompt is written (typically stderr).
+/// - `input`: where the user's response is read from (typically locked stdin).
+/// - `run_download`: called only when the user confirms; should execute the download.
+pub fn offer_download<W, R, F>(
+    model_id: &str,
+    is_interactive: bool,
+    out: &mut W,
+    mut input: R,
+    run_download: F,
+) -> Result<(), String>
+where
+    W: Write,
+    R: BufRead,
+    F: FnOnce() -> Result<(), String>,
+{
+    if !is_interactive {
+        return Err(format!(
+            "model '{model_id}' not found in HuggingFace cache; run: huggingface-cli download {model_id}"
+        ));
+    }
+
+    write!(
+        out,
+        "Model '{model_id}' not found in HuggingFace cache. Download now? [y/N] "
+    )
+    .map_err(|e| e.to_string())?;
+    out.flush().map_err(|e| e.to_string())?;
+
+    let mut line = String::new();
+    input.read_line(&mut line).map_err(|e| e.to_string())?;
+
+    if !line.trim().eq_ignore_ascii_case("y") {
+        return Err(format!("model '{model_id}' not downloaded; aborting"));
+    }
+
+    run_download()
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn ok_download() -> Result<(), String> {
+        Ok(())
+    }
+
+    fn err_download() -> Result<(), String> {
+        Err("download failed".to_owned())
+    }
+
+    #[test]
+    fn non_interactive_returns_error_with_hint() {
+        let mut out = Vec::new();
+        let result = offer_download("org/model", false, &mut out, "".as_bytes(), ok_download);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("org/model"));
+        assert!(err.contains("huggingface-cli download"));
+    }
+
+    #[test]
+    fn non_interactive_writes_no_prompt() {
+        let mut out = Vec::new();
+        let _ = offer_download("org/model", false, &mut out, "".as_bytes(), ok_download);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn user_confirms_lowercase_succeeds() {
+        let mut out = Vec::new();
+        let result = offer_download("org/model", true, &mut out, "y\n".as_bytes(), ok_download);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn user_confirms_uppercase_succeeds() {
+        let mut out = Vec::new();
+        let result = offer_download("org/model", true, &mut out, "Y\n".as_bytes(), ok_download);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn user_declines_does_not_call_download() {
+        let mut out = Vec::new();
+        let mut called = false;
+        let result = offer_download("org/model", true, &mut out, "n\n".as_bytes(), || {
+            called = true;
+            Ok(())
+        });
+        assert!(result.is_err());
+        assert!(!called);
+    }
+
+    #[test]
+    fn empty_input_treated_as_no() {
+        let mut out = Vec::new();
+        let result = offer_download("org/model", true, &mut out, "\n".as_bytes(), ok_download);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("not downloaded"));
+    }
+
+    #[test]
+    fn download_failure_propagates() {
+        let mut out = Vec::new();
+        let result = offer_download("org/model", true, &mut out, "y\n".as_bytes(), err_download);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("download failed"));
+    }
+
+    #[test]
+    fn prompt_contains_model_id() {
+        let mut out = Vec::new();
+        let _ = offer_download("myorg/mymodel", true, &mut out, "n\n".as_bytes(), ok_download);
+        let prompt = String::from_utf8(out).unwrap();
+        assert!(prompt.contains("myorg/mymodel"));
+    }
+
+    #[test]
+    fn non_interactive_error_contains_exact_command() {
+        let mut out = Vec::new();
+        let result =
+            offer_download("myorg/mymodel", false, &mut out, "".as_bytes(), ok_download);
+        let err = result.unwrap_err();
+        assert!(err.contains("huggingface-cli download myorg/mymodel"));
+    }
+}

--- a/crates/mlx-server/src/model_download.rs
+++ b/crates/mlx-server/src/model_download.rs
@@ -118,7 +118,13 @@ mod tests {
     #[test]
     fn prompt_contains_model_id() {
         let mut out = Vec::new();
-        let _ = offer_download("myorg/mymodel", true, &mut out, "n\n".as_bytes(), ok_download);
+        let _ = offer_download(
+            "myorg/mymodel",
+            true,
+            &mut out,
+            "n\n".as_bytes(),
+            ok_download,
+        );
         let prompt = String::from_utf8(out).unwrap();
         assert!(prompt.contains("myorg/mymodel"));
     }
@@ -126,8 +132,7 @@ mod tests {
     #[test]
     fn non_interactive_error_contains_exact_command() {
         let mut out = Vec::new();
-        let result =
-            offer_download("myorg/mymodel", false, &mut out, "".as_bytes(), ok_download);
+        let result = offer_download("myorg/mymodel", false, &mut out, "".as_bytes(), ok_download);
         let err = result.unwrap_err();
         assert!(err.contains("huggingface-cli download myorg/mymodel"));
     }

--- a/crates/mlx-server/src/model_resolver.rs
+++ b/crates/mlx-server/src/model_resolver.rs
@@ -28,7 +28,7 @@ pub fn resolve(path: &str) -> Result<PathBuf, String> {
     resolve_with_cache(path, default_hf_cache().as_deref())
 }
 
-/// Returns `true` if `s` looks like a `org/name` HuggingFace model ID.
+/// Returns `true` if `s` looks like a `org/name` `HuggingFace` model ID.
 pub fn is_hf_model_id(s: &str) -> bool {
     if s.starts_with("~/") || s.starts_with('/') {
         return false;

--- a/crates/mlx-server/src/model_resolver.rs
+++ b/crates/mlx-server/src/model_resolver.rs
@@ -43,11 +43,9 @@ fn resolve_with_cache(path: &str, cache_root: Option<&Path>) -> Result<PathBuf, 
         return Ok(as_path.to_path_buf());
     }
 
-    if let Some((org, name)) = path.split_once('/') {
-        if !org.is_empty() && !name.is_empty() && !name.contains('/') {
-            if let Some(cache) = cache_root {
-                return resolve_hf_snapshot(cache, org, name);
-            }
+    if is_hf_model_id(path) {
+        if let (Some((org, name)), Some(cache)) = (path.split_once('/'), cache_root) {
+            return resolve_hf_snapshot(cache, org, name);
         }
     }
 


### PR DESCRIPTION
## Summary

- When `--model org/name` is not in the local HuggingFace cache and stdin is a terminal, the server now prompts `[y/N]` and shells out to `huggingface-cli download` instead of failing immediately
- In non-interactive mode (piped/scripted), startup fails with a hint: `run: huggingface-cli download org/name`
- Adds `depends_on "huggingface-cli"` to the generated Homebrew formula so it is installed automatically

## Changes

- `model_download.rs` (new) — `offer_download` with injectable `W: Write`, `R: BufRead`, and `F: FnOnce` for full unit testability
- `model_resolver.rs` — `pub fn is_hf_model_id` + 7 unit tests
- `main.rs` — match on resolve failure, call `model_download::offer_download` with real stdio handles
- `release.yml` — `depends_on "huggingface-cli"` in Homebrew formula
- `README.md` — documents the new prompt behavior and non-interactive fallback

## Test plan

- [ ] `cargo test -p mlx-server` — 158 unit tests + 76 integration tests pass
- [ ] Start server with a model not in cache while in a terminal — prompt appears
- [ ] Answer `n` — server aborts cleanly
- [ ] Answer `y` — `huggingface-cli download` runs, server loads model after
- [ ] Start server with missing model from a script (non-interactive) — fails with hint message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive model download prompt when a specified model isn't found
  * Automatic handling to attempt a model download and retry resolution

* **Documentation**
  * Build requirements updated to include huggingface-cli
  * --model flag docs expanded with interactive and non-interactive behaviors and example usage

* **Tests**
  * Added coverage for interactive/non-interactive download flows and model ID validation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->