### PR TITLE
chore: switch mlx-rs patch to upstream oxideai

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,8 +118,8 @@ uuid = { version = "1", features = ["v4"] }
 chrono = { version = "0.4", features = ["serde"] }
 
 [patch.crates-io]
-mlx-rs = { git = "https://github.com/panbanda/mlx-rs.git", rev = "801b114e" }
-mlx-sys = { git = "https://github.com/panbanda/mlx-rs.git", rev = "801b114e" }
+mlx-rs = { git = "https://github.com/oxideai/mlx-rs.git", rev = "af21d79" }
+mlx-sys = { git = "https://github.com/oxideai/mlx-rs.git", rev = "af21d79" }
 
 [profile.release]
 lto = "thin"


### PR DESCRIPTION
## Summary
- Point `[patch.crates-io]` for mlx-rs/mlx-sys at `oxideai/mlx-rs` instead of `panbanda/mlx-rs`
- Upstream now includes the mlx-c v0.5.0 submodule update (MLX v0.30.6)

## Test plan
- [ ] `cargo build --release`
- [ ] `cargo test -- --test-threads=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated patch sources for core dependencies to use updated repository references and revisions, ensuring access to the latest improvements and bug fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->