### PR TITLE
fix: qwen3 correctness (attention_bias, QK norm, RoPE bug)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1328,12 +1328,22 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minijinja"
-version = "2.15.1"
+version = "2.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b479616bb6f0779fb0f3964246beda02d4b01144e1b0d5519616e012ccc2a245"
+checksum = "5c54f3bcc034dd74496b5ca929fd0b710186672d5ff0b0f255a9ceb259042ece"
 dependencies = [
  "memo-map",
  "self_cell",
+ "serde",
+]
+
+[[package]]
+name = "minijinja-contrib"
+version = "2.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86201a560fde90bf270d3c9d5da0c2a5a0c25bd3242d674fcf03e6a35fcfa7ba"
+dependencies = [
+ "minijinja",
  "serde",
 ]
 
@@ -1366,9 +1376,10 @@ dependencies = [
 
 [[package]]
 name = "mlx-engine"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "minijinja",
+ "minijinja-contrib",
  "mlx-models",
  "mlx-rs",
  "mlx-sys",
@@ -1406,7 +1417,7 @@ dependencies = [
 
 [[package]]
 name = "mlx-models"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "mlx-rs",
  "mlx-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ serde_json = "1"
 # Tokenization + Templates
 tokenizers = { version = "0.22", features = ["http"] }
 minijinja = { version = "2", features = ["loader"] }
+minijinja-contrib = { version = "2", features = ["pycompat"] }
 
 # CLI + Configuration
 clap = { version = "4", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -114,6 +114,18 @@ curl http://localhost:8000/v1/models
 | Qwen3 | `qwen3` | Qwen3 |
 | Qwen3-Next | `qwen3_next` | Qwen3-Coder (hybrid SSM/attention + MoE) |
 
+## Performance
+
+Decode throughput vs Python `mlx_lm` on Apple Silicon (500 tokens, long-form prompt):
+
+| Architecture | Model | Rust tok/s | Python tok/s | Ratio |
+|---|---|---|---|---|
+| llama | Llama-3.2-1B-Instruct-4bit | 453.5 | 436.7 | 1.04x |
+| mistral | Mistral-7B-Instruct-v0.3-4bit | 103.7 | 102.8 | 1.01x |
+| qwen2 | Arch-Router-1.5B | 132.4 | 130.4 | 1.02x |
+| qwen3 | Qwen3-1.7B-4bit | 307.3 | 282.4 | 1.09x |
+| qwen3_next | Qwen3-Coder-Next-4bit | 75.1 | 86.6 | 0.87x |
+
 ## Development
 
 ```bash

--- a/crates/mlx-engine/Cargo.toml
+++ b/crates/mlx-engine/Cargo.toml
@@ -18,6 +18,7 @@ serde.workspace = true
 serde_json.workspace = true
 tokenizers.workspace = true
 minijinja.workspace = true
+minijinja-contrib.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 tokio = { version = "1", features = ["sync"] }

--- a/crates/mlx-engine/src/chat_template.rs
+++ b/crates/mlx-engine/src/chat_template.rs
@@ -372,7 +372,10 @@ TOOLS:{{ tools | length }}
         .unwrap();
         let renderer = ChatTemplateRenderer::from_model_dir(dir.path()).unwrap();
         let result = renderer.apply(&[msg("user", "hi")], None, false).unwrap();
-        assert!(result.starts_with("DEFAULT:"), "Expected default template, got: {result}");
+        assert!(
+            result.starts_with("DEFAULT:"),
+            "Expected default template, got: {result}"
+        );
     }
 
     #[test]
@@ -388,7 +391,21 @@ TOOLS:{{ tools | length }}
         .unwrap();
         let renderer = ChatTemplateRenderer::from_model_dir(dir.path()).unwrap();
         let result = renderer.apply(&[msg("user", "hi")], None, false).unwrap();
-        assert!(result.starts_with("RAG:"), "Expected first template, got: {result}");
+        assert!(
+            result.starts_with("RAG:"),
+            "Expected first template, got: {result}"
+        );
+    }
+
+    #[test]
+    fn test_from_model_dir_array_template_empty_array_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("tokenizer_config.json"),
+            r#"{"chat_template": []}"#,
+        )
+        .unwrap();
+        assert!(ChatTemplateRenderer::from_model_dir(dir.path()).is_err());
     }
 
     #[test]

--- a/crates/mlx-models/src/lib.rs
+++ b/crates/mlx-models/src/lib.rs
@@ -186,7 +186,6 @@ pub fn load_quantized_safetensors_weights<M: ModuleParametersExt>(
             if let Some(param) = params.get_mut(&*key) {
                 **param = value;
             } else if quantized {
-                // Remap: "a.b.weight" -> "a.b.inner.weight", "a.b.bias" -> "a.b.inner.bias"
                 if let Some(remapped) = remap_quantized_key(&key) {
                     if let Some(param) = params.get_mut(&*remapped) {
                         **param = value;


### PR DESCRIPTION
## Summary

- **Chat template**: add `minijinja-contrib` pycompat for Jinja2 compatibility and support array-of-templates `chat_template` format (needed by qwen3/mistral)
- **attention_bias**: read from config instead of hardcoding per model_type; qwen3 requires `bias=false` but was getting `true`
- **QK normalization**: add per-head RMSNorm on Q and K for qwen3 (was entirely missing)
- **RoPE 3D reshape bug**: mlx-rs `nn::Rope::forward` reshapes to 3D before calling `mlx_fast_rope`, which zeros batch elements beyond the first when `seq_len=1`. This broke all heads except head 0 during decode. Workaround: call `mlx_fast_rope` directly on the 4D tensor. Applied to both `transformer.rs` and `qwen3_next.rs`.

## Benchmark results

All 5 architectures, 500 tokens, long-form prompt (M-series Apple Silicon):

| Architecture | Model | Rust tok/s | Python tok/s | Ratio |
|---|---|---|---|---|
| llama | Llama-3.2-1B-Instruct-4bit | 453.5 | 436.7 | 1.04x |
| mistral | Mistral-7B-Instruct-v0.3-4bit | 103.7 | 102.8 | 1.01x |
| qwen2 | Arch-Router-1.5B | 132.4 | 130.4 | 1.02x |
| qwen3 | Qwen3-1.7B-4bit | 307.3 | 282.4 | 1.09x |
| qwen3_next | Qwen3-Coder-Next-4bit | 75.1 | 86.6 | 0.87x |

Rust matches or exceeds Python on all standard transformer architectures. The qwen3_next gap (13%) is structural FFI overhead from ~1950 ops/step in the hybrid SSM/MoE architecture.

## Test plan

- [x] `cargo test --all-features -- --test-threads=1` (76 passed, 10 ignored)
- [x] `RUSTFLAGS=-Dwarnings cargo clippy --all-targets --all-features` (clean)
- [x] Benchmark all 5 architectures against Python mlx_lm (see table above)

Generated with [Claude Code](https://claude.com/claude-code)