### PR TITLE
fix: add linked-versions plugin so mlx-server always releases with its workspace deps

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,13 @@
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "include-v-in-tag": true,
+  "plugins": [
+    {
+      "type": "linked-versions",
+      "groupName": "workspace",
+      "components": ["mlx-models", "mlx-engine", "mlx-server"]
+    }
+  ],
   "packages": {
     "crates/mlx-models": {
       "component": "mlx-models"


### PR DESCRIPTION
## Problem

When a fix only touches `crates/mlx-engine` or `crates/mlx-models`, release-please correctly creates releases for those crates but sees zero new commits for `crates/mlx-server`. Since the `build`, `publish`, and `homebrew` jobs are all gated on `crates/mlx-server--release_created`, the binary is never rebuilt.

This happened with #23 (qwen3 correctness fix): mlx-engine-v0.1.6 and mlx-models-v0.1.5 were released but the mlx-server binary still points to the pre-fix versions.

## Fix

Add the `linked-versions` plugin to `release-please-config.json`, grouping all three workspace components (`mlx-models`, `mlx-engine`, `mlx-server`) together. When any component has a releasable commit, all components in the group will be included in the next release PR and released together.

The next conventional commit to any workspace crate will produce a release PR that bumps all three to the same version (starting from the current max, 0.1.8 → 0.1.9).

## Note on the current qwen3 fix

All commits from #23 were already consumed by the PR #24 release cycle (mlx-engine-v0.1.6 and mlx-models-v0.1.5 are published). Since release-please sees zero pending commits for any crate right now, merging this PR alone won't create a new release. The **next** commit to any crate will trigger a full workspace release (mlx-server-v0.1.9) that includes the qwen3 fix in the binary.

If you need the binary released immediately, a trivial `fix:` commit to any file under `crates/mlx-server/` will do it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release management configuration to enable synchronized versioning across multiple workspace components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->