### PR TITLE
feat: unified AI gateway with proxy routing and format translation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,6 @@ jobs:
         with:
           comment: true
           label: true
-          check: true
-          check-threshold: critical
+          check: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,7 @@ jobs:
         with:
           comment: true
           label: true
-          check: false
+          check: true
+          check-threshold: high
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -697,6 +707,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1134,6 +1162,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hf-hub"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1187,6 +1221,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]
@@ -1974,6 +2009,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -4015,6 +4060,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,16 +600,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
-dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
 name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,19 +628,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling_core"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
-dependencies = [
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
-]
-
-[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -668,17 +645,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
-dependencies = [
- "darling_core 0.23.0",
  "quote",
  "syn",
 ]
@@ -1591,11 +1557,11 @@ checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
 name = "instability"
-version = "0.3.11"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
+checksum = "0bf9fed6d91cfb734e7476a06bde8300a1b94e217e1b523b6f0cd1a01998c71d"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.20.11",
  "indoc",
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,6 +298,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,6 +336,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -407,6 +425,20 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
+name = "compact_str"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
@@ -429,7 +461,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width",
+ "unicode-width 0.2.0",
  "windows-sys 0.59.0",
 ]
 
@@ -442,8 +474,28 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width",
+ "unicode-width 0.2.0",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -487,6 +539,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,6 +587,16 @@ checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
  "darling_core 0.21.3",
  "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -541,6 +628,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,6 +658,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn",
 ]
@@ -688,6 +799,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,6 +856,7 @@ dependencies = [
  "atomic",
  "pear",
  "serde",
+ "toml",
  "uncased",
  "version_check",
 ]
@@ -769,6 +890,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,12 +914,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -791,6 +943,34 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -816,9 +996,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -891,6 +1075,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -913,6 +1116,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -952,22 +1157,31 @@ dependencies = [
  "async-stream",
  "axum",
  "base64 0.22.1",
+ "bytes",
  "chrono",
  "clap",
+ "crossterm",
  "directories",
  "figment",
+ "futures",
  "governor",
  "higgs-engine",
  "higgs-models",
+ "http",
  "http-body-util",
  "hyper",
  "mlx-rs",
+ "nix",
+ "ratatui",
+ "regex",
+ "reqwest",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
+ "toml_edit 0.22.27",
  "tower",
  "tower-http",
  "tracing",
@@ -1064,6 +1278,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1073,6 +1288,39 @@ dependencies = [
  "pin-utils",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1081,13 +1329,23 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
+ "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1264,7 +1522,7 @@ dependencies = [
  "console 0.15.11",
  "number_prefix",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.0",
  "web-time",
 ]
 
@@ -1276,9 +1534,18 @@ checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
  "console 0.16.2",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.0",
  "unit-prefix",
  "web-time",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -1286,6 +1553,35 @@ name = "inlinable_string"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
+name = "instability"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
+dependencies = [
+ "darling 0.23.0",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1367,6 +1663,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
@@ -1391,6 +1693,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "mach-sys"
@@ -1494,6 +1805,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1540,7 +1852,7 @@ dependencies = [
  "parking_lot",
  "paste",
  "smallvec",
- "strum",
+ "strum 0.27.2",
  "thiserror 2.0.18",
 ]
 
@@ -1584,6 +1896,35 @@ checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
 dependencies = [
  "num-traits",
  "pxfm",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -1695,6 +2036,50 @@ checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1849,7 +2234,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.23.10+spec-1.0.0",
 ]
 
 [[package]]
@@ -1973,6 +2358,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str 0.8.1",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools 0.13.0",
+ "lru",
+ "paste",
+ "strum 0.26.3",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "raw-cpuid"
 version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2073,6 +2479,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2094,6 +2543,19 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
@@ -2101,7 +2563,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
 ]
 
@@ -2153,10 +2615,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "self_cell"
@@ -2226,6 +2720,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2251,6 +2754,27 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -2342,11 +2866,33 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
 ]
 
 [[package]]
@@ -2383,6 +2929,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -2396,6 +2945,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2404,7 +2974,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.1",
  "once_cell",
- "rustix",
+ "rustix 1.1.3",
  "windows-sys 0.61.2",
 ]
 
@@ -2475,7 +3045,7 @@ checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
 dependencies = [
  "ahash",
  "aho-corasick",
- "compact_str",
+ "compact_str 0.9.0",
  "dary_heap",
  "derive_builder",
  "esaxx-rs",
@@ -2531,6 +3101,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2539,6 +3129,40 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2552,12 +3176,26 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "winnow",
 ]
@@ -2570,6 +3208,12 @@ checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -2596,11 +3240,14 @@ dependencies = [
  "base64 0.22.1",
  "bitflags",
  "bytes",
+ "futures-util",
  "http",
  "http-body",
+ "iri-string",
  "mime",
  "pin-project-lite",
  "tokio",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2695,6 +3342,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "uncased"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2725,10 +3378,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.2"
+name = "unicode-truncate"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"
@@ -2821,6 +3491,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2831,6 +3507,15 @@ name = "virtue"
 version = "0.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -2867,6 +3552,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2921,6 +3620,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -3035,6 +3747,17 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
 
 [[package]]
 name = "windows-result"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,8 +100,22 @@ minijinja-contrib = { version = "2", features = ["pycompat"] }
 
 # CLI + Configuration
 clap = { version = "4", features = ["derive"] }
-figment = { version = "0.10", features = ["env"] }
+figment = { version = "0.10", features = ["env", "toml"] }
 directories = "6"
+toml_edit = "0.22"
+
+# Proxy + Networking
+reqwest = { version = "0.12", features = ["stream", "json"] }
+regex = "1"
+bytes = "1"
+http = "1"
+http-body-util = "0.1"
+futures = "0.3"
+
+# Daemon + TUI
+nix = { version = "0.29", features = ["signal", "process"] }
+ratatui = "0.29"
+crossterm = "0.28"
 
 # Observability
 tracing = "0.1"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Crates.io](https://img.shields.io/crates/v/higgs)](https://crates.io/crates/higgs)
 [![License](https://img.shields.io/badge/license-MIT-blue)](#license)
 
-OpenAI and Anthropic-compatible inference server for Apple Silicon. Single static Rust binary, no Python runtime. Built on [mlx-rs](https://github.com/oxideai/mlx-rs).
+Unified AI gateway for Apple Silicon. Serve local MLX models and proxy to remote providers (OpenAI, Anthropic, Ollama, etc.) through a single endpoint with automatic format translation. Single static Rust binary, no Python runtime. Built on [mlx-rs](https://github.com/oxideai/mlx-rs).
 
 ## Install
 
@@ -19,19 +19,30 @@ Or build from source (Rust 1.87.0+, Xcode CLI Tools):
 cargo build --release
 ```
 
-## Usage
+## Quick Start
+
+### Simple mode (no config file)
 
 ```bash
-higgs --model mlx-community/Llama-3.2-1B-Instruct-4bit
-higgs --model mlx-community/Llama-3.2-1B-Instruct-4bit --model mlx-community/Qwen3-1.7B-4bit
+higgs serve --model mlx-community/Llama-3.2-1B-Instruct-4bit
+higgs serve --model mlx-community/Llama-3.2-1B-Instruct-4bit --model mlx-community/Qwen3-1.7B-4bit
 ```
 
-Accepts HuggingFace model IDs (resolved from `~/.cache/huggingface/hub/`) or local paths. Prompts to download if not cached.
+Accepts HuggingFace model IDs (resolved from `~/.cache/huggingface/hub/`) or local paths. Prompts to download if not cached. Models must be **MLX safetensors format** from [mlx-community](https://huggingface.co/mlx-community).
 
-Models must be **MLX safetensors format** from [mlx-community](https://huggingface.co/mlx-community).
+### Gateway mode (config file)
+
+```bash
+higgs init        # create ~/.config/higgs/config.toml
+higgs serve       # start with config
+higgs start       # start as background daemon
+higgs attach      # attach TUI dashboard to running daemon
+higgs stop        # stop daemon
+```
 
 ## Features
 
+### Local inference
 - **OpenAI + Anthropic APIs** -- chat completions, text completions, embeddings, messages
 - **Structured output** -- `json_schema` response format (100% schema compliance)
 - **Reasoning models** -- `<think>` tag extraction to `reasoning_content`
@@ -39,6 +50,185 @@ Models must be **MLX safetensors format** from [mlx-community](https://huggingfa
 - **Radix tree prefix cache** -- shared prefix reuse across requests
 - **Vision** -- multimodal image+text (LLaVA-Qwen2)
 - **11 architectures** -- LLaMA, Mistral, Qwen2/3, Qwen3-MoE, Qwen3-Next, Gemma 2, Phi-3, Starcoder2, DeepSeek-V2, LLaVA-Qwen2
+
+### Gateway
+- **Remote providers** -- proxy requests to OpenAI, Anthropic, Ollama, or any OpenAI-compatible API
+- **Format translation** -- send OpenAI requests to Anthropic providers (and vice versa) with automatic conversion of request/response formats, including streaming
+- **Pattern routing** -- regex-based model name matching to route requests to the right provider
+- **Model rewriting** -- map model aliases to upstream model names
+- **Auto-router** -- classify requests using a local LLM to pick the best provider
+- **Metrics dashboard** -- TUI with live request rates, latency, token throughput, and error tracking
+- **Daemon mode** -- `higgs start`/`stop`/`attach` for background operation
+- **Config management** -- `higgs config get/set`, `higgs doctor` for validation
+
+## Configuration
+
+### Simple mode (CLI flags)
+
+| CLI Flag | Env Variable | Default | Description |
+|---|---|---|---|
+| `--model` | `HIGGS_MODELS` | *(required)* | Model path or HF ID (repeatable) |
+| `--host` | `HIGGS_HOST` | `0.0.0.0` | Bind address |
+| `--port` | `HIGGS_PORT` | `8000` | Bind port |
+| `--max-tokens` | `HIGGS_MAX_TOKENS` | `32768` | Max generation tokens |
+| `--api-key` | `HIGGS_API_KEY` | *(none)* | Bearer token for auth |
+| `--rate-limit` | `HIGGS_RATE_LIMIT` | `0` | Requests/min per client |
+| `--timeout` | `HIGGS_TIMEOUT` | `300` | Request timeout (seconds) |
+| `--batch` | -- | `false` | Enable continuous batching |
+
+### Gateway mode (config file)
+
+Run `higgs init` to create `~/.config/higgs/config.toml`:
+
+```toml
+[server]
+host = "0.0.0.0"
+port = 8000
+# max_tokens = 32768
+# timeout = 300.0
+# api_key = "sk-..."
+
+# --- Local models ---
+[[models]]
+path = "mlx-community/Llama-3.2-1B-Instruct-4bit"
+# batch = false
+
+# --- Remote providers ---
+[provider.anthropic]
+url = "https://api.anthropic.com"
+format = "anthropic"
+
+[provider.openai]
+url = "https://api.openai.com"
+format = "openai"
+
+[provider.ollama]
+url = "http://localhost:11434"
+strip_auth = true
+
+# --- Routes ---
+# First regex match wins. Requests matching a local model name are served locally.
+
+[[routes]]
+pattern = "claude-.*"
+provider = "anthropic"
+
+[[routes]]
+pattern = "gpt-.*"
+provider = "openai"
+
+# Model rewriting: requests for "my-alias" are sent to the provider as "actual-model-name"
+# [[routes]]
+# pattern = "my-alias"
+# provider = "openai"
+# model = "gpt-4o"
+
+# --- Default route ---
+[default]
+provider = "higgs"   # "higgs" = local models only; set to a provider name to proxy unmatched requests
+
+# --- Auto router (optional) ---
+# Classify requests with a local LLM to pick the best provider automatically.
+# [auto_router]
+# enabled = true
+# model = "mlx-community/Arch-Router-1.5B-4bit"
+# timeout_ms = 2000
+
+# --- Metrics & dashboard ---
+[retention]
+enabled = true
+minutes = 60
+
+[logging.metrics]
+enabled = true
+# path = "~/.config/higgs/logs/metrics.jsonl"
+# max_size_mb = 50
+# max_files = 5
+```
+
+#### Provider options
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `url` | string | *(required)* | Base URL of the upstream API |
+| `format` | `"openai"` or `"anthropic"` | `"openai"` | API format the provider speaks |
+| `api_key` | string | *(none)* | API key to inject into proxied requests |
+| `strip_auth` | bool | `false` | Remove the client's Authorization header before proxying |
+| `stub_count_tokens` | bool | `false` | Return a stub for `/v1/messages/count_tokens` |
+
+#### Route options
+
+| Field | Type | Description |
+|---|---|---|
+| `pattern` | regex | Match against the `model` field in requests |
+| `provider` | string | Provider name to forward to |
+| `model` | string | Rewrite the model field before forwarding |
+| `name` | string | Human label (used by auto-router) |
+| `description` | string | Route description (used by auto-router for classification) |
+
+## API
+
+**OpenAI**: `/v1/chat/completions`, `/v1/completions`, `/v1/embeddings`, `/v1/models`
+**Anthropic**: `/v1/messages`, `/v1/messages/count_tokens`
+**Metrics**: `/metrics` (JSON)
+**Health**: `/health`
+
+Format translation works transparently: send an OpenAI-format request to higgs and it will translate to Anthropic format if the matched route points to an Anthropic provider (and vice versa), including streaming responses.
+
+```bash
+# Local model
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model": "mlx-community/Llama-3.2-1B-Instruct-4bit",
+       "messages": [{"role": "user", "content": "Hello!"}]}'
+
+# Proxied to Anthropic (translated from OpenAI format automatically)
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $ANTHROPIC_API_KEY" \
+  -d '{"model": "claude-sonnet-4-6",
+       "messages": [{"role": "user", "content": "Hello!"}]}'
+```
+
+### Shell integration
+
+Add to your shell profile to point AI tools at higgs:
+
+```bash
+eval "$(higgs shellenv)"
+# Exports ANTHROPIC_BASE_URL and OPENAI_BASE_URL when the server is reachable
+```
+
+## CLI Commands
+
+| Command | Description |
+|---|---|
+| `higgs serve` | Start the server in the foreground |
+| `higgs start` | Start as a background daemon |
+| `higgs stop` | Stop a running daemon |
+| `higgs attach` | Attach TUI dashboard to a running daemon |
+| `higgs init` | Create default config at `~/.config/higgs/config.toml` |
+| `higgs shellenv` | Print `export` lines for `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` |
+| `higgs config get <key>` | Read a config value (dot-separated key) |
+| `higgs config set <key> <value>` | Write a config value |
+| `higgs config path` | Print the resolved config file path |
+| `higgs doctor` | Validate config, check model paths, probe providers |
+
+## Supported Architectures
+
+| Architecture | `model_type` | Examples |
+|---|---|---|
+| LLaMA | `llama` | Llama 3/3.1, CodeLlama |
+| Mistral | `mistral` | Mistral 7B |
+| Qwen2 | `qwen2` | Qwen2, Qwen2.5 |
+| Qwen3 | `qwen3` | Qwen3 |
+| Qwen3-Next | `qwen3_next` | Qwen3-Coder (SSM hybrid) |
+| Qwen3-MoE | `qwen3_moe` | Qwen3-30B-A3B (sparse MoE) |
+| Gemma 2 | `gemma2` | Gemma 2 2B/9B/27B |
+| Phi-3 | `phi3` | Phi-3 Mini/Small/Medium |
+| Starcoder2 | `starcoder2` | Starcoder2 3B/7B/15B |
+| DeepSeek-V2 | `deepseek_v2` | DeepSeek-V2-Lite (MLA + MoE) |
+| LLaVA-Qwen2 | `llava-qwen2` | nanoLLaVA-1.5 (vision) |
 
 ## Performance
 
@@ -89,48 +279,6 @@ MLX models use 4-bit (8-bit for MoE). llama.cpp/Ollama use Q4_K_M (Q8_0 for MoE)
 | Structured output (10 prompts, JSON schema) | 100% | 0% |
 | Reasoning extraction (5 questions, Qwen3) | 5/5 | 4/5 |
 | All architectures produce coherent output | Yes | Yes |
-
-## Configuration
-
-| CLI Flag | Env Variable | Default | Description |
-|---|---|---|---|
-| `--model` | `HIGGS_MODELS` | *(required)* | Model path or HF ID (repeatable) |
-| `--host` | `HIGGS_HOST` | `0.0.0.0` | Bind address |
-| `--port` | `HIGGS_PORT` | `8000` | Bind port |
-| `--max-tokens` | `HIGGS_MAX_TOKENS` | `32768` | Max generation tokens |
-| `--api-key` | `HIGGS_API_KEY` | *(none)* | Bearer token for auth |
-| `--rate-limit` | `HIGGS_RATE_LIMIT` | `0` | Requests/min per client |
-| `--timeout` | `HIGGS_TIMEOUT` | `300` | Request timeout (seconds) |
-| `--batch` | -- | `false` | Enable continuous batching |
-
-## API
-
-**OpenAI**: `/v1/chat/completions`, `/v1/completions`, `/v1/embeddings`, `/v1/models`
-**Anthropic**: `/v1/messages`, `/v1/messages/count_tokens`
-**Health**: `/health`
-
-```bash
-curl http://localhost:8000/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -d '{"model": "mlx-community/Llama-3.2-1B-Instruct-4bit",
-       "messages": [{"role": "user", "content": "Hello!"}]}'
-```
-
-## Supported Architectures
-
-| Architecture | `model_type` | Examples |
-|---|---|---|
-| LLaMA | `llama` | Llama 3/3.1, CodeLlama |
-| Mistral | `mistral` | Mistral 7B |
-| Qwen2 | `qwen2` | Qwen2, Qwen2.5 |
-| Qwen3 | `qwen3` | Qwen3 |
-| Qwen3-Next | `qwen3_next` | Qwen3-Coder (SSM hybrid) |
-| Qwen3-MoE | `qwen3_moe` | Qwen3-30B-A3B (sparse MoE) |
-| Gemma 2 | `gemma2` | Gemma 2 2B/9B/27B |
-| Phi-3 | `phi3` | Phi-3 Mini/Small/Medium |
-| Starcoder2 | `starcoder2` | Starcoder2 3B/7B/15B |
-| DeepSeek-V2 | `deepseek_v2` | DeepSeek-V2-Lite (MLA + MoE) |
-| LLaVA-Qwen2 | `llava-qwen2` | nanoLLaVA-1.5 (vision) |
 
 ## Development
 

--- a/crates/higgs/Cargo.toml
+++ b/crates/higgs/Cargo.toml
@@ -47,3 +47,4 @@ tokio = { version = "1", features = ["macros", "rt"] }
 tower = { version = "0.5", features = ["util"] }
 hyper = "1"
 tempfile = "3.25.0"
+wiremock = "0.6"

--- a/crates/higgs/Cargo.toml
+++ b/crates/higgs/Cargo.toml
@@ -31,9 +31,18 @@ uuid.workspace = true
 chrono.workspace = true
 async-stream.workspace = true
 base64.workspace = true
+reqwest.workspace = true
+regex.workspace = true
+bytes.workspace = true
+http.workspace = true
+futures.workspace = true
+toml_edit.workspace = true
+nix.workspace = true
+ratatui.workspace = true
+crossterm.workspace = true
 
 [dev-dependencies]
-http-body-util = "0.1"
+http-body-util.workspace = true
 tokio = { version = "1", features = ["macros", "rt"] }
 tower = { version = "0.5", features = ["util"] }
 hyper = "1"

--- a/crates/higgs/src/attach.rs
+++ b/crates/higgs/src/attach.rs
@@ -80,13 +80,16 @@ pub fn load_history(config: &MetricsLogConfig, store: &MetricsStore) {
             if record.wallclock < cutoff {
                 continue;
             }
-            store.record(record);
+            store.record_silent(record);
         }
     }
 }
 
 pub fn tail_log(path: &Path, store: &Arc<MetricsStore>, stop: &Arc<AtomicBool>) {
+    use std::os::unix::fs::MetadataExt;
+
     let mut position: u64 = std::fs::metadata(path).map_or(0, |m| m.len());
+    let mut current_ino: u64 = std::fs::metadata(path).map_or(0, |m| m.ino());
 
     while !stop.load(Ordering::Relaxed) {
         std::thread::sleep(Duration::from_millis(250));
@@ -99,10 +102,12 @@ pub fn tail_log(path: &Path, store: &Arc<MetricsStore>, stop: &Arc<AtomicBool>) 
             continue;
         };
         let file_len = meta.len();
+        let file_ino = meta.ino();
 
-        // Detect rotation: file shrunk
-        if file_len < position {
+        // Detect rotation: inode changed or file shrunk
+        if file_ino != current_ino || file_len < position {
             position = 0;
+            current_ino = file_ino;
         }
 
         if file_len == position {
@@ -127,7 +132,7 @@ pub fn tail_log(path: &Path, store: &Arc<MetricsStore>, stop: &Arc<AtomicBool>) 
                         continue;
                     }
                     if let Some(record) = parse_log_entry(trimmed) {
-                        store.record(record);
+                        store.record_silent(record);
                     }
                 }
             }

--- a/crates/higgs/src/attach.rs
+++ b/crates/higgs/src/attach.rs
@@ -26,8 +26,10 @@ struct LogEntry {
 
 pub fn parse_log_entry(line: &str) -> Option<RequestRecord> {
     let entry: LogEntry = serde_json::from_str(line).ok()?;
-    let age = (Utc::now() - entry.timestamp).to_std().ok()?;
-    let timestamp = Instant::now().checked_sub(age)?;
+    let age = (Utc::now() - entry.timestamp)
+        .to_std()
+        .unwrap_or(Duration::ZERO);
+    let timestamp = Instant::now().checked_sub(age).unwrap_or_else(Instant::now);
     Some(RequestRecord {
         id: 0,
         timestamp,

--- a/crates/higgs/src/attach.rs
+++ b/crates/higgs/src/attach.rs
@@ -134,7 +134,13 @@ pub fn tail_log(path: &Path, store: &Arc<MetricsStore>, stop: &Arc<AtomicBool>) 
 }
 
 #[cfg(test)]
-#[allow(clippy::panic, clippy::unwrap_used, clippy::indexing_slicing)]
+#[allow(
+    clippy::panic,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    clippy::expect_used,
+    clippy::option_if_let_else
+)]
 mod tests {
     use super::*;
     use std::fs;

--- a/crates/higgs/src/attach.rs
+++ b/crates/higgs/src/attach.rs
@@ -1,0 +1,344 @@
+use std::io::{BufRead, BufReader, Seek, SeekFrom};
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+
+use crate::config::MetricsLogConfig;
+use crate::metrics::{MetricsStore, RequestRecord, RoutingMethod};
+use crate::metrics_log::rotated_path;
+
+#[derive(Debug, Deserialize)]
+struct LogEntry {
+    timestamp: DateTime<Utc>,
+    model: String,
+    provider: String,
+    routing_method: Option<String>,
+    status: u16,
+    duration_ms: u64,
+    input_tokens: u64,
+    output_tokens: u64,
+    error: Option<String>,
+}
+
+pub fn parse_log_entry(line: &str) -> Option<RequestRecord> {
+    let entry: LogEntry = serde_json::from_str(line).ok()?;
+    let age = (Utc::now() - entry.timestamp).to_std().ok()?;
+    let timestamp = Instant::now().checked_sub(age)?;
+    Some(RequestRecord {
+        id: 0,
+        timestamp,
+        wallclock: entry.timestamp,
+        model: entry.model,
+        provider: entry.provider,
+        routing_method: match entry.routing_method.as_deref() {
+            Some("higgs") => RoutingMethod::Higgs,
+            Some("pattern") => RoutingMethod::Pattern,
+            Some("auto") => RoutingMethod::Auto,
+            Some("default" | _) | None => RoutingMethod::Default,
+        },
+        status: entry.status,
+        duration: Duration::from_millis(entry.duration_ms),
+        input_tokens: entry.input_tokens,
+        output_tokens: entry.output_tokens,
+        error_body: entry.error,
+    })
+}
+
+pub fn load_history(config: &MetricsLogConfig, store: &MetricsStore) {
+    let base = Path::new(&config.path);
+    let cutoff =
+        Utc::now() - chrono::Duration::from_std(store.window()).unwrap_or(chrono::Duration::zero());
+
+    // Read rotated files oldest-first: .max_files, .max_files-1, ..., .1, then current
+    let mut paths = Vec::new();
+    for i in (1..=config.max_files).rev() {
+        paths.push(rotated_path(base, i));
+    }
+    paths.push(base.to_path_buf());
+
+    for path in paths {
+        let Ok(file) = std::fs::File::open(&path) else {
+            continue;
+        };
+        let reader = BufReader::new(file);
+        for result in reader.lines() {
+            let Ok(line) = result else {
+                continue;
+            };
+            if line.is_empty() {
+                continue;
+            }
+            let Some(record) = parse_log_entry(&line) else {
+                continue;
+            };
+            if record.wallclock < cutoff {
+                continue;
+            }
+            store.record(record);
+        }
+    }
+}
+
+pub fn tail_log(path: &Path, store: &Arc<MetricsStore>, stop: &Arc<AtomicBool>) {
+    let mut position: u64 = std::fs::metadata(path).map_or(0, |m| m.len());
+
+    while !stop.load(Ordering::Relaxed) {
+        std::thread::sleep(Duration::from_millis(250));
+
+        let Ok(file) = std::fs::File::open(path) else {
+            continue;
+        };
+
+        let Ok(meta) = file.metadata() else {
+            continue;
+        };
+        let file_len = meta.len();
+
+        // Detect rotation: file shrunk
+        if file_len < position {
+            position = 0;
+        }
+
+        if file_len == position {
+            continue;
+        }
+
+        let mut reader = BufReader::new(file);
+        if reader.seek(SeekFrom::Start(position)).is_err() {
+            continue;
+        }
+
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match reader.read_line(&mut line) {
+                Ok(0) | Err(_) => break,
+                Ok(n) => {
+                    let n_u64 = u64::try_from(n).unwrap_or(u64::MAX);
+                    position = position.saturating_add(n_u64);
+                    let trimmed = line.trim();
+                    if trimmed.is_empty() {
+                        continue;
+                    }
+                    if let Some(record) = parse_log_entry(trimmed) {
+                        store.record(record);
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used, clippy::indexing_slicing)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn recent_timestamp() -> String {
+        Utc::now().to_rfc3339()
+    }
+
+    fn old_timestamp() -> String {
+        (Utc::now() - chrono::Duration::hours(2)).to_rfc3339()
+    }
+
+    fn make_entry(ts: &str, model: &str, error: Option<&str>) -> String {
+        let error_json = match error {
+            Some(e) => format!("\"{e}\""),
+            None => "null".to_owned(),
+        };
+        format!(
+            r#"{{"timestamp":"{ts}","model":"{model}","provider":"anthropic","status":200,"duration_ms":100,"input_tokens":50,"output_tokens":75,"error":{error_json}}}"#
+        )
+    }
+
+    #[test]
+    fn parse_valid_entry() {
+        let ts = recent_timestamp();
+        let line = make_entry(&ts, "claude-opus-4-6", None);
+        let record = parse_log_entry(&line).expect("should parse");
+        assert_eq!(record.model, "claude-opus-4-6");
+        assert_eq!(record.provider, "anthropic");
+        assert_eq!(record.status, 200);
+        assert_eq!(record.duration.as_millis(), 100);
+        assert_eq!(record.input_tokens, 50);
+        assert_eq!(record.output_tokens, 75);
+        assert!(record.error_body.is_none());
+    }
+
+    #[test]
+    fn parse_entry_with_error() {
+        let ts = recent_timestamp();
+        let line = make_entry(&ts, "opus", Some("rate limited"));
+        let record = parse_log_entry(&line).expect("should parse");
+        assert_eq!(record.error_body.as_deref(), Some("rate limited"));
+    }
+
+    #[test]
+    fn parse_missing_fields() {
+        let line = r#"{"timestamp":"2025-01-01T00:00:00Z","model":"opus"}"#;
+        assert!(parse_log_entry(line).is_none());
+    }
+
+    #[test]
+    fn parse_malformed_json() {
+        assert!(parse_log_entry("not json").is_none());
+        assert!(parse_log_entry("").is_none());
+        assert!(parse_log_entry("{").is_none());
+        assert!(parse_log_entry("{}").is_none());
+    }
+
+    #[test]
+    fn parse_routing_method_variants() {
+        let ts = recent_timestamp();
+        let make = |method: &str| -> String {
+            format!(
+                r#"{{"timestamp":"{ts}","model":"m","provider":"p","routing_method":"{method}","status":200,"duration_ms":10,"input_tokens":1,"output_tokens":1,"error":null}}"#
+            )
+        };
+        assert_eq!(
+            parse_log_entry(&make("higgs")).unwrap().routing_method,
+            RoutingMethod::Higgs
+        );
+        assert_eq!(
+            parse_log_entry(&make("pattern")).unwrap().routing_method,
+            RoutingMethod::Pattern
+        );
+        assert_eq!(
+            parse_log_entry(&make("auto")).unwrap().routing_method,
+            RoutingMethod::Auto
+        );
+        assert_eq!(
+            parse_log_entry(&make("default")).unwrap().routing_method,
+            RoutingMethod::Default
+        );
+        assert_eq!(
+            parse_log_entry(&make("unknown_future"))
+                .unwrap()
+                .routing_method,
+            RoutingMethod::Default
+        );
+    }
+
+    #[test]
+    fn parse_routing_method_missing() {
+        let ts = recent_timestamp();
+        let line = format!(
+            r#"{{"timestamp":"{ts}","model":"m","provider":"p","status":200,"duration_ms":10,"input_tokens":1,"output_tokens":1,"error":null}}"#
+        );
+        assert_eq!(
+            parse_log_entry(&line).unwrap().routing_method,
+            RoutingMethod::Default
+        );
+    }
+
+    #[test]
+    fn load_history_reads_rotated_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path().join("metrics.jsonl");
+        let ts = recent_timestamp();
+
+        fs::write(
+            rotated_path(&base, 2),
+            format!("{}\n", make_entry(&ts, "oldest", None)),
+        )
+        .unwrap();
+        fs::write(
+            rotated_path(&base, 1),
+            format!("{}\n", make_entry(&ts, "middle", None)),
+        )
+        .unwrap();
+        fs::write(&base, format!("{}\n", make_entry(&ts, "newest", None))).unwrap();
+
+        let config = MetricsLogConfig {
+            enabled: true,
+            path: base.to_string_lossy().to_string(),
+            max_size_mb: 50,
+            max_files: 5,
+        };
+        let store = MetricsStore::new(Duration::from_secs(3600));
+        load_history(&config, &store);
+
+        let snap = store.snapshot();
+        assert_eq!(snap.len(), 3);
+        assert_eq!(snap[0].model, "oldest");
+        assert_eq!(snap[1].model, "middle");
+        assert_eq!(snap[2].model, "newest");
+    }
+
+    #[test]
+    fn load_history_skips_old_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path().join("metrics.jsonl");
+        let recent = recent_timestamp();
+        let old = old_timestamp();
+
+        let content = format!(
+            "{}\n{}\n",
+            make_entry(&old, "old-model", None),
+            make_entry(&recent, "new-model", None)
+        );
+        fs::write(&base, content).unwrap();
+
+        let config = MetricsLogConfig {
+            enabled: true,
+            path: base.to_string_lossy().to_string(),
+            max_size_mb: 50,
+            max_files: 5,
+        };
+        let store = MetricsStore::new(Duration::from_secs(3600));
+        load_history(&config, &store);
+
+        let snap = store.snapshot();
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].model, "new-model");
+    }
+
+    #[test]
+    fn load_history_skips_malformed_lines() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path().join("metrics.jsonl");
+        let ts = recent_timestamp();
+
+        let content = format!(
+            "garbage\n{}\n{{}}\n{}\n",
+            make_entry(&ts, "good1", None),
+            make_entry(&ts, "good2", None)
+        );
+        fs::write(&base, content).unwrap();
+
+        let config = MetricsLogConfig {
+            enabled: true,
+            path: base.to_string_lossy().to_string(),
+            max_size_mb: 50,
+            max_files: 5,
+        };
+        let store = MetricsStore::new(Duration::from_secs(3600));
+        load_history(&config, &store);
+
+        let snap = store.snapshot();
+        assert_eq!(snap.len(), 2);
+    }
+
+    #[test]
+    fn load_history_handles_missing_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path().join("metrics.jsonl");
+
+        let config = MetricsLogConfig {
+            enabled: true,
+            path: base.to_string_lossy().to_string(),
+            max_size_mb: 50,
+            max_files: 5,
+        };
+        let store = MetricsStore::new(Duration::from_secs(3600));
+        load_history(&config, &store);
+
+        assert_eq!(store.snapshot().len(), 0);
+    }
+}

--- a/crates/higgs/src/auto_router.rs
+++ b/crates/higgs/src/auto_router.rs
@@ -68,13 +68,13 @@ fn build_prompt(routes: &[RouteCandidate], messages: &[serde_json::Value]) -> St
 
 fn parse_route_name(text: &str, valid_names: &[&str]) -> Option<String> {
     // Try full JSON parse first
-    if let Ok(v) = serde_json::from_str::<serde_json::Value>(text.trim())
-        && let Some(name) = v.get("route").and_then(|r| r.as_str())
-    {
-        if name != "other" && valid_names.contains(&name) {
-            return Some(name.to_owned());
+    if let Ok(v) = serde_json::from_str::<serde_json::Value>(text.trim()) {
+        if let Some(name) = v.get("route").and_then(|r| r.as_str()) {
+            if name != "other" && valid_names.contains(&name) {
+                return Some(name.to_owned());
+            }
+            return None;
         }
-        return None;
     }
 
     // Fallback: regex extraction from surrounding text

--- a/crates/higgs/src/auto_router.rs
+++ b/crates/higgs/src/auto_router.rs
@@ -1,0 +1,248 @@
+use std::sync::LazyLock;
+
+use regex::Regex;
+use tracing::{info, warn};
+
+use crate::router::RouteCandidate;
+use crate::state::Engine;
+
+#[allow(clippy::expect_used)]
+static ROUTE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"\{"route"\s*:\s*"([^"]+)"\}"#).expect("hardcoded regex is valid")
+});
+
+const TASK_INSTRUCTION: &str = "\
+You are a helpful assistant designed to find the best suited route.
+You are provided with route description within <routes></routes> XML tags:
+<routes>
+
+{routes}
+
+</routes>
+
+<conversation>
+
+{conversation}
+
+</conversation>
+";
+
+const FORMAT_PROMPT: &str = "\
+Your task is to decide which route is best suit with user intent on the conversation \
+in <conversation></conversation> XML tags.  Follow the instruction:
+1. If the latest intent from user is irrelevant or user intent is full filled, \
+response with other route {\"route\": \"other\"}.
+2. You must analyze the route descriptions and find the best match route for user latest intent.
+3. You only response the name of the route that best matches the user's request, \
+use the exact name in the <routes></routes>.
+
+Based on your analysis, provide your response in the following JSON formats \
+if you decide to match any route:
+{\"route\": \"route_name\"}
+";
+
+fn build_prompt(routes: &[RouteCandidate], messages: &[serde_json::Value]) -> String {
+    let route_defs: Vec<serde_json::Value> = routes
+        .iter()
+        .map(|r| serde_json::json!({"name": &r.name, "description": &r.description}))
+        .collect();
+
+    let non_system: Vec<&serde_json::Value> = messages
+        .iter()
+        .filter(|m| m.get("role").and_then(|r| r.as_str()) != Some("system"))
+        .collect();
+
+    #[allow(clippy::literal_string_with_formatting_args)]
+    let prompt = TASK_INSTRUCTION
+        .replace(
+            "{routes}",
+            &serde_json::to_string(&route_defs).unwrap_or_default(),
+        )
+        .replace(
+            "{conversation}",
+            &serde_json::to_string(&non_system).unwrap_or_default(),
+        );
+
+    format!("{prompt}{FORMAT_PROMPT}")
+}
+
+fn parse_route_name(text: &str, valid_names: &[&str]) -> Option<String> {
+    // Try full JSON parse first
+    if let Ok(v) = serde_json::from_str::<serde_json::Value>(text.trim())
+        && let Some(name) = v.get("route").and_then(|r| r.as_str())
+    {
+        if name != "other" && valid_names.contains(&name) {
+            return Some(name.to_owned());
+        }
+        return None;
+    }
+
+    // Fallback: regex extraction from surrounding text
+    let captures = ROUTE_REGEX.captures(text)?;
+    let name = captures.get(1)?.as_str();
+    (name != "other" && valid_names.contains(&name)).then(|| name.to_owned())
+}
+
+/// Classify a request using a local MLX engine.
+///
+/// Returns the name of the best-matching route, or `None` if classification
+/// fails or returns "other".
+pub fn classify_local(
+    engine: &Engine,
+    routes: &[RouteCandidate],
+    messages: &[serde_json::Value],
+) -> Option<String> {
+    if routes.is_empty() || messages.is_empty() {
+        return None;
+    }
+
+    let prompt = build_prompt(routes, messages);
+    let valid_names: Vec<&str> = routes.iter().map(|r| r.name.as_str()).collect();
+
+    info!(
+        route_count = routes.len(),
+        "auto-routing request via local engine"
+    );
+
+    let chat_messages = vec![higgs_engine::chat_template::ChatMessage {
+        role: "user".to_owned(),
+        content: prompt,
+        tool_calls: None,
+    }];
+
+    let prompt_tokens = match engine.prepare_chat_prompt(&chat_messages, None) {
+        Ok(tokens) => tokens,
+        Err(e) => {
+            warn!(error = %e, "auto-router prompt preparation failed");
+            return None;
+        }
+    };
+
+    let sampling = higgs_models::SamplingParams {
+        temperature: 0.0,
+        top_p: 1.0,
+        top_k: None,
+        min_p: None,
+        repetition_penalty: None,
+        frequency_penalty: None,
+        presence_penalty: None,
+    };
+
+    let output = match engine.generate(&prompt_tokens, 64, &sampling, &[], false, None, None, None)
+    {
+        Ok(o) => o,
+        Err(e) => {
+            warn!(error = %e, "auto-router generation failed");
+            return None;
+        }
+    };
+
+    let result = parse_route_name(&output.text, &valid_names);
+
+    if let Some(name) = &result {
+        info!(route = %name, "auto-router selected route");
+    } else {
+        let truncated: String = output.text.chars().take(64).collect();
+        warn!(
+            response = %truncated,
+            "auto-router returned no match, falling through to default"
+        );
+    }
+
+    result
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn candidates() -> Vec<RouteCandidate> {
+        vec![
+            RouteCandidate {
+                name: "code_gen".to_owned(),
+                description: "code generation".to_owned(),
+            },
+            RouteCandidate {
+                name: "summarize".to_owned(),
+                description: "summarization".to_owned(),
+            },
+        ]
+    }
+
+    #[test]
+    fn parse_clean_json() {
+        let names = vec!["code_gen", "summarize"];
+        assert_eq!(
+            parse_route_name(r#"{"route": "code_gen"}"#, &names),
+            Some("code_gen".to_owned())
+        );
+    }
+
+    #[test]
+    fn parse_other_returns_none() {
+        let names = vec!["code_gen"];
+        assert_eq!(parse_route_name(r#"{"route": "other"}"#, &names), None);
+    }
+
+    #[test]
+    fn parse_unknown_name_returns_none() {
+        let names = vec!["code_gen"];
+        assert_eq!(parse_route_name(r#"{"route": "unknown"}"#, &names), None);
+    }
+
+    #[test]
+    fn parse_with_preamble() {
+        let names = vec!["code_gen", "summarize"];
+        let text = "Based on the analysis, the best route is:\n{\"route\": \"summarize\"}";
+        assert_eq!(parse_route_name(text, &names), Some("summarize".to_owned()));
+    }
+
+    #[test]
+    fn parse_garbage_returns_none() {
+        let names = vec!["code_gen"];
+        assert_eq!(parse_route_name("not json at all", &names), None);
+    }
+
+    #[test]
+    fn parse_empty_returns_none() {
+        let names = vec!["code_gen"];
+        assert_eq!(parse_route_name("", &names), None);
+    }
+
+    #[test]
+    fn build_prompt_filters_system_messages() {
+        let routes = candidates();
+        let messages = vec![
+            serde_json::json!({"role": "system", "content": "you are helpful"}),
+            serde_json::json!({"role": "user", "content": "write code"}),
+        ];
+        let prompt = build_prompt(&routes, &messages);
+        assert!(prompt.contains("write code"));
+        assert!(!prompt.contains("you are helpful"));
+        assert!(prompt.contains("code_gen"));
+        assert!(prompt.contains("summarize"));
+    }
+
+    #[test]
+    fn build_prompt_includes_all_routes() {
+        let routes = candidates();
+        let messages = vec![serde_json::json!({"role": "user", "content": "hello"})];
+        let prompt = build_prompt(&routes, &messages);
+        assert!(prompt.contains("code generation"));
+        assert!(prompt.contains("summarization"));
+    }
+
+    #[test]
+    fn build_prompt_includes_conversation() {
+        let routes = candidates();
+        let messages = vec![
+            serde_json::json!({"role": "user", "content": "fix this bug"}),
+            serde_json::json!({"role": "assistant", "content": "sure"}),
+            serde_json::json!({"role": "user", "content": "now optimize it"}),
+        ];
+        let prompt = build_prompt(&routes, &messages);
+        assert!(prompt.contains("fix this bug"));
+        assert!(prompt.contains("now optimize it"));
+    }
+}

--- a/crates/higgs/src/cli_config.rs
+++ b/crates/higgs/src/cli_config.rs
@@ -1,0 +1,190 @@
+use std::fs;
+use std::path::Path;
+
+fn format_toml_value(value: &toml_edit::Value) -> String {
+    value.as_str().map_or_else(
+        || {
+            value
+                .as_bool()
+                .map(|b| b.to_string())
+                .or_else(|| value.as_integer().map(|n| n.to_string()))
+                .unwrap_or_else(|| value.to_string())
+        },
+        str::to_owned,
+    )
+}
+
+fn parse_toml_value(raw: &str) -> toml_edit::Item {
+    if raw == "true" {
+        toml_edit::value(true)
+    } else if raw == "false" {
+        toml_edit::value(false)
+    } else if let Ok(n) = raw.parse::<i64>() {
+        toml_edit::value(n)
+    } else {
+        toml_edit::value(raw)
+    }
+}
+
+#[allow(clippy::print_stderr)]
+pub fn config_set(config_path: &Path, key: &str, value: &str) {
+    let segments: Vec<&str> = key.split('.').collect();
+    if segments.iter().any(|s| s.is_empty()) {
+        eprintln!("invalid key: {key}");
+        std::process::exit(1);
+    }
+
+    let content = fs::read_to_string(config_path).unwrap_or_default();
+    let mut doc: toml_edit::DocumentMut = content.parse().unwrap_or_else(|e| {
+        eprintln!("failed to parse {}: {e}", config_path.display());
+        std::process::exit(1);
+    });
+
+    let (table_segments, leaf_slice) = segments.split_at(segments.len() - 1);
+    let Some(&leaf) = leaf_slice.first() else {
+        eprintln!("invalid key: {key}");
+        std::process::exit(1);
+    };
+
+    let mut current = doc.as_table_mut();
+    for &seg in table_segments {
+        if !current.contains_key(seg) {
+            current.insert(seg, toml_edit::Item::Table(toml_edit::Table::new()));
+        }
+        current = current[seg].as_table_mut().unwrap_or_else(|| {
+            eprintln!("key segment '{seg}' is not a table");
+            std::process::exit(1);
+        });
+    }
+    current[leaf] = parse_toml_value(value);
+
+    if let Some(parent) = config_path.parent() {
+        fs::create_dir_all(parent).unwrap_or_else(|e| {
+            eprintln!("failed to create {}: {e}", parent.display());
+            std::process::exit(1);
+        });
+    }
+    fs::write(config_path, doc.to_string()).unwrap_or_else(|e| {
+        eprintln!("failed to write {}: {e}", config_path.display());
+        std::process::exit(1);
+    });
+}
+
+pub fn config_lookup(content: &str, key: &str) -> Result<String, String> {
+    let doc: toml_edit::DocumentMut = content
+        .parse()
+        .map_err(|e| format!("failed to parse config: {e}"))?;
+
+    let segments: Vec<&str> = key.split('.').collect();
+    let mut current = doc.as_item();
+    for &seg in &segments {
+        current = current
+            .get(seg)
+            .ok_or_else(|| format!("key not found: {key}"))?;
+    }
+
+    current
+        .as_value()
+        .map(format_toml_value)
+        .ok_or_else(|| format!("key '{key}' is a table, not a value"))
+}
+
+#[allow(clippy::print_stderr, clippy::print_stdout)]
+pub fn config_get(config_path: &Path, key: &str) {
+    let content = match fs::read_to_string(config_path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            eprintln!(
+                "config file not found: {}\nhint: run `higgs init` to create one",
+                config_path.display()
+            );
+            std::process::exit(1);
+        }
+        Err(e) => {
+            eprintln!("failed to read {}: {e}", config_path.display());
+            std::process::exit(1);
+        }
+    };
+
+    match config_lookup(&content, key) {
+        Ok(value) => println!("{value}"),
+        Err(e) => {
+            eprintln!("{e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn set_and_parse(initial: &str, key: &str, value: &str) -> toml_edit::DocumentMut {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("config.toml");
+        if !initial.is_empty() {
+            fs::write(&path, initial).unwrap();
+        }
+        config_set(&path, key, value);
+        let content = fs::read_to_string(&path).unwrap();
+        content.parse().unwrap()
+    }
+
+    #[test]
+    fn set_creates_nested_tables() {
+        let doc = set_and_parse("", "logging.metrics.enabled", "true");
+        assert_eq!(doc["logging"]["metrics"]["enabled"].as_bool(), Some(true));
+    }
+
+    #[test]
+    fn set_preserves_existing_values() {
+        let doc = set_and_parse(
+            "[server]\nhost = \"127.0.0.1\"\nport = 3100\n",
+            "server.port",
+            "3200",
+        );
+        assert_eq!(doc["server"]["host"].as_str(), Some("127.0.0.1"));
+        assert_eq!(doc["server"]["port"].as_integer(), Some(3200));
+    }
+
+    #[test]
+    fn set_bool_value() {
+        let doc = set_and_parse("", "flag", "true");
+        assert_eq!(doc["flag"].as_bool(), Some(true));
+    }
+
+    #[test]
+    fn set_integer_value() {
+        let doc = set_and_parse("", "server.port", "3100");
+        assert_eq!(doc["server"]["port"].as_integer(), Some(3100));
+    }
+
+    #[test]
+    fn set_string_value() {
+        let doc = set_and_parse("", "server.host", "localhost");
+        assert_eq!(doc["server"]["host"].as_str(), Some("localhost"));
+    }
+
+    #[test]
+    fn get_reads_nested_value() {
+        let toml = "[server]\nhost = \"127.0.0.1\"\nport = 3100\n";
+        assert_eq!(config_lookup(toml, "server.port").unwrap(), "3100");
+        assert_eq!(config_lookup(toml, "server.host").unwrap(), "127.0.0.1");
+    }
+
+    #[test]
+    fn get_missing_key_errors() {
+        let toml = "[server]\nport = 3100\n";
+        let err = config_lookup(toml, "server.host").unwrap_err();
+        assert!(err.contains("key not found"));
+    }
+
+    #[test]
+    fn get_table_key_errors() {
+        let toml = "[server]\nport = 3100\n";
+        let err = config_lookup(toml, "server").unwrap_err();
+        assert!(err.contains("table, not a value"));
+    }
+}

--- a/crates/higgs/src/cli_config.rs
+++ b/crates/higgs/src/cli_config.rs
@@ -21,6 +21,8 @@ fn parse_toml_value(raw: &str) -> toml_edit::Item {
         toml_edit::value(false)
     } else if let Ok(n) = raw.parse::<i64>() {
         toml_edit::value(n)
+    } else if let Ok(f) = raw.parse::<f64>() {
+        toml_edit::value(f)
     } else {
         toml_edit::value(raw)
     }
@@ -116,7 +118,7 @@ pub fn config_get(config_path: &Path, key: &str) {
 }
 
 #[cfg(test)]
-#[allow(clippy::panic, clippy::unwrap_used)]
+#[allow(clippy::panic, clippy::unwrap_used, clippy::indexing_slicing)]
 mod tests {
     use super::*;
     use tempfile::TempDir;

--- a/crates/higgs/src/config.rs
+++ b/crates/higgs/src/config.rs
@@ -249,6 +249,8 @@ pub struct AutoRouterConfig {
     #[serde(default)]
     pub enabled: bool,
     #[serde(default)]
+    pub force: bool,
+    #[serde(default = "default_auto_router_model")]
     pub model: String,
     #[serde(default = "default_auto_router_timeout_ms")]
     pub timeout_ms: u64,
@@ -258,10 +260,15 @@ impl Default for AutoRouterConfig {
     fn default() -> Self {
         Self {
             enabled: false,
-            model: String::new(),
+            force: false,
+            model: default_auto_router_model(),
             timeout_ms: default_auto_router_timeout_ms(),
         }
     }
+}
+
+fn default_auto_router_model() -> String {
+    "katanemo/Arch-Router-1.5B".to_owned()
 }
 
 const fn default_auto_router_timeout_ms() -> u64 {
@@ -397,6 +404,7 @@ pub fn build_simple_config(args: &ServeArgs) -> Result<HiggsConfig, String> {
     config.server = server;
 
     validate_config(&config, true)?;
+    ensure_auto_router_model(&mut config);
     Ok(config)
 }
 
@@ -440,11 +448,12 @@ pub fn load_config_file(path: &Path, args: Option<&ServeArgs>) -> Result<HiggsCo
         }
     }
 
-    let config: HiggsConfig = figment
+    let mut config: HiggsConfig = figment
         .extract()
         .map_err(|e| format!("failed to load config from {}: {e}", path.display()))?;
 
     validate_config(&config, false)?;
+    ensure_auto_router_model(&mut config);
     Ok(config)
 }
 
@@ -493,6 +502,23 @@ fn validate_config(config: &HiggsConfig, simple_mode: bool) -> Result<(), String
     }
 
     Ok(())
+}
+
+/// If `auto_router` is enabled, ensure its model is present in `config.models`.
+fn ensure_auto_router_model(config: &mut HiggsConfig) {
+    if !config.auto_router.enabled || config.auto_router.model.is_empty() {
+        return;
+    }
+    let already_listed = config
+        .models
+        .iter()
+        .any(|m| m.path == config.auto_router.model);
+    if !already_listed {
+        config.models.push(ModelConfig {
+            path: config.auto_router.model.clone(),
+            batch: false,
+        });
+    }
 }
 
 /// Returns the default config directory path (~/.config/higgs/).
@@ -805,8 +831,113 @@ mod tests {
     fn test_auto_router_defaults() {
         let config = HiggsConfig::default();
         assert!(!config.auto_router.enabled);
+        assert!(!config.auto_router.force);
         assert_eq!(config.auto_router.timeout_ms, 2000);
-        assert!(config.auto_router.model.is_empty());
+        assert_eq!(config.auto_router.model, "katanemo/Arch-Router-1.5B");
+    }
+
+    #[test]
+    fn auto_router_model_auto_injected_when_enabled() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            r#"
+            [provider.anthropic]
+            url = "https://api.anthropic.com"
+            format = "anthropic"
+
+            [default]
+            provider = "anthropic"
+
+            [auto_router]
+            enabled = true
+            model = "katanemo/Arch-Router-1.5B"
+            "#,
+        )
+        .unwrap();
+        let config = load_config_file(&path, None).unwrap();
+        assert!(
+            config
+                .models
+                .iter()
+                .any(|m| m.path == "katanemo/Arch-Router-1.5B")
+        );
+    }
+
+    #[test]
+    fn auto_router_model_not_duplicated_when_already_listed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            r#"
+            [[models]]
+            path = "katanemo/Arch-Router-1.5B"
+
+            [auto_router]
+            enabled = true
+            model = "katanemo/Arch-Router-1.5B"
+            "#,
+        )
+        .unwrap();
+        let config = load_config_file(&path, None).unwrap();
+        let count = config
+            .models
+            .iter()
+            .filter(|m| m.path == "katanemo/Arch-Router-1.5B")
+            .count();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn auto_router_model_not_injected_when_disabled() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            r#"
+            [provider.anthropic]
+            url = "https://api.anthropic.com"
+            format = "anthropic"
+
+            [default]
+            provider = "anthropic"
+
+            [auto_router]
+            enabled = false
+            "#,
+        )
+        .unwrap();
+        let config = load_config_file(&path, None).unwrap();
+        assert!(
+            !config
+                .models
+                .iter()
+                .any(|m| m.path == "katanemo/Arch-Router-1.5B")
+        );
+    }
+
+    #[test]
+    fn auto_router_force_deserializes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            r#"
+            [[models]]
+            path = "some/model"
+
+            [auto_router]
+            enabled = true
+            force = true
+            model = "katanemo/Arch-Router-1.5B"
+            "#,
+        )
+        .unwrap();
+        let config = load_config_file(&path, None).unwrap();
+        assert!(config.auto_router.force);
+        assert!(config.auto_router.enabled);
     }
 
     #[test]

--- a/crates/higgs/src/config.rs
+++ b/crates/higgs/src/config.rs
@@ -404,7 +404,7 @@ pub fn build_simple_config(args: &ServeArgs) -> Result<HiggsConfig, String> {
 pub fn load_config_file(path: &Path, args: Option<&ServeArgs>) -> Result<HiggsConfig, String> {
     let mut figment = Figment::new()
         .merge(Toml::file(path))
-        .merge(Env::prefixed("HIGGS_").split("_"));
+        .merge(Env::prefixed("HIGGS_").split("__"));
 
     // Overlay CLI args on server section
     if let Some(serve_args) = args {

--- a/crates/higgs/src/config.rs
+++ b/crates/higgs/src/config.rs
@@ -522,7 +522,11 @@ fn ensure_auto_router_model(config: &mut HiggsConfig) {
 }
 
 /// Returns the default config directory path (~/.config/higgs/).
+/// Honors the `HIGGS_CONFIG_DIR` environment variable if set.
 pub fn config_dir() -> PathBuf {
+    if let Ok(dir) = std::env::var("HIGGS_CONFIG_DIR") {
+        return PathBuf::from(dir);
+    }
     directories::BaseDirs::new().map_or_else(
         || PathBuf::from("/tmp/higgs"),
         |d| d.home_dir().join(".config/higgs"),

--- a/crates/higgs/src/config.rs
+++ b/crates/higgs/src/config.rs
@@ -1,320 +1,868 @@
-use clap::Parser;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use clap::{Parser, Subcommand};
 use figment::{
     Figment,
-    providers::{Env, Serialized},
+    providers::{Env, Format, Serialized, Toml},
 };
 use serde::{Deserialize, Serialize};
 
-/// CLI arguments (used as the highest-priority figment layer).
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
 #[derive(Parser, Debug)]
 #[command(
+    name = "higgs",
     author,
     version,
-    about = "Higgs - OpenAI and Anthropic-compatible inference server for Apple Silicon"
+    about = "Unified AI gateway: serve local MLX models and proxy to remote providers"
 )]
-struct CliArgs {
-    /// Path to a model directory or `HuggingFace` model ID. May be repeated to serve multiple models.
+pub struct Cli {
+    /// Path to config file (default: ~/.config/higgs/config.toml when auto-discovered).
+    #[arg(short, long, global = true, value_name = "FILE")]
+    pub config: Option<PathBuf>,
+
+    /// Enable debug logging.
+    #[arg(short, long, global = true)]
+    pub verbose: bool,
+
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Start the server in the foreground.
+    Serve(ServeArgs),
+    /// Start the server as a background daemon.
+    Start(ServeArgs),
+    /// Stop a running daemon.
+    Stop,
+    /// Attach TUI to a running daemon.
+    Attach,
+    /// Create a default config file at ~/.config/higgs/config.toml.
+    Init,
+    /// Print shell environment variables (for eval).
+    Shellenv,
+    /// Read or modify configuration values.
+    Config {
+        #[command(subcommand)]
+        action: ConfigAction,
+    },
+    /// Validate config, check model paths, and probe providers.
+    Doctor(ServeArgs),
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ConfigAction {
+    /// Get a configuration value (dot-separated key).
+    Get { key: String },
+    /// Set a configuration value (dot-separated key).
+    Set { key: String, value: String },
+    /// Print the resolved config file path.
+    Path,
+}
+
+#[derive(Parser, Debug)]
+pub struct ServeArgs {
+    /// Path to a model directory or `HuggingFace` model ID. May be repeated.
     #[arg(long = "model", action = clap::ArgAction::Append)]
-    models: Vec<String>,
+    pub models: Vec<String>,
 
     /// Host to bind the server to.
     #[arg(long)]
-    host: Option<String>,
+    pub host: Option<String>,
 
     /// Port to bind the server to.
     #[arg(long)]
-    port: Option<u16>,
+    pub port: Option<u16>,
 
     /// Default maximum tokens for generation.
     #[arg(long)]
-    max_tokens: Option<u32>,
+    pub max_tokens: Option<u32>,
 
     /// API key for authentication (if unset, no auth required).
     #[arg(long)]
-    api_key: Option<String>,
+    pub api_key: Option<String>,
 
     /// Rate limit (requests per minute per client, 0 = disabled).
     #[arg(long)]
-    rate_limit: Option<u32>,
+    pub rate_limit: Option<u32>,
 
     /// Default request timeout in seconds.
     #[arg(long)]
-    timeout: Option<f64>,
+    pub timeout: Option<f64>,
 
-    /// Use batch engine for interleaved concurrent request processing.
+    /// Use batch engine for all models (simple mode only).
     #[arg(long)]
-    batch: bool,
-}
-
-/// Resolved server configuration.
-///
-/// Layered resolution order (later wins):
-/// 1. Built-in defaults
-/// 2. `HIGGS_*` environment variables
-/// 3. CLI arguments
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ServerConfig {
-    pub models: Vec<String>,
-    pub host: String,
-    pub port: u16,
-    pub max_tokens: u32,
-    pub api_key: Option<String>,
-    pub rate_limit: u32,
-    pub timeout: f64,
     pub batch: bool,
 }
 
-impl Default for ServerConfig {
+// ---------------------------------------------------------------------------
+// Unified configuration
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct HiggsConfig {
+    #[serde(default)]
+    pub server: ServerSection,
+    #[serde(default)]
+    pub models: Vec<ModelConfig>,
+    #[serde(default, rename = "provider")]
+    pub providers: HashMap<String, ProviderConfig>,
+    #[serde(default)]
+    pub routes: Vec<RouteConfig>,
+    #[serde(default)]
+    pub default: DefaultRoute,
+    #[serde(default)]
+    pub auto_router: AutoRouterConfig,
+    #[serde(default)]
+    pub logging: LoggingConfig,
+    #[serde(default)]
+    pub retention: RetentionConfig,
+}
+
+// -- Server section ---------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServerSection {
+    #[serde(default = "default_host")]
+    pub host: String,
+    #[serde(default = "default_port")]
+    pub port: u16,
+    #[serde(default = "default_max_tokens")]
+    pub max_tokens: u32,
+    pub api_key: Option<String>,
+    #[serde(default)]
+    pub rate_limit: u32,
+    #[serde(default = "default_timeout")]
+    pub timeout: f64,
+    #[serde(default = "default_max_body_size")]
+    pub max_body_size: usize,
+}
+
+impl Default for ServerSection {
     fn default() -> Self {
         Self {
-            models: vec![],
-            host: "0.0.0.0".to_owned(),
-            port: 8000,
-            max_tokens: 32768,
+            host: default_host(),
+            port: default_port(),
+            max_tokens: default_max_tokens(),
             api_key: None,
             rate_limit: 0,
-            timeout: 300.0,
-            batch: false,
+            timeout: default_timeout(),
+            max_body_size: default_max_body_size(),
         }
     }
 }
 
-impl ServerConfig {
-    /// Load configuration from defaults, environment, and CLI args.
-    pub fn load() -> Result<Self, Box<figment::Error>> {
-        let cli = CliArgs::parse();
+fn default_host() -> String {
+    "0.0.0.0".to_owned()
+}
 
-        let mut figment = Figment::new()
-            .merge(Serialized::defaults(Self::default()))
-            .merge(Env::prefixed("HIGGS_"));
+const fn default_port() -> u16 {
+    8000
+}
 
-        // Overlay CLI args (only non-empty values)
-        if !cli.models.is_empty() {
-            figment = figment.merge(Serialized::default("models", &cli.models));
-        }
-        if let Some(ref host) = cli.host {
-            figment = figment.merge(Serialized::default("host", host));
-        }
-        if let Some(port) = cli.port {
-            figment = figment.merge(Serialized::default("port", port));
-        }
-        if let Some(max_tokens) = cli.max_tokens {
-            figment = figment.merge(Serialized::default("max_tokens", max_tokens));
-        }
-        if let Some(ref api_key) = cli.api_key {
-            figment = figment.merge(Serialized::default("api_key", api_key));
-        }
-        if let Some(rate_limit) = cli.rate_limit {
-            figment = figment.merge(Serialized::default("rate_limit", rate_limit));
-        }
-        if let Some(timeout) = cli.timeout {
-            figment = figment.merge(Serialized::default("timeout", timeout));
-        }
-        if cli.batch {
-            figment = figment.merge(Serialized::default("batch", true));
-        }
+const fn default_max_tokens() -> u32 {
+    32768
+}
 
-        let config: Self = figment.extract().map_err(Box::new)?;
-        config.validate()?;
-        Ok(config)
-    }
+const fn default_timeout() -> f64 {
+    300.0
+}
 
-    fn validate(&self) -> Result<(), Box<figment::Error>> {
-        if self.models.is_empty() {
-            return Err(Box::new(figment::Error::from(
-                "at least one --model is required".to_owned(),
-            )));
+const fn default_max_body_size() -> usize {
+    10 * 1024 * 1024
+}
+
+// -- Model config -----------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelConfig {
+    pub path: String,
+    #[serde(default)]
+    pub batch: bool,
+}
+
+// -- Provider config --------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProviderConfig {
+    pub url: String,
+    #[serde(default = "default_api_format")]
+    pub format: ApiFormat,
+    pub api_key: Option<String>,
+    #[serde(default)]
+    pub strip_auth: bool,
+    #[serde(default)]
+    pub stub_count_tokens: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ApiFormat {
+    OpenAi,
+    Anthropic,
+}
+
+const fn default_api_format() -> ApiFormat {
+    ApiFormat::OpenAi
+}
+
+// -- Route config -----------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RouteConfig {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub pattern: Option<String>,
+    pub provider: String,
+    pub model: Option<String>,
+}
+
+// -- Default route ----------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DefaultRoute {
+    #[serde(default = "default_provider_name")]
+    pub provider: String,
+}
+
+impl Default for DefaultRoute {
+    fn default() -> Self {
+        Self {
+            provider: default_provider_name(),
         }
-        for model in &self.models {
-            if model.trim().is_empty() {
-                return Err(Box::new(figment::Error::from(
-                    "model path must not be empty or whitespace-only".to_owned(),
-                )));
-            }
-        }
-        let mut seen = std::collections::HashSet::new();
-        for model in &self.models {
-            if !seen.insert(model) {
-                return Err(Box::new(figment::Error::from(format!(
-                    "duplicate model path: {model}"
-                ))));
-            }
-        }
-        if self.timeout < 0.0 {
-            return Err(Box::new(figment::Error::from(
-                "timeout must not be negative".to_owned(),
-            )));
-        }
-        Ok(())
     }
 }
+
+fn default_provider_name() -> String {
+    "higgs".to_owned()
+}
+
+// -- Auto router config -----------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AutoRouterConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub model: String,
+    #[serde(default = "default_auto_router_timeout_ms")]
+    pub timeout_ms: u64,
+}
+
+impl Default for AutoRouterConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            model: String::new(),
+            timeout_ms: default_auto_router_timeout_ms(),
+        }
+    }
+}
+
+const fn default_auto_router_timeout_ms() -> u64 {
+    2000
+}
+
+// -- Logging config ---------------------------------------------------------
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct LoggingConfig {
+    #[serde(default)]
+    pub metrics: MetricsLogConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MetricsLogConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default = "default_metrics_log_path")]
+    pub path: String,
+    #[serde(default = "default_max_size_mb")]
+    pub max_size_mb: u64,
+    #[serde(default = "default_max_files")]
+    pub max_files: u32,
+}
+
+impl Default for MetricsLogConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            path: default_metrics_log_path(),
+            max_size_mb: default_max_size_mb(),
+            max_files: default_max_files(),
+        }
+    }
+}
+
+fn default_metrics_log_path() -> String {
+    directories::BaseDirs::new()
+        .map_or_else(
+            || PathBuf::from("/tmp/higgs/logs/metrics.jsonl"),
+            |d| d.home_dir().join(".config/higgs/logs/metrics.jsonl"),
+        )
+        .to_string_lossy()
+        .to_string()
+}
+
+const fn default_max_size_mb() -> u64 {
+    50
+}
+
+const fn default_max_files() -> u32 {
+    5
+}
+
+// -- Retention config -------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RetentionConfig {
+    #[serde(default = "default_retention_enabled")]
+    pub enabled: bool,
+    #[serde(default = "default_retention_minutes")]
+    pub minutes: u64,
+}
+
+impl Default for RetentionConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_retention_enabled(),
+            minutes: default_retention_minutes(),
+        }
+    }
+}
+
+const fn default_retention_enabled() -> bool {
+    true
+}
+
+const fn default_retention_minutes() -> u64 {
+    60
+}
+
+// ---------------------------------------------------------------------------
+// Config loading
+// ---------------------------------------------------------------------------
+
+/// Returns true if this is "simple mode" -- no config file, models come from CLI.
+pub const fn is_simple_mode(cli: &Cli, serve_args: &ServeArgs) -> bool {
+    cli.config.is_none() && !serve_args.models.is_empty()
+}
+
+/// Build a `HiggsConfig` from CLI args only (simple mode, no config file).
+pub fn build_simple_config(args: &ServeArgs) -> Result<HiggsConfig, String> {
+    let models: Vec<ModelConfig> = args
+        .models
+        .iter()
+        .map(|p| ModelConfig {
+            path: p.clone(),
+            batch: args.batch,
+        })
+        .collect();
+
+    let mut config = HiggsConfig {
+        models,
+        ..HiggsConfig::default()
+    };
+
+    if let Some(ref host) = args.host {
+        host.clone_into(&mut config.server.host);
+    }
+    if let Some(port) = args.port {
+        config.server.port = port;
+    }
+    if let Some(max_tokens) = args.max_tokens {
+        config.server.max_tokens = max_tokens;
+    }
+    if let Some(ref api_key) = args.api_key {
+        config.server.api_key = Some(api_key.clone());
+    }
+    if let Some(rate_limit) = args.rate_limit {
+        config.server.rate_limit = rate_limit;
+    }
+    if let Some(timeout) = args.timeout {
+        config.server.timeout = timeout;
+    }
+
+    // Overlay HIGGS_* env vars on server section
+    let figment = Figment::new()
+        .merge(Serialized::defaults(&config.server))
+        .merge(Env::prefixed("HIGGS_"));
+    config.server = figment
+        .extract()
+        .map_err(|e| format!("env overlay failed: {e}"))?;
+
+    validate_config(&config, true)?;
+    Ok(config)
+}
+
+/// Load a `HiggsConfig` from a TOML file, with env and CLI overlays (config mode).
+pub fn load_config_file(path: &Path, args: Option<&ServeArgs>) -> Result<HiggsConfig, String> {
+    let mut figment = Figment::new()
+        .merge(Toml::file(path))
+        .merge(Env::prefixed("HIGGS_").split("_"));
+
+    // Overlay CLI args on server section
+    if let Some(serve_args) = args {
+        if let Some(ref host) = serve_args.host {
+            figment = figment.merge(Serialized::default("server.host", host));
+        }
+        if let Some(port) = serve_args.port {
+            figment = figment.merge(Serialized::default("server.port", port));
+        }
+        if let Some(max_tokens) = serve_args.max_tokens {
+            figment = figment.merge(Serialized::default("server.max_tokens", max_tokens));
+        }
+        if let Some(ref api_key) = serve_args.api_key {
+            figment = figment.merge(Serialized::default("server.api_key", api_key));
+        }
+        if let Some(rate_limit) = serve_args.rate_limit {
+            figment = figment.merge(Serialized::default("server.rate_limit", rate_limit));
+        }
+        if let Some(timeout) = serve_args.timeout {
+            figment = figment.merge(Serialized::default("server.timeout", timeout));
+        }
+        // Additional models from CLI in config mode
+        if !serve_args.models.is_empty() {
+            let extra: Vec<ModelConfig> = serve_args
+                .models
+                .iter()
+                .map(|p| ModelConfig {
+                    path: p.clone(),
+                    batch: serve_args.batch,
+                })
+                .collect();
+            figment = figment.merge(Serialized::default("models", &extra));
+        }
+    }
+
+    let config: HiggsConfig = figment
+        .extract()
+        .map_err(|e| format!("failed to load config from {}: {e}", path.display()))?;
+
+    validate_config(&config, false)?;
+    Ok(config)
+}
+
+fn validate_config(config: &HiggsConfig, simple_mode: bool) -> Result<(), String> {
+    if simple_mode {
+        if config.models.is_empty() {
+            return Err("at least one --model is required".to_owned());
+        }
+    } else if config.models.is_empty() && config.providers.is_empty() {
+        return Err("config must define at least one [[models]] entry or [provider.*]".to_owned());
+    }
+
+    for model in &config.models {
+        if model.path.trim().is_empty() {
+            return Err("model path must not be empty or whitespace-only".to_owned());
+        }
+    }
+
+    let mut seen = std::collections::HashSet::new();
+    for model in &config.models {
+        if !seen.insert(&model.path) {
+            return Err(format!("duplicate model path: {}", model.path));
+        }
+    }
+
+    for route in &config.routes {
+        if route.provider != "higgs" && !config.providers.contains_key(&route.provider) {
+            return Err(format!(
+                "route references unknown provider '{}'",
+                route.provider
+            ));
+        }
+    }
+
+    if config.default.provider != "higgs"
+        && !config.providers.contains_key(&config.default.provider)
+    {
+        return Err(format!(
+            "default provider '{}' not found in providers",
+            config.default.provider
+        ));
+    }
+
+    if config.server.timeout < 0.0 {
+        return Err("timeout must not be negative".to_owned());
+    }
+
+    Ok(())
+}
+
+/// Returns the default config directory path (~/.config/higgs/).
+pub fn config_dir() -> PathBuf {
+    directories::BaseDirs::new().map_or_else(
+        || PathBuf::from("/tmp/higgs"),
+        |d| d.home_dir().join(".config/higgs"),
+    )
+}
+
+/// Returns the default config file path (~/.config/higgs/config.toml).
+pub fn default_config_path() -> PathBuf {
+    config_dir().join("config.toml")
+}
+
+/// Returns the PID file path (~/.config/higgs/higgs.pid).
+pub fn pid_path() -> PathBuf {
+    config_dir().join("higgs.pid")
+}
+
+/// Returns the log file path (~/.config/higgs/higgs.log).
+pub fn log_path() -> PathBuf {
+    config_dir().join("higgs.log")
+}
+
+// ---------------------------------------------------------------------------
+// Legacy compat: ServerConfig alias for existing route handler code
+// ---------------------------------------------------------------------------
+
+/// Backward-compatible alias. Route handlers access `state.config.max_tokens`.
+pub type ServerConfig = ServerSection;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 #[allow(clippy::panic, clippy::unwrap_used)]
 mod tests {
     use super::*;
 
-    /// Returns a figment with `ServerConfig` defaults already merged.
-    fn test_figment() -> Figment {
-        Figment::new().merge(Serialized::defaults(ServerConfig::default()))
-    }
-
-    /// Creates a `ServerConfig` with a single key overridden.
-    fn config_with(key: &str, value: impl Serialize) -> ServerConfig {
-        test_figment()
-            .merge(Serialized::default(key, value))
-            .extract()
-            .unwrap()
-    }
-
     #[test]
-    fn test_default_config_has_reasonable_values() {
-        let config = ServerConfig::default();
+    fn test_default_higgs_config() {
+        let config = HiggsConfig::default();
         assert!(config.models.is_empty());
-        assert_eq!(config.host, "0.0.0.0");
-        assert_eq!(config.port, 8000);
-        assert_eq!(config.max_tokens, 32768);
-        assert!(config.api_key.is_none());
-        assert_eq!(config.rate_limit, 0);
-        assert!((config.timeout - 300.0).abs() < f64::EPSILON);
+        assert!(config.providers.is_empty());
+        assert!(config.routes.is_empty());
+        assert_eq!(config.server.host, "0.0.0.0");
+        assert_eq!(config.server.port, 8000);
+        assert_eq!(config.server.max_tokens, 32768);
+        assert!((config.server.timeout - 300.0).abs() < f64::EPSILON);
+        assert!(config.server.api_key.is_none());
+        assert_eq!(config.server.rate_limit, 0);
+        assert_eq!(config.default.provider, "higgs");
     }
 
     #[test]
-    fn test_config_layered_override() {
-        // Verifies that later figment layers override earlier ones,
-        // which is the same mechanism used by Env::prefixed("HIGGS_").
-        let config: ServerConfig = test_figment()
-            .merge(Serialized::default("port", 9000_u16))
-            .merge(Serialized::default("host", "127.0.0.1"))
-            .extract()
-            .unwrap();
-        assert_eq!(config.port, 9000);
-        assert_eq!(config.host, "127.0.0.1");
-    }
-
-    #[test]
-    fn test_cli_overrides_defaults() {
-        let config: ServerConfig = test_figment()
-            .merge(Serialized::default("max_tokens", 1024_u32))
-            .merge(Serialized::default("timeout", 60.0_f64))
-            .extract()
-            .unwrap();
-        assert_eq!(config.max_tokens, 1024);
-        assert!((config.timeout - 60.0).abs() < f64::EPSILON);
-    }
-
-    #[test]
-    fn test_api_key_can_be_set() {
-        let config = config_with("api_key", "sk-test-123");
-        assert_eq!(config.api_key, Some("sk-test-123".to_owned()));
-    }
-
-    #[test]
-    fn test_port_zero_is_accepted() {
-        let config = config_with("port", 0_u16);
-        assert_eq!(config.port, 0);
-    }
-
-    #[test]
-    fn test_max_tokens_zero() {
-        let config = config_with("max_tokens", 0_u32);
-        assert_eq!(config.max_tokens, 0);
-    }
-
-    #[test]
-    fn test_timeout_zero() {
-        let config = config_with("timeout", 0.0_f64);
-        assert!(config.timeout.abs() < f64::EPSILON);
-    }
-
-    #[test]
-    fn test_empty_models_rejected() {
-        let config = ServerConfig::default();
-        assert!(config.validate().is_err());
-    }
-
-    #[test]
-    fn test_single_model_accepted() {
-        let config = config_with("models", vec!["some/model"]);
-        assert!(config.validate().is_ok());
-    }
-
-    #[test]
-    fn test_multiple_models_accepted() {
-        let config = config_with("models", vec!["model/a", "model/b"]);
+    fn test_simple_mode_builds_models() {
+        let args = ServeArgs {
+            models: vec!["org/model-a".to_owned(), "org/model-b".to_owned()],
+            host: None,
+            port: None,
+            max_tokens: None,
+            api_key: None,
+            rate_limit: None,
+            timeout: None,
+            batch: true,
+        };
+        let config = build_simple_config(&args).unwrap();
         assert_eq!(config.models.len(), 2);
-        assert!(config.validate().is_ok());
+        assert!(config.models.iter().all(|m| m.batch));
+        assert_eq!(
+            config.models.first().map(|m| m.path.as_str()),
+            Some("org/model-a")
+        );
+    }
+
+    #[test]
+    fn test_simple_mode_cli_overrides() {
+        let args = ServeArgs {
+            models: vec!["some/model".to_owned()],
+            host: Some("127.0.0.1".to_owned()),
+            port: Some(9000),
+            max_tokens: Some(1024),
+            api_key: Some("sk-test".to_owned()),
+            rate_limit: Some(60),
+            timeout: Some(60.0),
+            batch: false,
+        };
+        let config = build_simple_config(&args).unwrap();
+        assert_eq!(config.server.host, "127.0.0.1");
+        assert_eq!(config.server.port, 9000);
+        assert_eq!(config.server.max_tokens, 1024);
+        assert_eq!(config.server.api_key, Some("sk-test".to_owned()));
+        assert_eq!(config.server.rate_limit, 60);
+        assert!((config.server.timeout - 60.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_simple_mode_no_models_rejected() {
+        let args = ServeArgs {
+            models: vec![],
+            host: None,
+            port: None,
+            max_tokens: None,
+            api_key: None,
+            rate_limit: None,
+            timeout: None,
+            batch: false,
+        };
+        assert!(build_simple_config(&args).is_err());
+    }
+
+    #[test]
+    fn test_simple_mode_empty_model_rejected() {
+        let args = ServeArgs {
+            models: vec!["  ".to_owned()],
+            host: None,
+            port: None,
+            max_tokens: None,
+            api_key: None,
+            rate_limit: None,
+            timeout: None,
+            batch: false,
+        };
+        assert!(build_simple_config(&args).is_err());
+    }
+
+    #[test]
+    fn test_simple_mode_duplicate_models_rejected() {
+        let args = ServeArgs {
+            models: vec!["org/model".to_owned(), "org/model".to_owned()],
+            host: None,
+            port: None,
+            max_tokens: None,
+            api_key: None,
+            rate_limit: None,
+            timeout: None,
+            batch: false,
+        };
+        assert!(build_simple_config(&args).is_err());
+    }
+
+    #[test]
+    fn test_config_file_parses_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            r#"
+            [server]
+            host = "127.0.0.1"
+            port = 3100
+
+            [[models]]
+            path = "mlx-community/Llama-3.2-1B-Instruct-4bit"
+            batch = true
+
+            [provider.anthropic]
+            url = "https://api.anthropic.com"
+            format = "anthropic"
+
+            [[routes]]
+            pattern = "claude-.*"
+            provider = "anthropic"
+
+            [default]
+            provider = "anthropic"
+            "#,
+        )
+        .unwrap();
+
+        let config = load_config_file(&path, None).unwrap();
+        assert_eq!(config.server.host, "127.0.0.1");
+        assert_eq!(config.server.port, 3100);
+        assert_eq!(config.models.len(), 1);
+        assert!(config.models.first().map_or(false, |m| m.batch));
+        assert_eq!(config.providers.len(), 1);
+        assert_eq!(config.routes.len(), 1);
+        assert_eq!(config.default.provider, "anthropic");
+    }
+
+    #[test]
+    fn test_config_mode_no_models_no_providers_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            r#"
+            [server]
+            host = "127.0.0.1"
+            "#,
+        )
+        .unwrap();
+
+        assert!(load_config_file(&path, None).is_err());
+    }
+
+    #[test]
+    fn test_config_mode_providers_only_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            r#"
+            [provider.anthropic]
+            url = "https://api.anthropic.com"
+            format = "anthropic"
+
+            [default]
+            provider = "anthropic"
+            "#,
+        )
+        .unwrap();
+
+        let config = load_config_file(&path, None).unwrap();
+        assert!(config.models.is_empty());
+        assert_eq!(config.providers.len(), 1);
+    }
+
+    #[test]
+    fn test_route_references_unknown_provider_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            r#"
+            [[models]]
+            path = "some/model"
+
+            [[routes]]
+            pattern = "test"
+            provider = "nonexistent"
+            "#,
+        )
+        .unwrap();
+
+        assert!(load_config_file(&path, None).is_err());
+    }
+
+    #[test]
+    fn test_route_to_higgs_provider_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            r#"
+            [[models]]
+            path = "some/model"
+
+            [[routes]]
+            pattern = "Llama.*"
+            provider = "higgs"
+            "#,
+        )
+        .unwrap();
+
+        let config = load_config_file(&path, None).unwrap();
+        assert_eq!(config.routes.len(), 1);
+    }
+
+    #[test]
+    fn test_api_format_deserialization() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            r#"
+            [provider.anthropic]
+            url = "https://api.anthropic.com"
+            format = "anthropic"
+
+            [provider.openai]
+            url = "https://api.openai.com"
+            format = "openai"
+
+            [provider.ollama]
+            url = "http://localhost:11434"
+            strip_auth = true
+
+            [default]
+            provider = "anthropic"
+            "#,
+        )
+        .unwrap();
+
+        let config = load_config_file(&path, None).unwrap();
+        assert_eq!(
+            config.providers.get("anthropic").map(|p| p.format),
+            Some(ApiFormat::Anthropic)
+        );
+        assert_eq!(
+            config.providers.get("openai").map(|p| p.format),
+            Some(ApiFormat::OpenAi)
+        );
+        assert_eq!(
+            config.providers.get("ollama").map(|p| p.format),
+            Some(ApiFormat::OpenAi)
+        );
+    }
+
+    #[test]
+    fn test_retention_defaults() {
+        let config = HiggsConfig::default();
+        assert!(config.retention.enabled);
+        assert_eq!(config.retention.minutes, 60);
+    }
+
+    #[test]
+    fn test_auto_router_defaults() {
+        let config = HiggsConfig::default();
+        assert!(!config.auto_router.enabled);
+        assert_eq!(config.auto_router.timeout_ms, 2000);
+        assert!(config.auto_router.model.is_empty());
+    }
+
+    #[test]
+    fn test_logging_defaults() {
+        let config = HiggsConfig::default();
+        assert!(!config.logging.metrics.enabled);
+        assert_eq!(config.logging.metrics.max_size_mb, 50);
+        assert_eq!(config.logging.metrics.max_files, 5);
+        assert!(config.logging.metrics.path.contains("metrics.jsonl"));
     }
 
     #[test]
     fn test_negative_timeout_rejected() {
-        let result: Result<ServerConfig, _> = test_figment()
-            .merge(Serialized::default("models", vec!["some/model"]))
-            .merge(Serialized::default("timeout", -1.0_f64))
-            .extract();
-        let config = result.unwrap();
-        assert!(config.validate().is_err());
+        let args = ServeArgs {
+            models: vec!["some/model".to_owned()],
+            host: None,
+            port: None,
+            max_tokens: None,
+            api_key: None,
+            rate_limit: None,
+            timeout: Some(-1.0),
+            batch: false,
+        };
+        assert!(build_simple_config(&args).is_err());
     }
 
     #[test]
-    fn test_rate_limit_zero_means_disabled() {
-        let config = ServerConfig::default();
-        assert_eq!(config.rate_limit, 0);
-    }
+    fn test_config_file_cli_overlay() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            r#"
+            [server]
+            host = "127.0.0.1"
+            port = 3100
 
-    #[test]
-    fn test_rate_limit_nonzero_means_enabled() {
-        let config = config_with("rate_limit", 60_u32);
-        assert_eq!(config.rate_limit, 60);
-    }
+            [[models]]
+            path = "some/model"
+            "#,
+        )
+        .unwrap();
 
-    #[test]
-    fn test_api_key_empty_string_vs_none() {
-        let config = ServerConfig::default();
-        assert!(config.api_key.is_none());
+        let args = ServeArgs {
+            models: vec![],
+            host: None,
+            port: Some(9000),
+            max_tokens: None,
+            api_key: None,
+            rate_limit: None,
+            timeout: None,
+            batch: false,
+        };
 
-        let config_with_empty = config_with("api_key", "");
-        assert_eq!(config_with_empty.api_key, Some(String::new()));
-    }
-
-    #[test]
-    fn test_default_timeout_is_300() {
-        let config = ServerConfig::default();
-        assert!((config.timeout - 300.0).abs() < f64::EPSILON);
-    }
-
-    #[test]
-    fn test_default_rate_limit_is_zero() {
-        let config = ServerConfig::default();
-        assert_eq!(config.rate_limit, 0);
-    }
-
-    #[test]
-    fn test_empty_string_model_rejected() {
-        let config = config_with("models", vec![""]);
-        assert!(config.validate().is_err());
-    }
-
-    #[test]
-    fn test_whitespace_only_model_rejected() {
-        let config = config_with("models", vec!["  "]);
-        assert!(config.validate().is_err());
-    }
-
-    #[test]
-    fn test_duplicate_models_rejected() {
-        let config = config_with("models", vec!["org/model", "org/model"]);
-        assert!(config.validate().is_err());
-    }
-
-    #[test]
-    fn test_duplicate_models_different_paths_same_name_rejected() {
-        // org-a/llama and org-b/llama both resolve to "llama" in the HashMap key
-        let config = config_with("models", vec!["org-a/llama", "org-b/llama"]);
-        // These are different strings, so path-level dedup doesn't catch this --
-        // but the name collision is detected at load time in main.rs, not here.
-        // This test documents that path-level dedup in validate() only catches
-        // exact string duplicates.
-        assert!(config.validate().is_ok());
+        let config = load_config_file(&path, Some(&args)).unwrap();
+        assert_eq!(config.server.host, "127.0.0.1");
+        assert_eq!(config.server.port, 9000);
     }
 }

--- a/crates/higgs/src/config.rs
+++ b/crates/higgs/src/config.rs
@@ -669,7 +669,7 @@ mod tests {
         assert_eq!(config.server.host, "127.0.0.1");
         assert_eq!(config.server.port, 3100);
         assert_eq!(config.models.len(), 1);
-        assert!(config.models.first().map_or(false, |m| m.batch));
+        assert!(config.models.first().is_some_and(|m| m.batch));
         assert_eq!(config.providers.len(), 1);
         assert_eq!(config.routes.len(), 1);
         assert_eq!(config.default.provider, "anthropic");

--- a/crates/higgs/src/config.rs
+++ b/crates/higgs/src/config.rs
@@ -369,32 +369,32 @@ pub fn build_simple_config(args: &ServeArgs) -> Result<HiggsConfig, String> {
         ..HiggsConfig::default()
     };
 
-    if let Some(ref host) = args.host {
-        host.clone_into(&mut config.server.host);
-    }
-    if let Some(port) = args.port {
-        config.server.port = port;
-    }
-    if let Some(max_tokens) = args.max_tokens {
-        config.server.max_tokens = max_tokens;
-    }
-    if let Some(ref api_key) = args.api_key {
-        config.server.api_key = Some(api_key.clone());
-    }
-    if let Some(rate_limit) = args.rate_limit {
-        config.server.rate_limit = rate_limit;
-    }
-    if let Some(timeout) = args.timeout {
-        config.server.timeout = timeout;
-    }
-
-    // Overlay HIGGS_* env vars on server section
+    // Overlay HIGGS_* env vars, then re-apply explicit CLI args on top
     let figment = Figment::new()
-        .merge(Serialized::defaults(&config.server))
+        .merge(Serialized::defaults(&ServerSection::default()))
         .merge(Env::prefixed("HIGGS_"));
-    config.server = figment
+    let mut server: ServerSection = figment
         .extract()
         .map_err(|e| format!("env overlay failed: {e}"))?;
+    if let Some(ref host) = args.host {
+        host.clone_into(&mut server.host);
+    }
+    if let Some(port) = args.port {
+        server.port = port;
+    }
+    if let Some(max_tokens) = args.max_tokens {
+        server.max_tokens = max_tokens;
+    }
+    if let Some(ref api_key) = args.api_key {
+        server.api_key = Some(api_key.clone());
+    }
+    if let Some(rate_limit) = args.rate_limit {
+        server.rate_limit = rate_limit;
+    }
+    if let Some(timeout) = args.timeout {
+        server.timeout = timeout;
+    }
+    config.server = server;
 
     validate_config(&config, true)?;
     Ok(config)
@@ -488,8 +488,8 @@ fn validate_config(config: &HiggsConfig, simple_mode: bool) -> Result<(), String
         ));
     }
 
-    if config.server.timeout < 0.0 {
-        return Err("timeout must not be negative".to_owned());
+    if !config.server.timeout.is_finite() || config.server.timeout < 0.0 {
+        return Err("timeout must be a finite, non-negative number".to_owned());
     }
 
     Ok(())

--- a/crates/higgs/src/daemon.rs
+++ b/crates/higgs/src/daemon.rs
@@ -14,6 +14,9 @@ use crate::metrics::MetricsStore;
 use crate::metrics_log::MetricsLogger;
 
 pub fn config_dir() -> PathBuf {
+    if let Ok(dir) = std::env::var("HIGGS_CONFIG_DIR") {
+        return PathBuf::from(dir);
+    }
     let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_owned());
     PathBuf::from(home).join(".config/higgs")
 }
@@ -384,5 +387,181 @@ pub async fn await_shutdown_signal() {
     tokio::select! {
         _ = async { if let Some(ref mut s) = sigint { s.recv().await } else { std::future::pending().await } } => {}
         _ = async { if let Some(ref mut s) = sigterm { s.recv().await } else { std::future::pending().await } } => {}
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used, unsafe_code)]
+mod tests {
+    use super::*;
+
+    fn with_temp_config_dir<F: FnOnce(&std::path::Path)>(f: F) {
+        let dir = tempfile::tempdir().unwrap();
+        unsafe {
+            std::env::set_var("HIGGS_CONFIG_DIR", dir.path());
+        }
+        f(dir.path());
+        unsafe {
+            std::env::remove_var("HIGGS_CONFIG_DIR");
+        }
+    }
+
+    #[test]
+    fn config_dir_respects_env_override() {
+        let dir = tempfile::tempdir().unwrap();
+        unsafe {
+            std::env::set_var("HIGGS_CONFIG_DIR", dir.path());
+        }
+        assert_eq!(config_dir(), dir.path());
+        unsafe {
+            std::env::remove_var("HIGGS_CONFIG_DIR");
+        }
+    }
+
+    #[test]
+    fn config_dir_falls_back_to_home() {
+        unsafe {
+            std::env::remove_var("HIGGS_CONFIG_DIR");
+        }
+        let path = config_dir();
+        assert!(path.to_string_lossy().ends_with(".config/higgs"));
+    }
+
+    #[test]
+    fn pid_path_suffix() {
+        with_temp_config_dir(|dir| {
+            assert_eq!(pid_path(), dir.join("higgs.pid"));
+        });
+    }
+
+    #[test]
+    fn log_path_suffix() {
+        with_temp_config_dir(|dir| {
+            assert_eq!(log_path(), dir.join("higgs.log"));
+        });
+    }
+
+    #[test]
+    fn read_pid_none_when_no_file() {
+        with_temp_config_dir(|_| {
+            assert!(read_pid().is_none());
+        });
+    }
+
+    #[test]
+    fn read_pid_returns_valid_pid() {
+        with_temp_config_dir(|dir| {
+            std::fs::write(dir.join("higgs.pid"), "12345").unwrap();
+            assert_eq!(read_pid(), Some(12345));
+        });
+    }
+
+    #[test]
+    fn read_pid_none_for_non_numeric() {
+        with_temp_config_dir(|dir| {
+            std::fs::write(dir.join("higgs.pid"), "not-a-number").unwrap();
+            assert!(read_pid().is_none());
+        });
+    }
+
+    #[test]
+    fn write_and_read_pid_file() {
+        with_temp_config_dir(|dir| {
+            std::fs::create_dir_all(dir).unwrap();
+            write_pid_file();
+            let pid = read_pid().unwrap();
+            assert_eq!(pid, i32::try_from(std::process::id()).unwrap());
+        });
+    }
+
+    #[test]
+    fn remove_pid_file_removes_file() {
+        with_temp_config_dir(|dir| {
+            let path = dir.join("higgs.pid");
+            std::fs::write(&path, "12345").unwrap();
+            assert!(path.exists());
+            remove_pid_file();
+            assert!(!path.exists());
+        });
+    }
+
+    #[test]
+    fn remove_pid_file_noop_when_missing() {
+        with_temp_config_dir(|_| {
+            remove_pid_file();
+        });
+    }
+
+    #[test]
+    fn pid_is_alive_for_own_process() {
+        let pid = i32::try_from(std::process::id()).unwrap();
+        assert!(pid_is_alive(pid));
+    }
+
+    #[test]
+    fn pid_is_alive_false_for_nonexistent() {
+        assert!(!pid_is_alive(99_999_999));
+    }
+
+    #[test]
+    fn retention_duration_uses_configured_minutes() {
+        let config = HiggsConfig {
+            retention: crate::config::RetentionConfig {
+                enabled: true,
+                minutes: 30,
+            },
+            ..HiggsConfig::default()
+        };
+        assert_eq!(retention_duration(&config), Duration::from_secs(1800));
+    }
+
+    #[test]
+    fn retention_duration_one_year_when_disabled() {
+        let config = HiggsConfig {
+            retention: crate::config::RetentionConfig {
+                enabled: false,
+                minutes: 30,
+            },
+            ..HiggsConfig::default()
+        };
+        assert_eq!(
+            retention_duration(&config),
+            Duration::from_secs(365 * 24 * 60 * 60)
+        );
+    }
+
+    #[test]
+    fn create_metrics_without_logger() {
+        let config = HiggsConfig {
+            logging: crate::config::LoggingConfig {
+                metrics: crate::config::MetricsLogConfig {
+                    enabled: false,
+                    ..Default::default()
+                },
+            },
+            ..HiggsConfig::default()
+        };
+        let store = create_metrics(&config);
+        assert_eq!(store.window(), retention_duration(&config));
+    }
+
+    #[test]
+    fn cmd_init_creates_config_file() {
+        with_temp_config_dir(|dir| {
+            std::fs::create_dir_all(dir).unwrap();
+            cmd_init();
+            assert!(dir.join("config.toml").exists());
+        });
+    }
+
+    #[test]
+    fn cmd_init_noop_when_config_exists() {
+        with_temp_config_dir(|dir| {
+            std::fs::create_dir_all(dir).unwrap();
+            let path = dir.join("config.toml");
+            std::fs::write(&path, "existing content").unwrap();
+            cmd_init();
+            assert_eq!(std::fs::read_to_string(&path).unwrap(), "existing content");
+        });
     }
 }

--- a/crates/higgs/src/daemon.rs
+++ b/crates/higgs/src/daemon.rs
@@ -58,6 +58,16 @@ pub fn cmd_stop() {
                 eprintln!("failed to send SIGTERM to {pid}: {e}");
                 std::process::exit(1);
             }
+            // Wait for process to exit before removing PID file
+            let deadline = std::time::Instant::now() + Duration::from_secs(5);
+            while pid_is_alive(pid) {
+                if std::time::Instant::now() >= deadline {
+                    eprintln!("sent SIGTERM to {pid} but process still running after 5s");
+                    remove_pid_file();
+                    return;
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
             remove_pid_file();
             eprintln!("stopped higgs (pid {pid})");
         }

--- a/crates/higgs/src/daemon.rs
+++ b/crates/higgs/src/daemon.rs
@@ -1,0 +1,388 @@
+use std::fs;
+use std::net::TcpStream;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use nix::sys::signal::{Signal, kill};
+use nix::unistd::Pid;
+
+use crate::attach;
+use crate::config::HiggsConfig;
+use crate::metrics::MetricsStore;
+use crate::metrics_log::MetricsLogger;
+
+pub fn config_dir() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_owned());
+    PathBuf::from(home).join(".config/higgs")
+}
+
+pub fn pid_path() -> PathBuf {
+    config_dir().join("higgs.pid")
+}
+
+pub fn log_path() -> PathBuf {
+    config_dir().join("higgs.log")
+}
+
+pub fn read_pid() -> Option<i32> {
+    fs::read_to_string(pid_path())
+        .ok()
+        .and_then(|s| s.trim().parse().ok())
+}
+
+pub fn pid_is_alive(pid: i32) -> bool {
+    kill(Pid::from_raw(pid), None).is_ok()
+}
+
+pub fn remove_pid_file() {
+    let _ = fs::remove_file(pid_path());
+}
+
+pub fn write_pid_file() {
+    let pid = std::process::id();
+    if let Err(e) = fs::write(pid_path(), pid.to_string()) {
+        tracing::warn!("failed to write pid file: {e}");
+    }
+}
+
+#[allow(clippy::print_stderr)]
+pub fn cmd_stop() {
+    match read_pid() {
+        Some(pid) if pid_is_alive(pid) => {
+            if let Err(e) = kill(Pid::from_raw(pid), Signal::SIGTERM) {
+                eprintln!("failed to send SIGTERM to {pid}: {e}");
+                std::process::exit(1);
+            }
+            remove_pid_file();
+            eprintln!("stopped higgs (pid {pid})");
+        }
+        Some(_) => {
+            remove_pid_file();
+            eprintln!("higgs is not running (stale pid file removed)");
+        }
+        None => {
+            eprintln!("higgs is not running (no pid file)");
+        }
+    }
+}
+
+#[allow(clippy::print_stderr)]
+pub fn cmd_init() {
+    let dir = config_dir();
+    let path = dir.join("config.toml");
+
+    if path.exists() {
+        eprintln!("config already exists: {}", path.display());
+        return;
+    }
+
+    if let Err(e) = fs::create_dir_all(&dir) {
+        eprintln!("failed to create {}: {e}", dir.display());
+        std::process::exit(1);
+    }
+
+    let default_config = r#"[server]
+host = "0.0.0.0"
+port = 8000
+# max_tokens = 32768
+# timeout = 300.0
+# api_key = "sk-..."
+# rate_limit = 0
+
+# --- Local models ---
+# Each [[models]] entry loads an MLX model into GPU memory.
+# Use a HuggingFace model ID or a local path.
+
+# [[models]]
+# path = "mlx-community/Llama-3.2-1B-Instruct-4bit"
+# batch = false
+
+# --- Remote providers ---
+# Forward requests to external APIs via proxy routes.
+
+# [provider.anthropic]
+# url = "https://api.anthropic.com"
+# format = "anthropic"
+
+# [provider.openai]
+# url = "https://api.openai.com"
+# format = "openai"
+
+# [provider.ollama]
+# url = "http://localhost:11434"
+# strip_auth = true
+# api_key = "ollama"
+# stub_count_tokens = true
+
+# --- Routes ---
+# Pattern routes match model names with regex. First match wins.
+
+# [[routes]]
+# pattern = "claude-.*"
+# provider = "anthropic"
+
+# [[routes]]
+# pattern = "gpt-.*"
+# provider = "openai"
+
+# --- Default route ---
+# When no pattern matches and the model isn't loaded locally.
+
+[default]
+provider = "higgs"
+
+# --- Auto router ---
+# Classify requests using a local model to pick the best route.
+
+# [auto_router]
+# enabled = true
+# model = "mlx-community/Arch-Router-1.5B-4bit"
+# timeout_ms = 2000
+
+# --- Retention ---
+# How long to keep metrics in memory for the TUI dashboard.
+
+# [retention]
+# enabled = true
+# minutes = 60
+
+# --- Metrics logging ---
+# Append request metrics to a JSONL file for attach/TUI history.
+
+# [logging.metrics]
+# enabled = true
+# path = "~/.config/higgs/logs/metrics.jsonl"
+# max_size_mb = 50
+# max_files = 5
+"#;
+
+    if let Err(e) = fs::write(&path, default_config) {
+        eprintln!("failed to write {}: {e}", path.display());
+        std::process::exit(1);
+    }
+
+    eprintln!("created {}", path.display());
+}
+
+#[allow(clippy::print_stdout)]
+pub fn cmd_shellenv(config: &HiggsConfig) {
+    let host = match config.server.host.as_str() {
+        "0.0.0.0" => "127.0.0.1",
+        "::" => "::1",
+        other => other,
+    };
+    let addr = format!("{host}:{}", config.server.port);
+
+    if TcpStream::connect(&addr).is_ok() {
+        let base_url = format!("http://{addr}");
+        println!("export ANTHROPIC_BASE_URL={base_url}");
+        println!("export OPENAI_BASE_URL={base_url}");
+    }
+}
+
+#[allow(clippy::print_stderr, unsafe_code)]
+pub fn detach(config_path: &Path, verbose: bool) {
+    if let Some(pid) = read_pid() {
+        if pid_is_alive(pid) {
+            eprintln!("higgs is already running (pid {pid})");
+            std::process::exit(1);
+        }
+        remove_pid_file();
+    }
+
+    let dir = config_dir();
+    if let Err(e) = fs::create_dir_all(&dir) {
+        eprintln!("failed to create {}: {e}", dir.display());
+        std::process::exit(1);
+    }
+
+    let Ok(log) = fs::File::create(log_path()) else {
+        eprintln!("failed to create log file");
+        std::process::exit(1);
+    };
+    let Ok(log_err) = log.try_clone() else {
+        eprintln!("failed to clone log file handle");
+        std::process::exit(1);
+    };
+
+    let Ok(exe) = std::env::current_exe() else {
+        eprintln!("failed to determine executable path");
+        std::process::exit(1);
+    };
+
+    let Ok(devnull) = fs::File::open("/dev/null") else {
+        eprintln!("failed to open /dev/null");
+        std::process::exit(1);
+    };
+
+    let mut cmd = std::process::Command::new(exe);
+    cmd.arg("serve").arg("--config").arg(config_path);
+    if verbose {
+        cmd.arg("--verbose");
+    }
+    cmd.stdin(devnull);
+
+    // Create new session so child survives terminal close
+    // SAFETY: setsid is async-signal-safe per POSIX
+    unsafe {
+        std::os::unix::process::CommandExt::pre_exec(&mut cmd, || {
+            nix::unistd::setsid().map_err(std::io::Error::other)?;
+            Ok(())
+        });
+    }
+
+    let Ok(mut child) = cmd.stdout(log).stderr(log_err).spawn() else {
+        eprintln!("failed to spawn detached process");
+        std::process::exit(1);
+    };
+
+    let child_pid = child.id();
+
+    // Detach: we don't want to wait on the child (it's the daemon).
+    // Reap it so we don't leave a zombie during the brief startup check.
+    std::thread::spawn(move || {
+        let _ = child.wait();
+    });
+
+    if let Err(e) = fs::write(pid_path(), child_pid.to_string()) {
+        eprintln!("failed to write pid file: {e}");
+        std::process::exit(1);
+    }
+
+    let Ok(child_pid_i32) = i32::try_from(child_pid) else {
+        eprintln!("child pid {child_pid} exceeds i32 range");
+        std::process::exit(1);
+    };
+
+    // Probe the server address from config to check readiness
+    let Ok(probe_config) = crate::config::load_config_file(config_path, None) else {
+        eprintln!(
+            "higgs started (pid {child_pid}), log: {}",
+            log_path().display()
+        );
+        return;
+    };
+    let probe_host = match probe_config.server.host.as_str() {
+        "0.0.0.0" => "127.0.0.1",
+        "::" => "::1",
+        other => other,
+    };
+    let probe_addr = format!("{probe_host}:{}", probe_config.server.port);
+
+    // Poll until the daemon is accepting connections or the process dies
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if !pid_is_alive(child_pid_i32) {
+            remove_pid_file();
+            eprintln!("higgs failed to start, check {}", log_path().display());
+            std::process::exit(1);
+        }
+        if TcpStream::connect(&probe_addr).is_ok() {
+            eprintln!(
+                "higgs started (pid {child_pid}), log: {}",
+                log_path().display()
+            );
+            return;
+        }
+        if std::time::Instant::now() >= deadline {
+            eprintln!(
+                "higgs started (pid {child_pid}) but not yet accepting connections, log: {}",
+                log_path().display()
+            );
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+#[allow(clippy::print_stderr)]
+pub fn run_attached(config: &HiggsConfig) {
+    if !config.logging.metrics.enabled {
+        eprintln!("cannot attach: [logging.metrics] enabled = true required in config");
+        std::process::exit(1);
+    }
+
+    let retention = retention_duration(config);
+    let metrics = Arc::new(MetricsStore::new(retention));
+
+    attach::load_history(&config.logging.metrics, &metrics);
+
+    let log_path_buf = PathBuf::from(&config.logging.metrics.path);
+    let stop = Arc::new(AtomicBool::new(false));
+
+    let tail_store = Arc::clone(&metrics);
+    let tail_stop = Arc::clone(&stop);
+    let _tail_handle = std::thread::spawn(move || {
+        attach::tail_log(&log_path_buf, &tail_store, &tail_stop);
+    });
+
+    let evict_metrics = Arc::clone(&metrics);
+    let evict_stop = Arc::clone(&stop);
+    let _evict_handle = std::thread::spawn(move || {
+        while !evict_stop.load(Ordering::Relaxed) {
+            std::thread::sleep(Duration::from_secs(60));
+            evict_metrics.evict_expired();
+        }
+    });
+
+    match crate::tui::run(Arc::clone(&metrics), true) {
+        Ok(_) => {}
+        Err(e) => {
+            eprintln!("TUI error: {e}");
+        }
+    }
+
+    stop.store(true, Ordering::Relaxed);
+}
+
+pub const fn retention_duration(config: &HiggsConfig) -> Duration {
+    if config.retention.enabled {
+        Duration::from_secs(config.retention.minutes.saturating_mul(60))
+    } else {
+        Duration::from_secs(365 * 24 * 60 * 60)
+    }
+}
+
+pub fn create_metrics(config: &HiggsConfig) -> Arc<MetricsStore> {
+    let retention = retention_duration(config);
+    Arc::new(if config.logging.metrics.enabled {
+        match MetricsLogger::new(&config.logging.metrics) {
+            Ok(logger) => {
+                tracing::info!(path = %config.logging.metrics.path, "metrics logging enabled");
+                MetricsStore::with_logger(retention, logger)
+            }
+            Err(e) => {
+                tracing::warn!("failed to initialize metrics logger: {e}");
+                MetricsStore::new(retention)
+            }
+        }
+    } else {
+        MetricsStore::new(retention)
+    })
+}
+
+pub fn spawn_eviction_task(metrics: &Arc<MetricsStore>) {
+    let evict_metrics = Arc::clone(metrics);
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(60));
+        loop {
+            interval.tick().await;
+            evict_metrics.evict_expired();
+        }
+    });
+}
+
+pub async fn await_shutdown_signal() {
+    // Use explicit unix signals because crossterm's signal-hook
+    // handler can interfere with tokio::signal::ctrl_c().
+    let mut sigint = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt()).ok();
+    let mut sigterm =
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()).ok();
+
+    tokio::select! {
+        _ = async { if let Some(ref mut s) = sigint { s.recv().await } else { std::future::pending().await } } => {}
+        _ = async { if let Some(ref mut s) = sigterm { s.recv().await } else { std::future::pending().await } } => {}
+    }
+}

--- a/crates/higgs/src/daemon.rs
+++ b/crates/higgs/src/daemon.rs
@@ -9,24 +9,16 @@ use nix::sys::signal::{Signal, kill};
 use nix::unistd::Pid;
 
 use crate::attach;
-use crate::config::HiggsConfig;
+use crate::config::{self, HiggsConfig};
 use crate::metrics::MetricsStore;
 use crate::metrics_log::MetricsLogger;
 
-pub fn config_dir() -> PathBuf {
-    if let Ok(dir) = std::env::var("HIGGS_CONFIG_DIR") {
-        return PathBuf::from(dir);
-    }
-    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_owned());
-    PathBuf::from(home).join(".config/higgs")
+fn pid_path() -> std::path::PathBuf {
+    config::pid_path()
 }
 
-pub fn pid_path() -> PathBuf {
-    config_dir().join("higgs.pid")
-}
-
-pub fn log_path() -> PathBuf {
-    config_dir().join("higgs.log")
+fn log_path() -> std::path::PathBuf {
+    config::log_path()
 }
 
 pub fn read_pid() -> Option<i32> {
@@ -83,7 +75,7 @@ pub fn cmd_stop() {
 
 #[allow(clippy::print_stderr)]
 pub fn cmd_init() {
-    let dir = config_dir();
+    let dir = config::config_dir();
     let path = dir.join("config.toml");
 
     if path.exists() {
@@ -205,7 +197,7 @@ pub fn detach(config_path: &Path, verbose: bool) {
         remove_pid_file();
     }
 
-    let dir = config_dir();
+    let dir = config::config_dir();
     if let Err(e) = fs::create_dir_all(&dir) {
         eprintln!("failed to create {}: {e}", dir.display());
         std::process::exit(1);
@@ -422,7 +414,7 @@ mod tests {
         unsafe {
             std::env::set_var("HIGGS_CONFIG_DIR", dir.path());
         }
-        assert_eq!(config_dir(), dir.path());
+        assert_eq!(config::config_dir(), dir.path());
         unsafe {
             std::env::remove_var("HIGGS_CONFIG_DIR");
         }
@@ -433,7 +425,7 @@ mod tests {
         unsafe {
             std::env::remove_var("HIGGS_CONFIG_DIR");
         }
-        let path = config_dir();
+        let path = config::config_dir();
         assert!(path.to_string_lossy().ends_with(".config/higgs"));
     }
 

--- a/crates/higgs/src/doctor.rs
+++ b/crates/higgs/src/doctor.rs
@@ -206,6 +206,17 @@ fn check_auto_router(config: &HiggsConfig, result: &mut DoctorResult) {
         );
     }
 
+    match model_resolver::resolve(model_name) {
+        Ok(_) => pass(
+            &format!("auto_router model \"{model_name}\" downloaded"),
+            result,
+        ),
+        Err(err) => fail(
+            &format!("auto_router model \"{model_name}\" not downloaded: {err}"),
+            result,
+        ),
+    }
+
     let routes_with_descriptions = config
         .routes
         .iter()
@@ -540,6 +551,7 @@ mod tests {
         let config = HiggsConfig {
             auto_router: AutoRouterConfig {
                 enabled: false,
+                force: false,
                 model: String::new(),
                 timeout_ms: 2000,
             },
@@ -557,6 +569,7 @@ mod tests {
         let config = HiggsConfig {
             auto_router: AutoRouterConfig {
                 enabled: true,
+                force: false,
                 model: String::new(),
                 timeout_ms: 2000,
             },
@@ -572,6 +585,7 @@ mod tests {
         let config = HiggsConfig {
             auto_router: AutoRouterConfig {
                 enabled: true,
+                force: false,
                 model: "nonexistent/model".to_owned(),
                 timeout_ms: 2000,
             },
@@ -583,7 +597,31 @@ mod tests {
         };
         let mut result = empty_result();
         check_auto_router(&config, &mut result);
+        // Fails twice: not in [[models]] and not downloaded
+        assert_eq!(result.failures, 2);
+    }
+
+    #[test]
+    fn test_auto_router_model_not_downloaded_fails() {
+        let config = HiggsConfig {
+            auto_router: AutoRouterConfig {
+                enabled: true,
+                force: false,
+                model: "org/router-model".to_owned(),
+                timeout_ms: 2000,
+            },
+            models: vec![ModelConfig {
+                path: "org/router-model".to_owned(),
+                batch: false,
+            }],
+            ..HiggsConfig::default()
+        };
+        let mut result = empty_result();
+        check_auto_router(&config, &mut result);
+        // Model is in [[models]] (pass), but not downloaded (fail)
+        assert_eq!(result.passes, 1);
         assert_eq!(result.failures, 1);
+        assert_eq!(result.warnings, 0);
     }
 
     #[test]
@@ -591,6 +629,7 @@ mod tests {
         let config = HiggsConfig {
             auto_router: AutoRouterConfig {
                 enabled: true,
+                force: false,
                 model: "org/router-model".to_owned(),
                 timeout_ms: 2000,
             },

--- a/crates/higgs/src/doctor.rs
+++ b/crates/higgs/src/doctor.rs
@@ -1,0 +1,641 @@
+use std::collections::HashSet;
+use std::time::Instant;
+
+use crate::config::HiggsConfig;
+use crate::model_resolver;
+
+pub struct DoctorResult {
+    pub passes: u32,
+    pub warnings: u32,
+    pub failures: u32,
+}
+
+#[allow(clippy::print_stderr)]
+fn pass(msg: &str, result: &mut DoctorResult) {
+    eprintln!("\x1b[32m[PASS]\x1b[0m {msg}");
+    result.passes += 1;
+}
+
+#[allow(clippy::print_stderr)]
+fn warn(msg: &str, result: &mut DoctorResult) {
+    eprintln!("\x1b[33m[WARN]\x1b[0m {msg}");
+    result.warnings += 1;
+}
+
+#[allow(clippy::print_stderr)]
+fn fail(msg: &str, result: &mut DoctorResult) {
+    eprintln!("\x1b[31m[FAIL]\x1b[0m {msg}");
+    result.failures += 1;
+}
+
+#[allow(clippy::print_stderr)]
+pub async fn run_doctor(config: &HiggsConfig) -> DoctorResult {
+    let mut result = DoctorResult {
+        passes: 0,
+        warnings: 0,
+        failures: 0,
+    };
+
+    eprintln!("\x1b[1mhiggs doctor\x1b[0m\n");
+
+    check_config_valid(&mut result);
+    check_models(config, &mut result);
+    check_duplicate_models(config, &mut result);
+    check_providers(config, &mut result).await;
+    check_route_consistency(config, &mut result);
+    check_default_provider(config, &mut result);
+    check_auto_router(config, &mut result);
+    check_port_availability(config, &mut result);
+    check_orphaned_providers(config, &mut result);
+
+    eprintln!(
+        "\n{} passed, {} warnings, {} failures",
+        result.passes, result.warnings, result.failures
+    );
+
+    result
+}
+
+fn check_config_valid(result: &mut DoctorResult) {
+    // If we got this far, the config parsed and validated successfully.
+    pass("config file is valid", result);
+}
+
+fn check_models(config: &HiggsConfig, result: &mut DoctorResult) {
+    for model in &config.models {
+        match model_resolver::resolve(&model.path) {
+            Ok(_) => pass(&format!("model {} resolvable", model.path), result),
+            Err(err) => fail(&format!("model {} not found: {err}", model.path), result),
+        }
+    }
+}
+
+fn check_duplicate_models(config: &HiggsConfig, result: &mut DoctorResult) {
+    let mut seen = HashSet::new();
+    let mut duplicates = Vec::new();
+    for model in &config.models {
+        if !seen.insert(&model.path) {
+            duplicates.push(model.path.clone());
+        }
+    }
+    if duplicates.is_empty() {
+        if config.models.len() > 1 {
+            pass("no duplicate model paths", result);
+        }
+    } else {
+        for dup in &duplicates {
+            warn(&format!("duplicate model path: {dup}"), result);
+        }
+    }
+}
+
+async fn check_providers(config: &HiggsConfig, result: &mut DoctorResult) {
+    let http_client = match reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+    {
+        Ok(c) => c,
+        Err(err) => {
+            warn(&format!("could not create HTTP client: {err}"), result);
+            return;
+        }
+    };
+
+    for (name, provider) in &config.providers {
+        let start = Instant::now();
+        match http_client.head(&provider.url).send().await {
+            Ok(response) => {
+                let elapsed = start.elapsed();
+                pass(
+                    &format!(
+                        "provider {name} reachable ({} {}ms)",
+                        response.status(),
+                        elapsed.as_millis()
+                    ),
+                    result,
+                );
+            }
+            Err(err) => {
+                warn(&format!("provider {name} unreachable: {err}"), result);
+            }
+        }
+    }
+}
+
+fn check_route_consistency(config: &HiggsConfig, result: &mut DoctorResult) {
+    let mut all_valid = true;
+    for route in &config.routes {
+        if route.provider == "higgs" {
+            if config.models.is_empty() {
+                warn(
+                    &format!(
+                        "route {:?} targets \"higgs\" but no models are loaded",
+                        route
+                            .name
+                            .as_deref()
+                            .or(route.pattern.as_deref())
+                            .unwrap_or("(unnamed)")
+                    ),
+                    result,
+                );
+                all_valid = false;
+            }
+        } else if !config.providers.contains_key(&route.provider) {
+            fail(
+                &format!(
+                    "route {:?} references unknown provider \"{}\"",
+                    route
+                        .name
+                        .as_deref()
+                        .or(route.pattern.as_deref())
+                        .unwrap_or("(unnamed)"),
+                    route.provider
+                ),
+                result,
+            );
+            all_valid = false;
+        }
+    }
+    if all_valid && !config.routes.is_empty() {
+        pass("all route providers exist", result);
+    }
+}
+
+fn check_default_provider(config: &HiggsConfig, result: &mut DoctorResult) {
+    let provider = &config.default.provider;
+    if provider == "higgs" {
+        if config.models.is_empty() {
+            warn(
+                "default provider is \"higgs\" but no models are loaded",
+                result,
+            );
+        } else {
+            pass(&format!("default provider \"{provider}\" exists"), result);
+        }
+    } else if config.providers.contains_key(provider) {
+        pass(&format!("default provider \"{provider}\" exists"), result);
+    } else {
+        fail(
+            &format!("default provider \"{provider}\" not found in providers"),
+            result,
+        );
+    }
+}
+
+fn check_auto_router(config: &HiggsConfig, result: &mut DoctorResult) {
+    if !config.auto_router.enabled {
+        return;
+    }
+
+    let model_name = &config.auto_router.model;
+    if model_name.is_empty() {
+        fail("auto_router enabled but no model specified", result);
+        return;
+    }
+
+    let model_known = config.models.iter().any(|m| m.path == *model_name);
+    if model_known {
+        pass(
+            &format!("auto_router model \"{model_name}\" found in models"),
+            result,
+        );
+    } else {
+        fail(
+            &format!("auto_router model \"{model_name}\" not found in models"),
+            result,
+        );
+    }
+
+    let routes_with_descriptions = config
+        .routes
+        .iter()
+        .filter(|r| r.description.is_some())
+        .count();
+    if routes_with_descriptions == 0 && !config.routes.is_empty() {
+        warn(
+            "auto_router enabled but no routes have descriptions",
+            result,
+        );
+    }
+}
+
+fn check_port_availability(config: &HiggsConfig, result: &mut DoctorResult) {
+    let addr = format!("{}:{}", config.server.host, config.server.port);
+    match std::net::TcpListener::bind(&addr) {
+        Ok(_) => pass(&format!("port {} available", config.server.port), result),
+        Err(err) => warn(
+            &format!("port {} unavailable: {err}", config.server.port),
+            result,
+        ),
+    }
+}
+
+fn check_orphaned_providers(config: &HiggsConfig, result: &mut DoctorResult) {
+    let mut referenced: HashSet<&str> = HashSet::new();
+
+    if config.default.provider != "higgs" {
+        referenced.insert(&config.default.provider);
+    }
+
+    for route in &config.routes {
+        if route.provider != "higgs" {
+            referenced.insert(&route.provider);
+        }
+    }
+
+    for name in config.providers.keys() {
+        if !referenced.contains(name.as_str()) {
+            warn(
+                &format!("provider \"{name}\" defined but not used by any route"),
+                result,
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::config::{
+        AutoRouterConfig, DefaultRoute, HiggsConfig, ModelConfig, ProviderConfig, RouteConfig,
+        ServerSection,
+    };
+    use std::collections::HashMap;
+
+    fn empty_result() -> DoctorResult {
+        DoctorResult {
+            passes: 0,
+            warnings: 0,
+            failures: 0,
+        }
+    }
+
+    // -- Helper function counter tests --
+
+    #[test]
+    fn test_pass_increments_counter() {
+        let mut result = empty_result();
+        pass("test", &mut result);
+        assert_eq!(result.passes, 1);
+        assert_eq!(result.warnings, 0);
+        assert_eq!(result.failures, 0);
+    }
+
+    #[test]
+    fn test_warn_increments_counter() {
+        let mut result = empty_result();
+        warn("test", &mut result);
+        assert_eq!(result.passes, 0);
+        assert_eq!(result.warnings, 1);
+        assert_eq!(result.failures, 0);
+    }
+
+    #[test]
+    fn test_fail_increments_counter() {
+        let mut result = empty_result();
+        fail("test", &mut result);
+        assert_eq!(result.passes, 0);
+        assert_eq!(result.warnings, 0);
+        assert_eq!(result.failures, 1);
+    }
+
+    // -- Duplicate model detection --
+
+    #[test]
+    fn test_no_duplicates_passes() {
+        let config = HiggsConfig {
+            models: vec![
+                ModelConfig {
+                    path: "org/model-a".to_owned(),
+                    batch: false,
+                },
+                ModelConfig {
+                    path: "org/model-b".to_owned(),
+                    batch: false,
+                },
+            ],
+            ..HiggsConfig::default()
+        };
+        let mut result = empty_result();
+        check_duplicate_models(&config, &mut result);
+        assert_eq!(result.passes, 1);
+        assert_eq!(result.warnings, 0);
+    }
+
+    #[test]
+    fn test_duplicate_models_warns() {
+        let config = HiggsConfig {
+            models: vec![
+                ModelConfig {
+                    path: "org/model-a".to_owned(),
+                    batch: false,
+                },
+                ModelConfig {
+                    path: "org/model-a".to_owned(),
+                    batch: false,
+                },
+            ],
+            ..HiggsConfig::default()
+        };
+        let mut result = empty_result();
+        check_duplicate_models(&config, &mut result);
+        assert_eq!(result.warnings, 1);
+    }
+
+    // -- Orphaned provider detection --
+
+    #[test]
+    fn test_orphaned_provider_warns() {
+        let mut providers = HashMap::new();
+        providers.insert(
+            "openai".to_owned(),
+            ProviderConfig {
+                url: "https://api.openai.com".to_owned(),
+                format: crate::config::ApiFormat::OpenAi,
+                api_key: None,
+                strip_auth: false,
+                stub_count_tokens: false,
+            },
+        );
+        let config = HiggsConfig {
+            providers,
+            default: DefaultRoute {
+                provider: "higgs".to_owned(),
+            },
+            ..HiggsConfig::default()
+        };
+        let mut result = empty_result();
+        check_orphaned_providers(&config, &mut result);
+        assert_eq!(result.warnings, 1);
+    }
+
+    #[test]
+    fn test_referenced_provider_not_orphaned() {
+        let mut providers = HashMap::new();
+        providers.insert(
+            "anthropic".to_owned(),
+            ProviderConfig {
+                url: "https://api.anthropic.com".to_owned(),
+                format: crate::config::ApiFormat::Anthropic,
+                api_key: None,
+                strip_auth: false,
+                stub_count_tokens: false,
+            },
+        );
+        let config = HiggsConfig {
+            providers,
+            default: DefaultRoute {
+                provider: "anthropic".to_owned(),
+            },
+            ..HiggsConfig::default()
+        };
+        let mut result = empty_result();
+        check_orphaned_providers(&config, &mut result);
+        assert_eq!(result.warnings, 0);
+    }
+
+    // -- Route consistency --
+
+    #[test]
+    fn test_route_unknown_provider_fails() {
+        let config = HiggsConfig {
+            routes: vec![RouteConfig {
+                name: Some("test".to_owned()),
+                description: None,
+                pattern: None,
+                provider: "nonexistent".to_owned(),
+                model: None,
+            }],
+            ..HiggsConfig::default()
+        };
+        let mut result = empty_result();
+        check_route_consistency(&config, &mut result);
+        assert_eq!(result.failures, 1);
+    }
+
+    #[test]
+    fn test_route_higgs_no_models_warns() {
+        let config = HiggsConfig {
+            routes: vec![RouteConfig {
+                name: Some("local".to_owned()),
+                description: None,
+                pattern: None,
+                provider: "higgs".to_owned(),
+                model: None,
+            }],
+            models: vec![],
+            ..HiggsConfig::default()
+        };
+        let mut result = empty_result();
+        check_route_consistency(&config, &mut result);
+        assert_eq!(result.warnings, 1);
+    }
+
+    #[test]
+    fn test_route_valid_provider_passes() {
+        let mut providers = HashMap::new();
+        providers.insert(
+            "anthropic".to_owned(),
+            ProviderConfig {
+                url: "https://api.anthropic.com".to_owned(),
+                format: crate::config::ApiFormat::Anthropic,
+                api_key: None,
+                strip_auth: false,
+                stub_count_tokens: false,
+            },
+        );
+        let config = HiggsConfig {
+            providers,
+            routes: vec![RouteConfig {
+                name: Some("claude".to_owned()),
+                description: None,
+                pattern: Some("claude-.*".to_owned()),
+                provider: "anthropic".to_owned(),
+                model: None,
+            }],
+            ..HiggsConfig::default()
+        };
+        let mut result = empty_result();
+        check_route_consistency(&config, &mut result);
+        assert_eq!(result.passes, 1);
+        assert_eq!(result.failures, 0);
+    }
+
+    // -- Default provider --
+
+    #[test]
+    fn test_default_provider_exists() {
+        let mut providers = HashMap::new();
+        providers.insert(
+            "anthropic".to_owned(),
+            ProviderConfig {
+                url: "https://api.anthropic.com".to_owned(),
+                format: crate::config::ApiFormat::Anthropic,
+                api_key: None,
+                strip_auth: false,
+                stub_count_tokens: false,
+            },
+        );
+        let config = HiggsConfig {
+            providers,
+            default: DefaultRoute {
+                provider: "anthropic".to_owned(),
+            },
+            ..HiggsConfig::default()
+        };
+        let mut result = empty_result();
+        check_default_provider(&config, &mut result);
+        assert_eq!(result.passes, 1);
+    }
+
+    #[test]
+    fn test_default_provider_missing_fails() {
+        let config = HiggsConfig {
+            default: DefaultRoute {
+                provider: "nonexistent".to_owned(),
+            },
+            ..HiggsConfig::default()
+        };
+        let mut result = empty_result();
+        check_default_provider(&config, &mut result);
+        assert_eq!(result.failures, 1);
+    }
+
+    #[test]
+    fn test_default_higgs_no_models_warns() {
+        let config = HiggsConfig {
+            default: DefaultRoute {
+                provider: "higgs".to_owned(),
+            },
+            models: vec![],
+            ..HiggsConfig::default()
+        };
+        let mut result = empty_result();
+        check_default_provider(&config, &mut result);
+        assert_eq!(result.warnings, 1);
+    }
+
+    // -- Port availability --
+
+    #[test]
+    fn test_port_zero_available() {
+        let config = HiggsConfig {
+            server: ServerSection {
+                host: "127.0.0.1".to_owned(),
+                port: 0,
+                ..ServerSection::default()
+            },
+            ..HiggsConfig::default()
+        };
+        let mut result = empty_result();
+        check_port_availability(&config, &mut result);
+        assert_eq!(result.passes, 1);
+    }
+
+    // -- Auto router --
+
+    #[test]
+    fn test_auto_router_disabled_skips() {
+        let config = HiggsConfig {
+            auto_router: AutoRouterConfig {
+                enabled: false,
+                model: String::new(),
+                timeout_ms: 2000,
+            },
+            ..HiggsConfig::default()
+        };
+        let mut result = empty_result();
+        check_auto_router(&config, &mut result);
+        assert_eq!(result.passes, 0);
+        assert_eq!(result.warnings, 0);
+        assert_eq!(result.failures, 0);
+    }
+
+    #[test]
+    fn test_auto_router_empty_model_fails() {
+        let config = HiggsConfig {
+            auto_router: AutoRouterConfig {
+                enabled: true,
+                model: String::new(),
+                timeout_ms: 2000,
+            },
+            ..HiggsConfig::default()
+        };
+        let mut result = empty_result();
+        check_auto_router(&config, &mut result);
+        assert_eq!(result.failures, 1);
+    }
+
+    #[test]
+    fn test_auto_router_unknown_model_fails() {
+        let config = HiggsConfig {
+            auto_router: AutoRouterConfig {
+                enabled: true,
+                model: "nonexistent/model".to_owned(),
+                timeout_ms: 2000,
+            },
+            models: vec![ModelConfig {
+                path: "org/other-model".to_owned(),
+                batch: false,
+            }],
+            ..HiggsConfig::default()
+        };
+        let mut result = empty_result();
+        check_auto_router(&config, &mut result);
+        assert_eq!(result.failures, 1);
+    }
+
+    #[test]
+    fn test_auto_router_no_descriptions_warns() {
+        let config = HiggsConfig {
+            auto_router: AutoRouterConfig {
+                enabled: true,
+                model: "org/router-model".to_owned(),
+                timeout_ms: 2000,
+            },
+            models: vec![ModelConfig {
+                path: "org/router-model".to_owned(),
+                batch: false,
+            }],
+            routes: vec![RouteConfig {
+                name: Some("test".to_owned()),
+                description: None,
+                pattern: None,
+                provider: "higgs".to_owned(),
+                model: None,
+            }],
+            ..HiggsConfig::default()
+        };
+        let mut result = empty_result();
+        check_auto_router(&config, &mut result);
+        // Should pass for model found, but warn for no descriptions
+        assert_eq!(result.passes, 1);
+        assert_eq!(result.warnings, 1);
+    }
+
+    // -- Provider reachability --
+
+    #[tokio::test]
+    async fn test_unreachable_provider_warns() {
+        let mut providers = HashMap::new();
+        providers.insert(
+            "bad".to_owned(),
+            ProviderConfig {
+                url: "http://127.0.0.1:1".to_owned(),
+                format: crate::config::ApiFormat::OpenAi,
+                api_key: None,
+                strip_auth: false,
+                stub_count_tokens: false,
+            },
+        );
+        let config = HiggsConfig {
+            providers,
+            ..HiggsConfig::default()
+        };
+        let mut result = empty_result();
+        check_providers(&config, &mut result).await;
+        assert_eq!(result.warnings, 1);
+        assert_eq!(result.passes, 0);
+    }
+}

--- a/crates/higgs/src/error.rs
+++ b/crates/higgs/src/error.rs
@@ -33,6 +33,9 @@ pub enum ServerError {
 
     #[error("Internal error: {0}")]
     InternalError(String),
+
+    #[error("Proxy error: {0}")]
+    ProxyError(String),
 }
 
 impl IntoResponse for ServerError {
@@ -62,6 +65,14 @@ impl IntoResponse for ServerError {
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "server_error",
                     "Internal server error".to_owned(),
+                )
+            }
+            Self::ProxyError(msg) => {
+                tracing::error!(error = %msg, "Proxy error");
+                (
+                    StatusCode::BAD_GATEWAY,
+                    "proxy_error",
+                    format!("Upstream provider error: {msg}"),
                 )
             }
         };
@@ -204,6 +215,21 @@ mod tests {
         assert!(error_obj.get("message").is_some());
         assert!(error_obj.get("type").is_some());
         assert!(error_obj.get("code").is_some());
+    }
+
+    #[tokio::test]
+    async fn test_proxy_error_returns_502() {
+        let error = ServerError::ProxyError("connection refused".to_owned());
+        let resp = error.into_response();
+        let (status, body) = response_status_and_body(resp).await;
+
+        assert_eq!(status, StatusCode::BAD_GATEWAY);
+        assert_eq!(body["error"]["type"].as_str().unwrap(), "proxy_error");
+        let message = body["error"]["message"].as_str().unwrap();
+        assert!(
+            message.contains("connection refused"),
+            "expected proxy detail in message: {message}"
+        );
     }
 
     #[tokio::test]

--- a/crates/higgs/src/lib.rs
+++ b/crates/higgs/src/lib.rs
@@ -1,10 +1,21 @@
 pub mod anthropic_adapter;
+pub mod attach;
+pub mod auto_router;
+pub mod cli_config;
 pub mod config;
+pub mod daemon;
+pub mod doctor;
 pub mod error;
+pub mod metrics;
+pub mod metrics_log;
 pub mod model_download;
 pub mod model_resolver;
+pub mod proxy;
+pub mod router;
 pub mod routes;
 pub mod state;
+pub mod translate;
+pub mod tui;
 pub mod types;
 
 use std::net::SocketAddr;

--- a/crates/higgs/src/main.rs
+++ b/crates/higgs/src/main.rs
@@ -3,26 +3,179 @@ use std::io::IsTerminal;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+use clap::Parser;
+
 use higgs::{
     build_router,
-    config::ServerConfig,
+    config::{self, Cli, Commands, ConfigAction, HiggsConfig, ServeArgs},
     model_download, model_resolver,
+    router::Router,
     state::{AppState, Engine},
 };
 
 #[tokio::main]
+#[allow(clippy::print_stderr)]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::Serve(ref args) => cmd_serve(&cli, args).await,
+        Commands::Start(ref _args) => {
+            let config_path = resolve_config_path(&cli)?;
+            higgs::daemon::detach(&config_path, cli.verbose);
+            Ok(())
+        }
+        Commands::Stop => {
+            higgs::daemon::cmd_stop();
+            Ok(())
+        }
+        Commands::Attach => {
+            let config = load_config_for_command(&cli)?;
+            higgs::daemon::run_attached(&config);
+            Ok(())
+        }
+        Commands::Init => {
+            higgs::daemon::cmd_init();
+            Ok(())
+        }
+        Commands::Shellenv => {
+            let config = load_config_for_command(&cli).unwrap_or_default();
+            higgs::daemon::cmd_shellenv(&config);
+            Ok(())
+        }
+        Commands::Config { ref action } => {
+            cmd_config(&cli, action);
+            Ok(())
+        }
+        Commands::Doctor(ref args) => {
+            init_tracing(cli.verbose);
+            let config = if let Some(ref path) = cli.config {
+                config::load_config_file(path, Some(args))?
+            } else {
+                let default = config::default_config_path();
+                if default.exists() {
+                    config::load_config_file(&default, Some(args))?
+                } else if !args.models.is_empty() {
+                    config::build_simple_config(args)?
+                } else {
+                    return Err("no config to validate; use --config or 'higgs init'".into());
+                }
+            };
+            let result = higgs::doctor::run_doctor(&config).await;
+            if result.failures > 0 {
+                std::process::exit(1);
+            }
+            Ok(())
+        }
+    }
+}
+
+/// Resolve a config file path from CLI args or the default location.
+#[allow(clippy::print_stderr)]
+fn resolve_config_path(cli: &Cli) -> Result<std::path::PathBuf, Box<dyn std::error::Error>> {
+    if let Some(ref path) = cli.config {
+        return Ok(path.clone());
+    }
+    let default = config::default_config_path();
+    if default.exists() {
+        Ok(default)
+    } else {
+        Err(format!(
+            "no config file specified or found at {}\nhint: use 'higgs init' to create one",
+            default.display()
         )
-        .init();
+        .into())
+    }
+}
 
-    let config = ServerConfig::load()?;
+/// Load config from CLI path or default location.
+fn load_config_for_command(cli: &Cli) -> Result<HiggsConfig, Box<dyn std::error::Error>> {
+    let path = resolve_config_path(cli)?;
+    config::load_config_file(&path, None).map_err(Into::into)
+}
 
+async fn cmd_serve(cli: &Cli, args: &ServeArgs) -> Result<(), Box<dyn std::error::Error>> {
+    init_tracing(cli.verbose);
+
+    let simple_mode = config::is_simple_mode(cli, args);
+
+    // Load config: simple mode (--model) or config file mode (--config)
+    let higgs_config = if simple_mode {
+        config::build_simple_config(args)?
+    } else if let Some(ref path) = cli.config {
+        config::load_config_file(path, Some(args))?
+    } else if args.models.is_empty() {
+        let default_path = config::default_config_path();
+        if default_path.exists() {
+            tracing::info!(path = %default_path.display(), "Auto-discovered config file");
+            config::load_config_file(&default_path, Some(args))?
+        } else {
+            return Err("no --model or --config provided, and no config file found at ~/.config/higgs/config.toml\n\
+                hint: use 'higgs serve --model <model>' or 'higgs init' to create a config".into());
+        }
+    } else {
+        config::build_simple_config(args)?
+    };
+
+    // Load all local models and build router
+    let engines = load_engines(&higgs_config)?;
+    let router = Router::from_config(&higgs_config, engines)?;
+
+    // Validate timeout
+    let timeout_secs = higgs_config.server.timeout;
+    if !timeout_secs.is_finite() || timeout_secs <= 0.0 {
+        return Err("timeout must be a positive, finite number".into());
+    }
+
+    let api_key = higgs_config.server.api_key.clone();
+    let rate_limit = higgs_config.server.rate_limit;
+    let bind_addr = format!("{}:{}", higgs_config.server.host, higgs_config.server.port);
+
+    // Create metrics (config mode only)
+    let metrics = if simple_mode {
+        None
+    } else {
+        let m = higgs::daemon::create_metrics(&higgs_config);
+        higgs::daemon::spawn_eviction_task(&m);
+        Some(m)
+    };
+
+    // Create shared state
+    let http_client = reqwest::Client::new();
+    let shared_state = Arc::new(AppState {
+        router,
+        config: higgs_config,
+        http_client,
+        metrics,
+    });
+
+    // Build router with middleware
+    let app = build_router(shared_state, timeout_secs, api_key, rate_limit);
+
+    // Write PID file for daemon management
+    higgs::daemon::write_pid_file();
+
+    // Start server
+    tracing::info!(addr = %bind_addr, "Starting server");
+    let listener = tokio::net::TcpListener::bind(&bind_addr).await?;
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .with_graceful_shutdown(higgs::daemon::await_shutdown_signal())
+    .await?;
+
+    higgs::daemon::remove_pid_file();
+    Ok(())
+}
+
+fn load_engines(
+    config: &HiggsConfig,
+) -> Result<HashMap<String, Arc<Engine>>, Box<dyn std::error::Error>> {
     let mut engines = HashMap::new();
-    for model_path in &config.models {
+
+    for model_cfg in &config.models {
+        let model_path = &model_cfg.path;
         tracing::info!(model = %model_path, "Resolving model path");
         let resolved = match model_resolver::resolve(model_path) {
             Ok(path) => path,
@@ -38,7 +191,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         let status = std::process::Command::new("huggingface-cli")
                             .args(["download", model_path])
                             .status()
-                            .map_err(|e| format!("failed to run huggingface-cli: {e}\nInstall with: brew install huggingface-cli"))?;
+                            .map_err(|e| {
+                                format!(
+                                    "failed to run huggingface-cli: {e}\nInstall with: brew install huggingface-cli"
+                                )
+                            })?;
                         if status.success() {
                             Ok(())
                         } else {
@@ -52,14 +209,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
             Err(err) => return Err(err.into()),
         };
+
         tracing::info!(model = %model_path, resolved = %resolved.display(), "Loading model");
-        let engine = if config.batch {
+        let engine = if model_cfg.batch {
             Engine::load_batch(&resolved)?
         } else {
             Engine::load_simple(&resolved)?
         };
         let name = engine.model_name().to_owned();
         tracing::info!(model_name = %name, "Model loaded");
+
         if engines.insert(name.clone(), Arc::new(engine)).is_some() {
             return Err(format!(
                 "model name collision: two model paths resolve to the same name '{name}'"
@@ -68,31 +227,36 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    let timeout_secs = config.timeout;
-    if !timeout_secs.is_finite() || timeout_secs <= 0.0 {
-        return Err("timeout must be a positive, finite number".into());
-    }
-    let api_key = config.api_key.clone();
-    let rate_limit = config.rate_limit;
-    let bind_addr = format!("{}:{}", config.host, config.port);
-
-    let shared_state = Arc::new(AppState { engines, config });
-
-    let app = build_router(shared_state, timeout_secs, api_key, rate_limit);
-
-    tracing::info!(addr = %bind_addr, "Starting server");
-    let listener = tokio::net::TcpListener::bind(&bind_addr).await?;
-    axum::serve(
-        listener,
-        app.into_make_service_with_connect_info::<SocketAddr>(),
-    )
-    .with_graceful_shutdown(shutdown_signal())
-    .await?;
-
-    Ok(())
+    Ok(engines)
 }
 
-async fn shutdown_signal() {
-    let _ = tokio::signal::ctrl_c().await;
-    tracing::info!("Shutdown signal received, draining connections");
+fn cmd_config(_cli: &Cli, action: &ConfigAction) {
+    let config_path = config::default_config_path();
+    match action {
+        ConfigAction::Get { key } => {
+            higgs::cli_config::config_get(&config_path, key);
+        }
+        ConfigAction::Set { key, value } => {
+            higgs::cli_config::config_set(&config_path, key, value);
+        }
+        ConfigAction::Path => {
+            #[allow(clippy::print_stdout)]
+            {
+                println!("{}", config_path.display());
+            }
+        }
+    }
+}
+
+fn init_tracing(verbose: bool) {
+    let default_filter = if verbose { "higgs=debug" } else { "info" };
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                default_filter
+                    .parse()
+                    .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"))
+            }),
+        )
+        .init();
 }

--- a/crates/higgs/src/main.rs
+++ b/crates/higgs/src/main.rs
@@ -152,12 +152,13 @@ async fn cmd_serve(cli: &Cli, args: &ServeArgs) -> Result<(), Box<dyn std::error
     // Build router with middleware
     let app = build_router(shared_state, timeout_secs, api_key, rate_limit);
 
-    // Write PID file for daemon management
-    higgs::daemon::write_pid_file();
-
     // Start server
     tracing::info!(addr = %bind_addr, "Starting server");
     let listener = tokio::net::TcpListener::bind(&bind_addr).await?;
+
+    // Write PID file after bind succeeds so it's never stale on bind errors
+    higgs::daemon::write_pid_file();
+
     axum::serve(
         listener,
         app.into_make_service_with_connect_info::<SocketAddr>(),
@@ -230,8 +231,11 @@ fn load_engines(
     Ok(engines)
 }
 
-fn cmd_config(_cli: &Cli, action: &ConfigAction) {
-    let config_path = config::default_config_path();
+fn cmd_config(cli: &Cli, action: &ConfigAction) {
+    let config_path = cli
+        .config
+        .clone()
+        .unwrap_or_else(config::default_config_path);
     match action {
         ConfigAction::Get { key } => {
             higgs::cli_config::config_get(&config_path, key);

--- a/crates/higgs/src/metrics.rs
+++ b/crates/higgs/src/metrics.rs
@@ -184,11 +184,12 @@ impl MetricsStore {
             "output_tokens": record.output_tokens,
             "error": &record.error_body,
         });
-        if let Ok(line) = serde_json::to_string(&entry)
-            && let Ok(mut l) = logger.lock()
-            && let Err(e) = l.write_line(&line)
-        {
-            tracing::warn!("failed to write metrics log: {e}");
+        if let Ok(line) = serde_json::to_string(&entry) {
+            if let Ok(mut l) = logger.lock() {
+                if let Err(e) = l.write_line(&line) {
+                    tracing::warn!("failed to write metrics log: {e}");
+                }
+            }
         }
     }
 

--- a/crates/higgs/src/metrics.rs
+++ b/crates/higgs/src/metrics.rs
@@ -88,7 +88,6 @@ impl MetricsStore {
         let idx = records.len();
         let id = record.id;
         records.push(record);
-        drop(records);
         self.id_index
             .write()
             .unwrap_or_else(PoisonError::into_inner)
@@ -102,7 +101,6 @@ impl MetricsStore {
         let mut records = self.records.write().unwrap_or_else(PoisonError::into_inner);
         let idx = records.len();
         records.push(record);
-        drop(records);
         self.id_index
             .write()
             .unwrap_or_else(PoisonError::into_inner)
@@ -266,6 +264,7 @@ impl MetricsStore {
 #[allow(clippy::panic, clippy::unwrap_used, clippy::indexing_slicing)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
 
     fn sample_record() -> RequestRecord {
         RequestRecord {
@@ -542,5 +541,41 @@ mod tests {
         store.record(rec);
         let snap = store.snapshot();
         assert_eq!(snap[0].routing_method, RoutingMethod::Higgs);
+    }
+
+    #[test]
+    fn concurrent_pending_finalize_and_eviction() {
+        let store = Arc::new(MetricsStore::new(Duration::from_secs(60)));
+        let iterations: u64 = 200;
+
+        let writer_store = Arc::clone(&store);
+        let writer = std::thread::spawn(move || {
+            for i in 0..iterations {
+                let mut rec = sample_record();
+                rec.output_tokens = 0;
+                let id = writer_store.record_pending(rec);
+                writer_store.finalize_stream(id, i + 1, Duration::from_millis(i + 1));
+            }
+        });
+
+        let evictor_store = Arc::clone(&store);
+        let evictor = std::thread::spawn(move || {
+            for _ in 0..iterations {
+                evictor_store.evict_expired();
+            }
+        });
+
+        writer.join().unwrap();
+        evictor.join().unwrap();
+
+        let snap = store.snapshot();
+        assert_eq!(snap.len(), usize::try_from(iterations).unwrap());
+        for record in &snap {
+            assert!(
+                record.output_tokens > 0,
+                "record {} was never finalized",
+                record.id
+            );
+        }
     }
 }

--- a/crates/higgs/src/metrics.rs
+++ b/crates/higgs/src/metrics.rs
@@ -81,6 +81,7 @@ impl MetricsStore {
         }
     }
 
+    #[allow(clippy::significant_drop_tightening)]
     pub fn record(&self, mut record: RequestRecord) {
         record.id = self.next_id.fetch_add(1, Ordering::Relaxed);
         self.log_record(&record);
@@ -95,6 +96,7 @@ impl MetricsStore {
     }
 
     /// Record a pending entry and return its stable ID for later finalization.
+    #[allow(clippy::significant_drop_tightening)]
     pub fn record_pending(&self, mut record: RequestRecord) -> u64 {
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
         record.id = id;
@@ -261,7 +263,13 @@ impl MetricsStore {
 }
 
 #[cfg(test)]
-#[allow(clippy::panic, clippy::unwrap_used, clippy::indexing_slicing)]
+#[allow(
+    clippy::panic,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    clippy::expect_used,
+    clippy::unchecked_time_subtraction
+)]
 mod tests {
     use super::*;
     use std::sync::Arc;
@@ -481,8 +489,8 @@ mod tests {
 
         store.finalize_stream(id, 500, Duration::from_secs(3));
 
-        let content = std::fs::read_to_string(dir.path().join("metrics.jsonl")).unwrap();
-        let entry: serde_json::Value = serde_json::from_str(content.trim()).unwrap();
+        let log_content = std::fs::read_to_string(dir.path().join("metrics.jsonl")).unwrap();
+        let entry: serde_json::Value = serde_json::from_str(log_content.trim()).unwrap();
         assert_eq!(entry["output_tokens"], 500);
         assert_eq!(entry["duration_ms"], 3000);
     }

--- a/crates/higgs/src/metrics.rs
+++ b/crates/higgs/src/metrics.rs
@@ -85,6 +85,18 @@ impl MetricsStore {
     pub fn record(&self, mut record: RequestRecord) {
         record.id = self.next_id.fetch_add(1, Ordering::Relaxed);
         self.log_record(&record);
+        self.insert_record(record);
+    }
+
+    /// Store a record without writing it to the JSONL log. Used when ingesting
+    /// entries that already exist in the log (history replay / tail).
+    pub fn record_silent(&self, mut record: RequestRecord) {
+        record.id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        self.insert_record(record);
+    }
+
+    #[allow(clippy::significant_drop_tightening)]
+    fn insert_record(&self, record: RequestRecord) {
         let mut records = self.records.write().unwrap_or_else(PoisonError::into_inner);
         let idx = records.len();
         let id = record.id;

--- a/crates/higgs/src/metrics.rs
+++ b/crates/higgs/src/metrics.rs
@@ -1,0 +1,546 @@
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, PoisonError, RwLock};
+use std::time::{Duration, Instant};
+
+use chrono::{DateTime, Utc};
+
+use crate::metrics_log::MetricsLogger;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RoutingMethod {
+    Pattern,
+    Auto,
+    Default,
+    Higgs,
+}
+
+impl From<crate::router::RoutingMethod> for RoutingMethod {
+    fn from(m: crate::router::RoutingMethod) -> Self {
+        match m {
+            crate::router::RoutingMethod::Direct => Self::Higgs,
+            crate::router::RoutingMethod::Pattern => Self::Pattern,
+            crate::router::RoutingMethod::Auto => Self::Auto,
+            crate::router::RoutingMethod::Default => Self::Default,
+        }
+    }
+}
+
+impl std::fmt::Display for RoutingMethod {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Pattern => write!(f, "pattern"),
+            Self::Auto => write!(f, "auto"),
+            Self::Default => write!(f, "default"),
+            Self::Higgs => write!(f, "higgs"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RequestRecord {
+    pub id: u64,
+    pub timestamp: Instant,
+    pub wallclock: DateTime<Utc>,
+    pub model: String,
+    pub provider: String,
+    pub routing_method: RoutingMethod,
+    pub status: u16,
+    pub duration: Duration,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub error_body: Option<String>,
+}
+
+pub struct MetricsStore {
+    records: RwLock<Vec<RequestRecord>>,
+    id_index: RwLock<HashMap<u64, usize>>,
+    window: Duration,
+    logger: Option<Mutex<MetricsLogger>>,
+    next_id: AtomicU64,
+}
+
+impl MetricsStore {
+    pub fn new(window: Duration) -> Self {
+        Self {
+            records: RwLock::new(Vec::new()),
+            id_index: RwLock::new(HashMap::new()),
+            window,
+            logger: None,
+            next_id: AtomicU64::new(1),
+        }
+    }
+
+    pub fn with_logger(window: Duration, logger: MetricsLogger) -> Self {
+        Self {
+            records: RwLock::new(Vec::new()),
+            id_index: RwLock::new(HashMap::new()),
+            window,
+            logger: Some(Mutex::new(logger)),
+            next_id: AtomicU64::new(1),
+        }
+    }
+
+    pub fn record(&self, mut record: RequestRecord) {
+        record.id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        self.log_record(&record);
+        let mut records = self.records.write().unwrap_or_else(PoisonError::into_inner);
+        let idx = records.len();
+        let id = record.id;
+        records.push(record);
+        drop(records);
+        self.id_index
+            .write()
+            .unwrap_or_else(PoisonError::into_inner)
+            .insert(id, idx);
+    }
+
+    /// Record a pending entry and return its stable ID for later finalization.
+    pub fn record_pending(&self, mut record: RequestRecord) -> u64 {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        record.id = id;
+        let mut records = self.records.write().unwrap_or_else(PoisonError::into_inner);
+        let idx = records.len();
+        records.push(record);
+        drop(records);
+        self.id_index
+            .write()
+            .unwrap_or_else(PoisonError::into_inner)
+            .insert(id, idx);
+        id
+    }
+
+    /// Update `output_tokens` and duration for a previously recorded entry by ID.
+    pub fn finalize_stream(&self, id: u64, output_tokens: u64, duration: Duration) {
+        let completed = {
+            let mut records = self.records.write().unwrap_or_else(PoisonError::into_inner);
+            let index = self.id_index.read().unwrap_or_else(PoisonError::into_inner);
+            if let Some(&idx) = index.get(&id) {
+                if let Some(record) = records.get_mut(idx) {
+                    record.output_tokens = output_tokens;
+                    record.duration = duration;
+                    Some(record.clone())
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        };
+        if let Some(record) = completed {
+            self.log_record(&record);
+        }
+    }
+
+    pub fn snapshot(&self) -> Vec<RequestRecord> {
+        #[allow(clippy::unchecked_time_subtraction)]
+        let cutoff = Instant::now() - self.window;
+        self.records
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .iter()
+            .filter(|r| r.timestamp >= cutoff)
+            .cloned()
+            .collect()
+    }
+
+    pub const fn window(&self) -> Duration {
+        self.window
+    }
+
+    pub const fn window_minutes(&self) -> u64 {
+        self.window.as_secs() / 60
+    }
+
+    pub fn evict_expired(&self) {
+        #[allow(clippy::unchecked_time_subtraction)]
+        let cutoff = Instant::now() - self.window;
+        let mut records = self.records.write().unwrap_or_else(PoisonError::into_inner);
+        records.retain(|r| r.timestamp >= cutoff);
+
+        let mut index = self
+            .id_index
+            .write()
+            .unwrap_or_else(PoisonError::into_inner);
+        index.clear();
+        for (i, record) in records.iter().enumerate() {
+            index.insert(record.id, i);
+        }
+    }
+
+    fn log_record(&self, record: &RequestRecord) {
+        let Some(ref logger) = self.logger else {
+            return;
+        };
+        let duration_ms = u64::try_from(record.duration.as_millis()).unwrap_or(u64::MAX);
+        let entry = serde_json::json!({
+            "timestamp": record.wallclock.to_rfc3339(),
+            "model": &record.model,
+            "provider": &record.provider,
+            "routing_method": record.routing_method.to_string(),
+            "status": record.status,
+            "duration_ms": duration_ms,
+            "input_tokens": record.input_tokens,
+            "output_tokens": record.output_tokens,
+            "error": &record.error_body,
+        });
+        if let Ok(line) = serde_json::to_string(&entry)
+            && let Ok(mut l) = logger.lock()
+            && let Err(e) = l.write_line(&line)
+        {
+            tracing::warn!("failed to write metrics log: {e}");
+        }
+    }
+
+    pub fn group_by<F, K>(records: &[RequestRecord], key_fn: F) -> HashMap<K, Vec<&RequestRecord>>
+    where
+        F: Fn(&RequestRecord) -> K,
+        K: Eq + std::hash::Hash,
+    {
+        let mut groups: HashMap<K, Vec<&RequestRecord>> = HashMap::new();
+        for record in records {
+            groups.entry(key_fn(record)).or_default().push(record);
+        }
+        groups
+    }
+
+    pub fn duration_percentile(durations: &[Duration], p: u8) -> Duration {
+        if durations.is_empty() {
+            return Duration::ZERO;
+        }
+        let mut sorted = durations.to_vec();
+        sorted.sort();
+        let len_minus_one = sorted.len().saturating_sub(1);
+        // p is u8 (0..=255), len_minus_one fits in u64 for any realistic Vec.
+        // Multiply in u64 to avoid overflow, then integer-round the division by 100.
+        let numerator = u64::from(p) * u64::try_from(len_minus_one).unwrap_or(u64::MAX);
+        // Round half-up: (numerator * 2 + 100) / 200 == round(numerator / 100)
+        let index_u64 = numerator.saturating_mul(2).saturating_add(100) / 200;
+        let index = usize::try_from(index_u64)
+            .unwrap_or(len_minus_one)
+            .min(len_minus_one);
+        sorted.get(index).copied().unwrap_or(Duration::ZERO)
+    }
+
+    pub fn status_counts(records: &[RequestRecord]) -> HashMap<u16, u64> {
+        let mut counts: HashMap<u16, u64> = HashMap::new();
+        for record in records {
+            *counts.entry(record.status).or_default() += 1;
+        }
+        counts
+    }
+
+    fn per_minute_buckets(
+        records: &[RequestRecord],
+        num_buckets: usize,
+        value_fn: impl Fn(&RequestRecord) -> u64,
+    ) -> Vec<u64> {
+        let now = Instant::now();
+        let mut buckets = vec![0u64; num_buckets];
+        for record in records {
+            if let Some(elapsed) = now.checked_duration_since(record.timestamp) {
+                let bucket_secs = elapsed.as_secs() / 60;
+                if let Ok(bucket_index) = usize::try_from(bucket_secs) {
+                    if bucket_index < num_buckets {
+                        let target = num_buckets.saturating_sub(1).saturating_sub(bucket_index);
+                        if let Some(slot) = buckets.get_mut(target) {
+                            *slot += value_fn(record);
+                        }
+                    }
+                }
+            }
+        }
+        buckets
+    }
+
+    pub fn tokens_per_minute(records: &[RequestRecord], num_buckets: usize) -> Vec<u64> {
+        Self::per_minute_buckets(records, num_buckets, |r| r.input_tokens + r.output_tokens)
+    }
+
+    pub fn requests_per_minute(records: &[RequestRecord], num_buckets: usize) -> Vec<u64> {
+        Self::per_minute_buckets(records, num_buckets, |_| 1)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used, clippy::indexing_slicing)]
+mod tests {
+    use super::*;
+
+    fn sample_record() -> RequestRecord {
+        RequestRecord {
+            id: 0,
+            timestamp: Instant::now(),
+            wallclock: Utc::now(),
+            model: "claude-opus-4-6".to_owned(),
+            provider: "anthropic".to_owned(),
+            routing_method: RoutingMethod::Default,
+            status: 200,
+            duration: Duration::from_millis(500),
+            input_tokens: 100,
+            output_tokens: 200,
+            error_body: None,
+        }
+    }
+
+    #[test]
+    fn window_returns_configured_duration() {
+        let store = MetricsStore::new(Duration::from_secs(3600));
+        assert_eq!(store.window(), Duration::from_secs(3600));
+    }
+
+    #[test]
+    fn records_and_retrieves() {
+        let store = MetricsStore::new(Duration::from_secs(60));
+        store.record(sample_record());
+        let snap = store.snapshot();
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].model, "claude-opus-4-6");
+    }
+
+    #[test]
+    fn snapshot_excludes_expired() {
+        let store = MetricsStore::new(Duration::from_millis(50));
+        let mut old = sample_record();
+        old.timestamp = Instant::now() - Duration::from_millis(100);
+        store.record(old);
+        store.record(sample_record());
+        let snap = store.snapshot();
+        assert_eq!(snap.len(), 1);
+    }
+
+    #[test]
+    fn evict_removes_old_records() {
+        let store = MetricsStore::new(Duration::from_millis(50));
+        let mut old = sample_record();
+        old.timestamp = Instant::now() - Duration::from_millis(100);
+        store.record(old);
+        store.record(sample_record());
+        store.evict_expired();
+        assert_eq!(store.records.read().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn snapshot_returns_owned_data() {
+        let store = MetricsStore::new(Duration::from_secs(60));
+        store.record(sample_record());
+        let snap = store.snapshot();
+        drop(snap);
+        assert_eq!(store.snapshot().len(), 1);
+    }
+
+    #[test]
+    fn group_by_model() {
+        let store = MetricsStore::new(Duration::from_secs(60));
+        for _ in 0..3 {
+            store.record(sample_record());
+        }
+        let mut sonnet = sample_record();
+        sonnet.model = "claude-sonnet-4-5-20250929".to_owned();
+        store.record(sonnet);
+
+        let snap = store.snapshot();
+        let groups = MetricsStore::group_by(&snap, |r| r.model.clone());
+        assert_eq!(groups.len(), 2);
+        assert_eq!(groups["claude-opus-4-6"].len(), 3);
+        assert_eq!(groups["claude-sonnet-4-5-20250929"].len(), 1);
+    }
+
+    #[test]
+    fn status_counts_all_codes() {
+        let store = MetricsStore::new(Duration::from_secs(60));
+        for status in [200, 200, 429, 429, 429, 500] {
+            let mut r = sample_record();
+            r.status = status;
+            store.record(r);
+        }
+        let snap = store.snapshot();
+        let counts = MetricsStore::status_counts(&snap);
+        assert_eq!(counts.len(), 3);
+        assert_eq!(counts[&200], 2);
+        assert_eq!(counts[&429], 3);
+        assert_eq!(counts[&500], 1);
+    }
+
+    #[test]
+    fn tokens_per_minute_buckets() {
+        let store = MetricsStore::new(Duration::from_secs(300));
+        for _ in 0..3 {
+            let mut r = sample_record();
+            r.input_tokens = 100;
+            r.output_tokens = 50;
+            store.record(r);
+        }
+        let snap = store.snapshot();
+        let buckets = MetricsStore::tokens_per_minute(&snap, 5);
+        assert_eq!(buckets.len(), 5);
+        assert_eq!(*buckets.last().unwrap(), 450);
+    }
+
+    #[test]
+    fn requests_per_minute_buckets() {
+        let store = MetricsStore::new(Duration::from_secs(300));
+        for _ in 0..5 {
+            store.record(sample_record());
+        }
+        let snap = store.snapshot();
+        let buckets = MetricsStore::requests_per_minute(&snap, 5);
+        assert_eq!(buckets.len(), 5);
+        assert_eq!(*buckets.last().unwrap(), 5);
+    }
+
+    #[test]
+    fn record_pending_returns_unique_ids() {
+        let store = MetricsStore::new(Duration::from_secs(60));
+        let id0 = store.record_pending(sample_record());
+        let id1 = store.record_pending(sample_record());
+        assert_ne!(id0, id1);
+        assert!(id0 > 0);
+        assert!(id1 > 0);
+    }
+
+    #[test]
+    fn finalize_stream_updates_record_by_id() {
+        let store = MetricsStore::new(Duration::from_secs(60));
+        let mut rec = sample_record();
+        rec.output_tokens = 0;
+        rec.duration = Duration::ZERO;
+        let id = store.record_pending(rec);
+
+        store.finalize_stream(id, 500, Duration::from_secs(3));
+
+        let snap = store.snapshot();
+        let record = snap.iter().find(|r| r.id == id).expect("record not found");
+        assert_eq!(record.output_tokens, 500);
+        assert_eq!(record.duration, Duration::from_secs(3));
+    }
+
+    #[test]
+    fn finalize_stream_ignores_unknown_id() {
+        let store = MetricsStore::new(Duration::from_secs(60));
+        store.record(sample_record());
+        store.finalize_stream(999_999, 100, Duration::from_secs(1));
+        assert_eq!(store.snapshot().len(), 1);
+    }
+
+    #[test]
+    fn finalize_stable_after_eviction() {
+        let store = MetricsStore::new(Duration::from_millis(50));
+        let mut old = sample_record();
+        old.timestamp = Instant::now() - Duration::from_millis(100);
+        store.record(old);
+
+        let mut rec = sample_record();
+        rec.output_tokens = 0;
+        let id = store.record_pending(rec);
+
+        store.evict_expired();
+
+        store.finalize_stream(id, 999, Duration::from_secs(5));
+        let snap = store.snapshot();
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].output_tokens, 999);
+    }
+
+    fn store_with_logger(dir: &std::path::Path) -> MetricsStore {
+        let config = crate::config::MetricsLogConfig {
+            enabled: true,
+            path: dir.join("metrics.jsonl").to_string_lossy().to_string(),
+            max_size_mb: 50,
+            max_files: 5,
+        };
+        let logger = crate::metrics_log::MetricsLogger::new(&config).unwrap();
+        MetricsStore::with_logger(Duration::from_secs(60), logger)
+    }
+
+    #[test]
+    fn record_writes_to_logger() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_with_logger(dir.path());
+
+        store.record(sample_record());
+
+        let content = std::fs::read_to_string(dir.path().join("metrics.jsonl")).unwrap();
+        let entry: serde_json::Value = serde_json::from_str(content.trim()).unwrap();
+        assert_eq!(entry["model"], "claude-opus-4-6");
+        assert_eq!(entry["status"], 200);
+        assert_eq!(entry["provider"], "anthropic");
+    }
+
+    #[test]
+    fn finalize_stream_writes_to_logger() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_with_logger(dir.path());
+
+        let mut rec = sample_record();
+        rec.output_tokens = 0;
+        rec.duration = Duration::ZERO;
+        let id = store.record_pending(rec);
+
+        let content = std::fs::read_to_string(dir.path().join("metrics.jsonl")).unwrap();
+        assert!(content.is_empty(), "record_pending should not log");
+
+        store.finalize_stream(id, 500, Duration::from_secs(3));
+
+        let content = std::fs::read_to_string(dir.path().join("metrics.jsonl")).unwrap();
+        let entry: serde_json::Value = serde_json::from_str(content.trim()).unwrap();
+        assert_eq!(entry["output_tokens"], 500);
+        assert_eq!(entry["duration_ms"], 3000);
+    }
+
+    #[test]
+    fn percentile_duration() {
+        let store = MetricsStore::new(Duration::from_secs(60));
+        for ms in [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000] {
+            let mut r = sample_record();
+            r.duration = Duration::from_millis(ms);
+            store.record(r);
+        }
+        let snap = store.snapshot();
+        let durations: Vec<Duration> = snap.iter().map(|r| r.duration).collect();
+        let p50 = MetricsStore::duration_percentile(&durations, 50);
+        let p95 = MetricsStore::duration_percentile(&durations, 95);
+        assert!(p50.as_millis() >= 500 && p50.as_millis() <= 600);
+        assert!(p95.as_millis() >= 900 && p95.as_millis() <= 1000);
+    }
+
+    #[test]
+    fn percentile_empty_returns_zero() {
+        let durations: Vec<Duration> = vec![];
+        assert_eq!(
+            MetricsStore::duration_percentile(&durations, 50),
+            Duration::ZERO
+        );
+    }
+
+    #[test]
+    fn percentile_single_value() {
+        let durations = vec![Duration::from_millis(42)];
+        assert_eq!(
+            MetricsStore::duration_percentile(&durations, 50),
+            Duration::from_millis(42)
+        );
+        assert_eq!(
+            MetricsStore::duration_percentile(&durations, 99),
+            Duration::from_millis(42)
+        );
+    }
+
+    #[test]
+    fn routing_method_display() {
+        assert_eq!(RoutingMethod::Pattern.to_string(), "pattern");
+        assert_eq!(RoutingMethod::Auto.to_string(), "auto");
+        assert_eq!(RoutingMethod::Default.to_string(), "default");
+        assert_eq!(RoutingMethod::Higgs.to_string(), "higgs");
+    }
+
+    #[test]
+    fn higgs_routing_method_in_record() {
+        let store = MetricsStore::new(Duration::from_secs(60));
+        let mut rec = sample_record();
+        rec.routing_method = RoutingMethod::Higgs;
+        store.record(rec);
+        let snap = store.snapshot();
+        assert_eq!(snap[0].routing_method, RoutingMethod::Higgs);
+    }
+}

--- a/crates/higgs/src/metrics_log.rs
+++ b/crates/higgs/src/metrics_log.rs
@@ -33,6 +33,9 @@ impl MetricsLogger {
     }
 
     fn maybe_rotate(&mut self) -> io::Result<()> {
+        if self.max_files == 0 {
+            return Ok(());
+        }
         let size = fs::metadata(&self.path).map(|m| m.len()).unwrap_or(0);
         if size < self.max_size {
             return Ok(());
@@ -76,11 +79,7 @@ mod tests {
     fn test_config(dir: &Path, max_size_mb: u64, max_files: u32) -> MetricsLogConfig {
         MetricsLogConfig {
             enabled: true,
-            path: dir
-                .join("metrics.jsonl")
-                .to_string_lossy()
-                .to_owned()
-                .to_string(),
+            path: dir.join("metrics.jsonl").to_string_lossy().to_string(),
             max_size_mb,
             max_files,
         }
@@ -92,11 +91,7 @@ mod tests {
         let nested = tmp.path().join("a/b/c");
         let config = MetricsLogConfig {
             enabled: true,
-            path: nested
-                .join("metrics.jsonl")
-                .to_string_lossy()
-                .to_owned()
-                .to_string(),
+            path: nested.join("metrics.jsonl").to_string_lossy().to_string(),
             max_size_mb: 1,
             max_files: 3,
         };
@@ -160,7 +155,6 @@ mod tests {
                 .path()
                 .join("metrics.jsonl")
                 .to_string_lossy()
-                .to_owned()
                 .to_string(),
             max_size_mb: 0,
             max_files: 3,
@@ -191,7 +185,6 @@ mod tests {
                 .path()
                 .join("metrics.jsonl")
                 .to_string_lossy()
-                .to_owned()
                 .to_string(),
             max_size_mb: 0,
             max_files: 3,
@@ -222,7 +215,6 @@ mod tests {
                 .path()
                 .join("metrics.jsonl")
                 .to_string_lossy()
-                .to_owned()
                 .to_string(),
             max_size_mb: 0,
             max_files: 2,

--- a/crates/higgs/src/metrics_log.rs
+++ b/crates/higgs/src/metrics_log.rs
@@ -1,0 +1,283 @@
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, BufWriter, Write};
+use std::path::{Path, PathBuf};
+
+use crate::config::MetricsLogConfig;
+
+pub struct MetricsLogger {
+    path: PathBuf,
+    max_size: u64,
+    max_files: u32,
+    writer: BufWriter<File>,
+}
+
+impl MetricsLogger {
+    pub fn new(config: &MetricsLogConfig) -> io::Result<Self> {
+        let path = PathBuf::from(&config.path);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let file = OpenOptions::new().create(true).append(true).open(&path)?;
+        Ok(Self {
+            path,
+            max_size: config.max_size_mb * 1024 * 1024,
+            max_files: config.max_files,
+            writer: BufWriter::new(file),
+        })
+    }
+
+    pub fn write_line(&mut self, line: &str) -> io::Result<()> {
+        writeln!(self.writer, "{line}")?;
+        self.writer.flush()?;
+        self.maybe_rotate()
+    }
+
+    fn maybe_rotate(&mut self) -> io::Result<()> {
+        let size = fs::metadata(&self.path).map(|m| m.len()).unwrap_or(0);
+        if size < self.max_size {
+            return Ok(());
+        }
+        self.rotate()
+    }
+
+    fn rotate(&mut self) -> io::Result<()> {
+        let oldest = rotated_path(&self.path, self.max_files);
+        if oldest.exists() {
+            fs::remove_file(&oldest)?;
+        }
+        for i in (1..self.max_files).rev() {
+            let from = rotated_path(&self.path, i);
+            let to = rotated_path(&self.path, i + 1);
+            if from.exists() {
+                fs::rename(&from, &to)?;
+            }
+        }
+        let first_rotated = rotated_path(&self.path, 1);
+        fs::rename(&self.path, &first_rotated)?;
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)?;
+        self.writer = BufWriter::new(file);
+        Ok(())
+    }
+}
+
+pub(crate) fn rotated_path(base: &Path, index: u32) -> PathBuf {
+    let name = base.file_name().unwrap_or_default().to_string_lossy();
+    base.with_file_name(format!("{name}.{index}"))
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used, clippy::indexing_slicing)]
+mod tests {
+    use super::*;
+
+    fn test_config(dir: &Path, max_size_mb: u64, max_files: u32) -> MetricsLogConfig {
+        MetricsLogConfig {
+            enabled: true,
+            path: dir
+                .join("metrics.jsonl")
+                .to_string_lossy()
+                .to_owned()
+                .to_string(),
+            max_size_mb,
+            max_files,
+        }
+    }
+
+    #[test]
+    fn test_creates_parent_directories() {
+        let tmp = tempfile::tempdir().unwrap();
+        let nested = tmp.path().join("a/b/c");
+        let config = MetricsLogConfig {
+            enabled: true,
+            path: nested
+                .join("metrics.jsonl")
+                .to_string_lossy()
+                .to_owned()
+                .to_string(),
+            max_size_mb: 1,
+            max_files: 3,
+        };
+        let _logger = MetricsLogger::new(&config).unwrap();
+        assert!(nested.exists());
+    }
+
+    #[test]
+    fn test_write_line_creates_file_content() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = test_config(tmp.path(), 1, 3);
+        let log_path = PathBuf::from(&config.path);
+
+        let mut logger = MetricsLogger::new(&config).unwrap();
+        logger.write_line(r#"{"event":"test"}"#).unwrap();
+
+        let content = fs::read_to_string(&log_path).unwrap();
+        assert_eq!(content.trim(), r#"{"event":"test"}"#);
+    }
+
+    #[test]
+    fn test_multiple_writes_append() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = test_config(tmp.path(), 1, 3);
+        let log_path = PathBuf::from(&config.path);
+
+        let mut logger = MetricsLogger::new(&config).unwrap();
+        logger.write_line("line1").unwrap();
+        logger.write_line("line2").unwrap();
+        logger.write_line("line3").unwrap();
+
+        let content = fs::read_to_string(&log_path).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 3);
+        assert_eq!(lines[0], "line1");
+        assert_eq!(lines[1], "line2");
+        assert_eq!(lines[2], "line3");
+    }
+
+    #[test]
+    fn test_no_rotation_under_limit() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = test_config(tmp.path(), 1, 3);
+
+        let mut logger = MetricsLogger::new(&config).unwrap();
+        logger.write_line("small").unwrap();
+
+        let rotated = rotated_path(&PathBuf::from(&config.path), 1);
+        assert!(!rotated.exists());
+    }
+
+    #[test]
+    fn test_rotation_when_size_exceeded() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Use a very small max_size_mb -- 0 means 0 bytes, so any write triggers rotation.
+        // Instead, write enough to exceed a small limit. We'll set max_size_mb to 0 which
+        // means max_size = 0, so the first write will exceed it.
+        let config = MetricsLogConfig {
+            enabled: true,
+            path: tmp
+                .path()
+                .join("metrics.jsonl")
+                .to_string_lossy()
+                .to_owned()
+                .to_string(),
+            max_size_mb: 0,
+            max_files: 3,
+        };
+        let log_path = PathBuf::from(&config.path);
+
+        let mut logger = MetricsLogger::new(&config).unwrap();
+        logger.write_line("first").unwrap();
+
+        // After writing "first\n", size > 0 = max_size, so rotation should have happened.
+        let rotated_1 = rotated_path(&log_path, 1);
+        assert!(rotated_1.exists(), "rotated file .1 should exist");
+
+        let rotated_content = fs::read_to_string(&rotated_1).unwrap();
+        assert_eq!(rotated_content.trim(), "first");
+
+        // The main file should now be empty (new file created after rotation).
+        let main_content = fs::read_to_string(&log_path).unwrap();
+        assert!(main_content.is_empty());
+    }
+
+    #[test]
+    fn test_rotation_shifts_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = MetricsLogConfig {
+            enabled: true,
+            path: tmp
+                .path()
+                .join("metrics.jsonl")
+                .to_string_lossy()
+                .to_owned()
+                .to_string(),
+            max_size_mb: 0,
+            max_files: 3,
+        };
+        let log_path = PathBuf::from(&config.path);
+
+        let mut logger = MetricsLogger::new(&config).unwrap();
+        logger.write_line("first").unwrap();
+        logger.write_line("second").unwrap();
+        logger.write_line("third").unwrap();
+
+        // After 3 rotations: .1 = "third", .2 = "second", .3 = "first"
+        let content_1 = fs::read_to_string(rotated_path(&log_path, 1)).unwrap();
+        let content_2 = fs::read_to_string(rotated_path(&log_path, 2)).unwrap();
+        let content_3 = fs::read_to_string(rotated_path(&log_path, 3)).unwrap();
+
+        assert_eq!(content_1.trim(), "third");
+        assert_eq!(content_2.trim(), "second");
+        assert_eq!(content_3.trim(), "first");
+    }
+
+    #[test]
+    fn test_oldest_file_deleted_on_rotation() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = MetricsLogConfig {
+            enabled: true,
+            path: tmp
+                .path()
+                .join("metrics.jsonl")
+                .to_string_lossy()
+                .to_owned()
+                .to_string(),
+            max_size_mb: 0,
+            max_files: 2,
+        };
+        let log_path = PathBuf::from(&config.path);
+
+        let mut logger = MetricsLogger::new(&config).unwrap();
+        logger.write_line("first").unwrap();
+        logger.write_line("second").unwrap();
+        logger.write_line("third").unwrap();
+
+        // max_files=2, so .1 and .2 exist, but "first" was pushed past .2 and deleted.
+        let content_1 = fs::read_to_string(rotated_path(&log_path, 1)).unwrap();
+        let content_2 = fs::read_to_string(rotated_path(&log_path, 2)).unwrap();
+
+        assert_eq!(content_1.trim(), "third");
+        assert_eq!(content_2.trim(), "second");
+
+        // .3 should not exist since max_files=2.
+        assert!(!rotated_path(&log_path, 3).exists());
+    }
+
+    #[test]
+    fn test_rotated_path_format() {
+        let base = PathBuf::from("/tmp/logs/metrics.jsonl");
+        assert_eq!(
+            rotated_path(&base, 1),
+            PathBuf::from("/tmp/logs/metrics.jsonl.1")
+        );
+        assert_eq!(
+            rotated_path(&base, 5),
+            PathBuf::from("/tmp/logs/metrics.jsonl.5")
+        );
+    }
+
+    #[test]
+    fn test_append_after_reopen() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = test_config(tmp.path(), 1, 3);
+        let log_path = PathBuf::from(&config.path);
+
+        {
+            let mut logger = MetricsLogger::new(&config).unwrap();
+            logger.write_line("before").unwrap();
+        }
+
+        {
+            let mut logger = MetricsLogger::new(&config).unwrap();
+            logger.write_line("after").unwrap();
+        }
+
+        let content = fs::read_to_string(&log_path).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0], "before");
+        assert_eq!(lines[1], "after");
+    }
+}

--- a/crates/higgs/src/proxy.rs
+++ b/crates/higgs/src/proxy.rs
@@ -1,0 +1,326 @@
+use axum::{
+    body::Body,
+    http::{HeaderMap, HeaderValue, StatusCode},
+    response::{IntoResponse, Response},
+};
+use bytes::Bytes;
+use futures::TryStreamExt;
+
+use crate::error::ServerError;
+
+fn is_hop_by_hop(name: &http::header::HeaderName) -> bool {
+    matches!(
+        name.as_str(),
+        "connection"
+            | "keep-alive"
+            | "proxy-connection"
+            | "te"
+            | "trailer"
+            | "transfer-encoding"
+            | "upgrade"
+    )
+}
+
+/// Build forwarding headers from the original request.
+///
+/// Strips hop-by-hop headers, optionally strips auth headers, and injects
+/// the provider's API key as `x-api-key` if configured.
+fn build_forwarding_headers(
+    original: &HeaderMap,
+    strip_auth: bool,
+    api_key: Option<&str>,
+    body_len: usize,
+) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    for (key, value) in original {
+        if key == http::header::HOST || is_hop_by_hop(key) {
+            continue;
+        }
+        if strip_auth && (key == http::header::AUTHORIZATION || key.as_str() == "x-api-key") {
+            continue;
+        }
+        headers.insert(key.clone(), value.clone());
+    }
+
+    if let Some(key) = api_key {
+        if let Ok(value) = HeaderValue::from_str(key) {
+            headers.insert(http::header::HeaderName::from_static("x-api-key"), value);
+        } else {
+            tracing::warn!("api_key contains invalid header characters, skipping");
+        }
+    }
+
+    if body_len > 0 {
+        if let Ok(val) = HeaderValue::from_str(&body_len.to_string()) {
+            headers.insert(http::header::CONTENT_LENGTH, val);
+        }
+    }
+
+    // Strip accept-encoding so provider doesn't compress; we need raw bytes for streaming
+    headers.remove(http::header::ACCEPT_ENCODING);
+
+    headers
+}
+
+/// Filter upstream response headers, removing hop-by-hop and content-encoding.
+fn filter_response_headers(upstream: &reqwest::header::HeaderMap) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    for (key, value) in upstream {
+        if is_hop_by_hop(key) || key == http::header::CONTENT_ENCODING {
+            continue;
+        }
+        headers.insert(key.clone(), value.clone());
+    }
+    headers
+}
+
+/// Rewrite the `model` field in a JSON body.
+pub fn rewrite_model_in_body(body: &[u8], new_model: &str) -> Result<Bytes, ServerError> {
+    let mut json: serde_json::Value = serde_json::from_slice(body)
+        .map_err(|e| ServerError::InternalError(format!("JSON parse for model rewrite: {e}")))?;
+    let obj = json
+        .as_object_mut()
+        .ok_or_else(|| ServerError::InternalError("expected JSON object".to_owned()))?;
+    obj.insert(
+        "model".to_owned(),
+        serde_json::Value::String(new_model.to_owned()),
+    );
+    serde_json::to_vec(&json)
+        .map(Bytes::from)
+        .map_err(|e| ServerError::InternalError(format!("JSON serialize after rewrite: {e}")))
+}
+
+/// Return a stub response for `/count_tokens` when the provider doesn't support it.
+pub fn stub_count_tokens_response() -> Response {
+    let stub = serde_json::json!({"input_tokens": 0});
+    let body = serde_json::to_vec(&stub).unwrap_or_default();
+    (
+        StatusCode::OK,
+        [(http::header::CONTENT_TYPE, "application/json")],
+        body,
+    )
+        .into_response()
+}
+
+/// Send a request to an upstream provider and return the raw response.
+///
+/// Unlike [`proxy_request`], this returns the reqwest response directly so the
+/// caller can process the body (e.g., for format translation).
+pub async fn send_to_provider(
+    client: &reqwest::Client,
+    provider_url: &str,
+    path: &str,
+    body: Bytes,
+    original_headers: &HeaderMap,
+    strip_auth: bool,
+    api_key: Option<&str>,
+) -> Result<reqwest::Response, ServerError> {
+    let url = format!("{}{path}", provider_url.trim_end_matches('/'));
+    let headers = build_forwarding_headers(original_headers, strip_auth, api_key, body.len());
+
+    tracing::debug!(url = %url, body_bytes = body.len(), "sending to provider");
+
+    let upstream = client
+        .post(&url)
+        .headers(headers)
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| {
+            tracing::error!(url = %url, error = %e, "provider request failed");
+            ServerError::ProxyError(format!("provider unreachable: {e}"))
+        })?;
+
+    let status = upstream.status().as_u16();
+    if status >= 400 {
+        let error_body = upstream
+            .text()
+            .await
+            .unwrap_or_else(|_| String::from("(failed to read error body)"));
+        return Err(ServerError::ProxyError(format!(
+            "upstream returned HTTP {status}: {error_body}"
+        )));
+    }
+
+    Ok(upstream)
+}
+
+/// Forward a request to an upstream provider and stream the response back.
+pub async fn proxy_request(
+    client: &reqwest::Client,
+    provider_url: &str,
+    path: &str,
+    body: Bytes,
+    original_headers: &HeaderMap,
+    strip_auth: bool,
+    api_key: Option<&str>,
+) -> Result<Response, ServerError> {
+    let url = format!("{}{path}", provider_url.trim_end_matches('/'));
+    let headers = build_forwarding_headers(original_headers, strip_auth, api_key, body.len());
+
+    tracing::debug!(url = %url, body_bytes = body.len(), "proxying request");
+
+    let upstream = client
+        .post(&url)
+        .headers(headers)
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| {
+            tracing::error!(url = %url, error = %e, "provider request failed");
+            ServerError::ProxyError(format!("provider unreachable: {e}"))
+        })?;
+
+    let status = StatusCode::from_u16(upstream.status().as_u16())
+        .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+
+    tracing::info!(status = %status, url = %url, "provider responded");
+
+    let response_headers = filter_response_headers(upstream.headers());
+
+    let stream = upstream.bytes_stream().map_err(std::io::Error::other);
+    let response_body = Body::from_stream(stream);
+
+    let mut response = Response::new(response_body);
+    *response.status_mut() = status;
+    *response.headers_mut() = response_headers;
+    Ok(response)
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used, clippy::indexing_slicing)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hop_by_hop_headers_filtered() {
+        assert!(is_hop_by_hop(&http::header::HeaderName::from_static(
+            "connection"
+        )));
+        assert!(is_hop_by_hop(&http::header::HeaderName::from_static(
+            "transfer-encoding"
+        )));
+        assert!(!is_hop_by_hop(&http::header::CONTENT_TYPE));
+    }
+
+    #[test]
+    fn forwarding_headers_strip_host() {
+        let mut original = HeaderMap::new();
+        original.insert(http::header::HOST, HeaderValue::from_static("localhost"));
+        original.insert(
+            http::header::CONTENT_TYPE,
+            HeaderValue::from_static("application/json"),
+        );
+
+        let headers = build_forwarding_headers(&original, false, None, 0);
+        assert!(headers.get(http::header::HOST).is_none());
+        assert!(headers.get(http::header::CONTENT_TYPE).is_some());
+    }
+
+    #[test]
+    fn forwarding_headers_strip_auth_when_requested() {
+        let mut original = HeaderMap::new();
+        original.insert(
+            http::header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer sk-test"),
+        );
+        original.insert(
+            http::header::HeaderName::from_static("x-api-key"),
+            HeaderValue::from_static("sk-ant-test"),
+        );
+
+        let headers = build_forwarding_headers(&original, true, None, 0);
+        assert!(headers.get(http::header::AUTHORIZATION).is_none());
+        assert!(headers.get("x-api-key").is_none());
+    }
+
+    #[test]
+    fn forwarding_headers_preserve_auth_when_not_stripping() {
+        let mut original = HeaderMap::new();
+        original.insert(
+            http::header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer sk-test"),
+        );
+
+        let headers = build_forwarding_headers(&original, false, None, 0);
+        assert!(headers.get(http::header::AUTHORIZATION).is_some());
+    }
+
+    #[test]
+    fn forwarding_headers_inject_api_key() {
+        let original = HeaderMap::new();
+        let headers = build_forwarding_headers(&original, false, Some("sk-provider"), 0);
+        assert_eq!(
+            headers.get("x-api-key").unwrap().to_str().unwrap(),
+            "sk-provider"
+        );
+    }
+
+    #[test]
+    fn forwarding_headers_set_content_length() {
+        let original = HeaderMap::new();
+        let headers = build_forwarding_headers(&original, false, None, 42);
+        assert_eq!(
+            headers
+                .get(http::header::CONTENT_LENGTH)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "42"
+        );
+    }
+
+    #[test]
+    fn forwarding_headers_strip_accept_encoding() {
+        let mut original = HeaderMap::new();
+        original.insert(
+            http::header::ACCEPT_ENCODING,
+            HeaderValue::from_static("gzip"),
+        );
+        let headers = build_forwarding_headers(&original, false, None, 0);
+        assert!(headers.get(http::header::ACCEPT_ENCODING).is_none());
+    }
+
+    #[test]
+    fn rewrite_model_changes_field() {
+        let body = br#"{"model":"old-model","messages":[]}"#;
+        let result = rewrite_model_in_body(body, "new-model").unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&result).unwrap();
+        assert_eq!(json["model"].as_str().unwrap(), "new-model");
+        assert!(json["messages"].is_array());
+    }
+
+    #[test]
+    fn rewrite_model_invalid_json_errors() {
+        let body = b"not json";
+        assert!(rewrite_model_in_body(body, "x").is_err());
+    }
+
+    #[test]
+    fn stub_count_tokens_returns_json() {
+        let resp = stub_count_tokens_response();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[test]
+    fn filter_response_removes_hop_by_hop() {
+        let mut upstream = reqwest::header::HeaderMap::new();
+        upstream.insert(
+            reqwest::header::CONTENT_TYPE,
+            reqwest::header::HeaderValue::from_static("application/json"),
+        );
+        upstream.insert(
+            reqwest::header::TRANSFER_ENCODING,
+            reqwest::header::HeaderValue::from_static("chunked"),
+        );
+        upstream.insert(
+            reqwest::header::CONTENT_ENCODING,
+            reqwest::header::HeaderValue::from_static("gzip"),
+        );
+
+        let filtered = filter_response_headers(&upstream);
+        assert!(filtered.get(http::header::CONTENT_TYPE).is_some());
+        assert!(filtered.get(http::header::TRANSFER_ENCODING).is_none());
+        assert!(filtered.get(http::header::CONTENT_ENCODING).is_none());
+    }
+}

--- a/crates/higgs/src/router.rs
+++ b/crates/higgs/src/router.rs
@@ -89,7 +89,6 @@ pub struct Router {
     auto_routes: Vec<AutoRouteEntry>,
     auto_candidates: Vec<RouteCandidate>,
     auto_router_engine: Option<Arc<Engine>>,
-    #[allow(dead_code)]
     auto_router_timeout_ms: u64,
     default_target: RouteTarget,
 }
@@ -236,11 +235,21 @@ impl Router {
         let candidates = self.auto_candidates.clone();
         let messages_owned = msg_slice.to_vec();
 
-        let name = tokio::task::spawn_blocking(move || {
-            crate::auto_router::classify_local(&engine_clone, &candidates, &messages_owned)
-        })
+        let timeout = std::time::Duration::from_millis(self.auto_router_timeout_ms);
+        let name = match tokio::time::timeout(
+            timeout,
+            tokio::task::spawn_blocking(move || {
+                crate::auto_router::classify_local(&engine_clone, &candidates, &messages_owned)
+            }),
+        )
         .await
-        .ok()??;
+        {
+            Ok(join_result) => join_result.ok()??,
+            Err(_) => {
+                warn!("auto-router classification timed out after {timeout:?}");
+                return None;
+            }
+        };
 
         let entry = self.auto_routes.iter().find(|r| r.name == name)?;
         self.resolve_target(&entry.target, "auto", RoutingMethod::Auto)

--- a/crates/higgs/src/router.rs
+++ b/crates/higgs/src/router.rs
@@ -299,16 +299,25 @@ impl Router {
                 strip_auth,
                 api_key,
                 stub_count_tokens,
-            } => Ok(ResolvedRoute::Remote {
-                provider_name: provider_name.clone(),
-                provider_url: provider_url.clone(),
-                provider_format: *provider_format,
-                model_rewrite: model_rewrite.clone(),
-                strip_auth: *strip_auth,
-                api_key: api_key.clone(),
-                stub_count_tokens: *stub_count_tokens,
-                routing_method: method,
-            }),
+            } => {
+                if model == "auto" && model_rewrite.is_none() {
+                    return Err(
+                        "cannot forward virtual model name \"auto\" to remote provider; \
+                         configure a model rewrite on the default route or add auto-router routes"
+                            .to_owned(),
+                    );
+                }
+                Ok(ResolvedRoute::Remote {
+                    provider_name: provider_name.clone(),
+                    provider_url: provider_url.clone(),
+                    provider_format: *provider_format,
+                    model_rewrite: model_rewrite.clone(),
+                    strip_auth: *strip_auth,
+                    api_key: api_key.clone(),
+                    stub_count_tokens: *stub_count_tokens,
+                    routing_method: method,
+                })
+            }
         }
     }
 }
@@ -800,21 +809,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn auto_model_with_remote_default_succeeds() {
-        // When model="auto" and default is a remote provider, should work fine
+    async fn auto_model_with_remote_default_rejects_without_rewrite() {
+        // model="auto" falling through to a remote default with no model_rewrite
+        // should error -- "auto" is not a real model name for upstream providers.
         let router = router_from_toml(production_toml());
         let result = router.resolve("auto", None).await;
         match result {
-            Ok(ResolvedRoute::Remote {
-                provider_name,
-                routing_method,
-                ..
-            }) => {
-                assert_eq!(provider_name, "anthropic");
-                assert_eq!(routing_method, RoutingMethod::Default);
-            }
-            Ok(ResolvedRoute::Higgs { .. }) => panic!("expected Remote route"),
-            Err(e) => panic!("should resolve to default remote, got error: {e}"),
+            Err(e) => assert!(e.contains("cannot forward virtual model name"), "got: {e}"),
+            Ok(_) => panic!("expected error for auto with remote default"),
         }
     }
 

--- a/crates/higgs/src/router.rs
+++ b/crates/higgs/src/router.rs
@@ -264,12 +264,24 @@ impl Router {
         match target {
             RouteTarget::Higgs { model_rewrite } => {
                 let lookup_name = model_rewrite.as_deref().unwrap_or(model);
-                let engine = self.local_engines.get(lookup_name).ok_or_else(|| {
-                    format!("model '{lookup_name}' not found among loaded local models")
-                })?;
+                let (engine, resolved_name) =
+                    if let Some(engine) = self.local_engines.get(lookup_name) {
+                        (Arc::clone(engine), lookup_name.to_owned())
+                    } else if model == "auto" {
+                        // "auto" is a virtual model name; pick any loaded engine
+                        let (name, engine) =
+                            self.local_engines.iter().next().ok_or_else(|| {
+                                "no local models loaded for default route".to_owned()
+                            })?;
+                        (Arc::clone(engine), name.clone())
+                    } else {
+                        return Err(format!(
+                            "model '{lookup_name}' not found among loaded local models"
+                        ));
+                    };
                 Ok(ResolvedRoute::Higgs {
-                    engine: Arc::clone(engine),
-                    model_name: lookup_name.to_owned(),
+                    engine,
+                    model_name: resolved_name,
                     routing_method: method,
                 })
             }
@@ -747,5 +759,56 @@ mod tests {
         );
         let router = Router::from_config(&config, HashMap::new()).unwrap();
         assert!(router.local_engines().is_empty());
+    }
+
+    #[tokio::test]
+    async fn auto_model_with_higgs_default_picks_first_engine() {
+        // When model="auto", auto-router returns None, default is higgs
+        // with no model_rewrite, it should pick the first loaded engine
+        // instead of trying to look up "auto" as a model name.
+        let config = config_from_toml(
+            r#"
+            [[models]]
+            path = "test/model-a"
+            "#,
+        );
+        let engine = crate::state::Engine::test_stub("test/model-a");
+        let mut engines = HashMap::new();
+        engines.insert("test/model-a".to_owned(), Arc::new(engine));
+
+        let router = Router::from_config(&config, engines).unwrap();
+        // No auto-router configured, so "auto" falls through to default
+        let result = router.resolve("auto", None).await;
+        match result {
+            Ok(ResolvedRoute::Higgs {
+                model_name,
+                routing_method,
+                ..
+            }) => {
+                assert_eq!(model_name, "test/model-a");
+                assert_eq!(routing_method, RoutingMethod::Default);
+            }
+            Ok(ResolvedRoute::Remote { .. }) => panic!("expected Higgs route"),
+            Err(e) => panic!("should resolve to first engine, got error: {e}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn auto_model_with_remote_default_succeeds() {
+        // When model="auto" and default is a remote provider, should work fine
+        let router = router_from_toml(production_toml());
+        let result = router.resolve("auto", None).await;
+        match result {
+            Ok(ResolvedRoute::Remote {
+                provider_name,
+                routing_method,
+                ..
+            }) => {
+                assert_eq!(provider_name, "anthropic");
+                assert_eq!(routing_method, RoutingMethod::Default);
+            }
+            Ok(ResolvedRoute::Higgs { .. }) => panic!("expected Remote route"),
+            Err(e) => panic!("should resolve to default remote, got error: {e}"),
+        }
     }
 }

--- a/crates/higgs/src/router.rs
+++ b/crates/higgs/src/router.rs
@@ -1,0 +1,737 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use regex::Regex;
+use tracing::warn;
+
+use crate::config::{ApiFormat, HiggsConfig};
+use crate::state::Engine;
+
+/// How a model name was resolved to its target.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RoutingMethod {
+    /// Direct lookup by model name in local engines (no route matched).
+    Direct,
+    /// Matched a regex pattern route.
+    Pattern,
+    /// Selected by the auto-router AI classifier.
+    Auto,
+    /// Fell through to the default provider.
+    Default,
+}
+
+/// Outcome of resolving a model name through the routing table.
+pub enum ResolvedRoute {
+    /// Serve locally via a loaded MLX engine.
+    Higgs {
+        engine: Arc<Engine>,
+        model_name: String,
+        routing_method: RoutingMethod,
+    },
+    /// Forward to a remote provider.
+    Remote {
+        provider_name: String,
+        provider_url: String,
+        provider_format: ApiFormat,
+        model_rewrite: Option<String>,
+        strip_auth: bool,
+        api_key: Option<String>,
+        stub_count_tokens: bool,
+        routing_method: RoutingMethod,
+    },
+}
+
+/// A named route candidate for auto-routing classification.
+#[derive(Clone)]
+pub struct RouteCandidate {
+    pub name: String,
+    pub description: String,
+}
+
+// -- Internal types --------------------------------------------------------
+
+#[derive(Clone)]
+enum RouteTarget {
+    Higgs {
+        model_rewrite: Option<String>,
+    },
+    Remote {
+        provider_name: String,
+        provider_url: String,
+        provider_format: ApiFormat,
+        model_rewrite: Option<String>,
+        strip_auth: bool,
+        api_key: Option<String>,
+        stub_count_tokens: bool,
+    },
+}
+
+struct CompiledRoute {
+    pattern: Regex,
+    target: RouteTarget,
+}
+
+struct AutoRouteEntry {
+    name: String,
+    target: RouteTarget,
+}
+
+/// Routes model names to local engines or remote providers.
+///
+/// Resolution order:
+/// 1. If `model == "auto"`, try auto-routing classification
+/// 2. Pattern matching (first match wins)
+/// 3. Direct engine lookup by model name
+/// 4. Default provider fallback
+pub struct Router {
+    local_engines: HashMap<String, Arc<Engine>>,
+    compiled_routes: Vec<CompiledRoute>,
+    auto_routes: Vec<AutoRouteEntry>,
+    auto_candidates: Vec<RouteCandidate>,
+    auto_router_engine: Option<Arc<Engine>>,
+    #[allow(dead_code)]
+    auto_router_timeout_ms: u64,
+    default_target: RouteTarget,
+}
+
+impl Router {
+    /// Build a router from the unified config and loaded local engines.
+    pub fn from_config(
+        config: &HiggsConfig,
+        engines: HashMap<String, Arc<Engine>>,
+    ) -> Result<Self, String> {
+        let mut compiled_routes = Vec::new();
+        let mut auto_routes = Vec::new();
+        let mut auto_candidates = Vec::new();
+        let mut seen_names = HashSet::new();
+
+        for route in &config.routes {
+            if route.pattern.is_none() && route.description.is_none() {
+                return Err(format!(
+                    "route for provider '{}' has neither pattern nor description",
+                    route.provider
+                ));
+            }
+
+            if route.description.is_some() && route.name.is_none() {
+                return Err(format!(
+                    "route for provider '{}' has description but no name",
+                    route.provider
+                ));
+            }
+
+            let target = build_route_target(&route.provider, route.model.clone(), config)?;
+
+            if let Some(ref pattern_str) = route.pattern {
+                let pattern = Regex::new(pattern_str)
+                    .map_err(|e| format!("invalid regex '{pattern_str}': {e}"))?;
+                compiled_routes.push(CompiledRoute {
+                    pattern,
+                    target: target.clone(),
+                });
+            }
+
+            if let (Some(name), Some(description)) = (&route.name, &route.description) {
+                if !seen_names.insert(name.clone()) {
+                    return Err(format!("duplicate route name '{name}'"));
+                }
+                auto_routes.push(AutoRouteEntry {
+                    name: name.clone(),
+                    target,
+                });
+                auto_candidates.push(RouteCandidate {
+                    name: name.clone(),
+                    description: description.clone(),
+                });
+            }
+        }
+
+        let auto_router_engine = if config.auto_router.enabled {
+            if config.auto_router.model.is_empty() {
+                return Err("auto_router.enabled is true but model is empty".to_owned());
+            }
+            if auto_candidates.is_empty() {
+                warn!("auto_router is enabled but no routes have descriptions");
+            }
+            let engine = engines
+                .get(&config.auto_router.model)
+                .cloned()
+                .ok_or_else(|| {
+                    format!(
+                        "auto_router model '{}' not found among loaded models",
+                        config.auto_router.model
+                    )
+                })?;
+            Some(engine)
+        } else {
+            None
+        };
+
+        let default_target = build_route_target(&config.default.provider, None, config)?;
+
+        Ok(Self {
+            local_engines: engines,
+            compiled_routes,
+            auto_routes,
+            auto_candidates,
+            auto_router_engine,
+            auto_router_timeout_ms: config.auto_router.timeout_ms,
+            default_target,
+        })
+    }
+
+    /// Resolve a model name to a route.
+    ///
+    /// Pass `messages` for auto-routing support (only used when `model == "auto"`).
+    pub async fn resolve(
+        &self,
+        model: &str,
+        messages: Option<&[serde_json::Value]>,
+    ) -> Result<ResolvedRoute, String> {
+        if model == "auto" {
+            if let Some(resolved) = self.try_auto_route(messages).await {
+                return Ok(resolved);
+            }
+            return self.resolve_target(&self.default_target, model, RoutingMethod::Default);
+        }
+
+        // Pattern matching (first match wins)
+        for route in &self.compiled_routes {
+            if route.pattern.is_match(model) {
+                return self.resolve_target(&route.target, model, RoutingMethod::Pattern);
+            }
+        }
+
+        // Direct engine lookup
+        if let Some(engine) = self.local_engines.get(model) {
+            return Ok(ResolvedRoute::Higgs {
+                engine: Arc::clone(engine),
+                model_name: model.to_owned(),
+                routing_method: RoutingMethod::Direct,
+            });
+        }
+
+        // Default fallback
+        self.resolve_target(&self.default_target, model, RoutingMethod::Default)
+    }
+
+    /// Returns all loaded local engines.
+    pub const fn local_engines(&self) -> &HashMap<String, Arc<Engine>> {
+        &self.local_engines
+    }
+
+    // -- Private helpers ---------------------------------------------------
+
+    async fn try_auto_route(
+        &self,
+        messages: Option<&[serde_json::Value]>,
+    ) -> Option<ResolvedRoute> {
+        let auto_engine = self.auto_router_engine.as_ref()?;
+        let msg_slice = messages?;
+        if self.auto_candidates.is_empty() || msg_slice.is_empty() {
+            return None;
+        }
+
+        let engine_clone = Arc::clone(auto_engine);
+        let candidates = self.auto_candidates.clone();
+        let messages_owned = msg_slice.to_vec();
+
+        let name = tokio::task::spawn_blocking(move || {
+            crate::auto_router::classify_local(&engine_clone, &candidates, &messages_owned)
+        })
+        .await
+        .ok()??;
+
+        let entry = self.auto_routes.iter().find(|r| r.name == name)?;
+        self.resolve_target(&entry.target, "auto", RoutingMethod::Auto)
+            .ok()
+    }
+
+    fn resolve_target(
+        &self,
+        target: &RouteTarget,
+        model: &str,
+        method: RoutingMethod,
+    ) -> Result<ResolvedRoute, String> {
+        match target {
+            RouteTarget::Higgs { model_rewrite } => {
+                let lookup_name = model_rewrite.as_deref().unwrap_or(model);
+                let engine = self.local_engines.get(lookup_name).ok_or_else(|| {
+                    format!("model '{lookup_name}' not found among loaded local models")
+                })?;
+                Ok(ResolvedRoute::Higgs {
+                    engine: Arc::clone(engine),
+                    model_name: lookup_name.to_owned(),
+                    routing_method: method,
+                })
+            }
+            RouteTarget::Remote {
+                provider_name,
+                provider_url,
+                provider_format,
+                model_rewrite,
+                strip_auth,
+                api_key,
+                stub_count_tokens,
+            } => Ok(ResolvedRoute::Remote {
+                provider_name: provider_name.clone(),
+                provider_url: provider_url.clone(),
+                provider_format: *provider_format,
+                model_rewrite: model_rewrite.clone(),
+                strip_auth: *strip_auth,
+                api_key: api_key.clone(),
+                stub_count_tokens: *stub_count_tokens,
+                routing_method: method,
+            }),
+        }
+    }
+}
+
+fn build_route_target(
+    provider_name: &str,
+    model_rewrite: Option<String>,
+    config: &HiggsConfig,
+) -> Result<RouteTarget, String> {
+    if provider_name == "higgs" {
+        return Ok(RouteTarget::Higgs { model_rewrite });
+    }
+    let provider = config
+        .providers
+        .get(provider_name)
+        .ok_or_else(|| format!("route provider '{provider_name}' not found in providers"))?;
+    Ok(RouteTarget::Remote {
+        provider_name: provider_name.to_owned(),
+        provider_url: provider.url.clone(),
+        provider_format: provider.format,
+        model_rewrite,
+        strip_auth: provider.strip_auth,
+        api_key: provider.api_key.clone(),
+        stub_count_tokens: provider.stub_count_tokens,
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::config::load_config_file;
+
+    fn config_from_toml(toml: &str) -> HiggsConfig {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, toml).unwrap();
+        load_config_file(&path, None).unwrap()
+    }
+
+    fn router_from_toml(toml: &str) -> Router {
+        let config = config_from_toml(toml);
+        Router::from_config(&config, HashMap::new()).unwrap()
+    }
+
+    fn production_toml() -> &'static str {
+        r#"
+        [provider.anthropic]
+        url = "https://api.anthropic.com"
+        format = "anthropic"
+
+        [provider.ollama]
+        url = "http://localhost:11434"
+        strip_auth = true
+        api_key = "ollama"
+        stub_count_tokens = true
+
+        [[routes]]
+        pattern = "opus"
+        provider = "anthropic"
+
+        [[routes]]
+        pattern = "sonnet|haiku"
+        provider = "ollama"
+        model = "qwen3-coder:30b"
+
+        [default]
+        provider = "anthropic"
+        "#
+    }
+
+    #[tokio::test]
+    async fn remote_pattern_resolves_to_anthropic() {
+        let router = router_from_toml(production_toml());
+        let route = router.resolve("claude-opus-4-6", None).await.unwrap();
+        match route {
+            ResolvedRoute::Remote {
+                provider_name,
+                provider_url,
+                provider_format,
+                model_rewrite,
+                strip_auth,
+                api_key,
+                stub_count_tokens,
+                routing_method,
+            } => {
+                assert_eq!(provider_name, "anthropic");
+                assert_eq!(provider_url, "https://api.anthropic.com");
+                assert_eq!(provider_format, ApiFormat::Anthropic);
+                assert_eq!(model_rewrite, None);
+                assert!(!strip_auth);
+                assert_eq!(api_key, None);
+                assert!(!stub_count_tokens);
+                assert_eq!(routing_method, RoutingMethod::Pattern);
+            }
+            ResolvedRoute::Higgs { .. } => panic!("expected Remote route"),
+        }
+    }
+
+    #[tokio::test]
+    async fn remote_pattern_with_model_rewrite() {
+        let router = router_from_toml(production_toml());
+        let route = router
+            .resolve("claude-sonnet-4-5-20250929", None)
+            .await
+            .unwrap();
+        match route {
+            ResolvedRoute::Remote {
+                provider_url,
+                model_rewrite,
+                strip_auth,
+                api_key,
+                stub_count_tokens,
+                ..
+            } => {
+                assert_eq!(provider_url, "http://localhost:11434");
+                assert_eq!(model_rewrite.as_deref(), Some("qwen3-coder:30b"));
+                assert!(strip_auth);
+                assert_eq!(api_key.as_deref(), Some("ollama"));
+                assert!(stub_count_tokens);
+            }
+            ResolvedRoute::Higgs { .. } => panic!("expected Remote route"),
+        }
+    }
+
+    #[tokio::test]
+    async fn unmatched_model_falls_to_default() {
+        let router = router_from_toml(production_toml());
+        let route = router.resolve("some-unknown-model", None).await.unwrap();
+        match route {
+            ResolvedRoute::Remote {
+                provider_name,
+                provider_url,
+                routing_method,
+                ..
+            } => {
+                assert_eq!(provider_name, "anthropic");
+                assert_eq!(provider_url, "https://api.anthropic.com");
+                assert_eq!(routing_method, RoutingMethod::Default);
+            }
+            ResolvedRoute::Higgs { .. } => panic!("expected Remote route"),
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_model_falls_to_default() {
+        let router = router_from_toml(production_toml());
+        let route = router.resolve("", None).await.unwrap();
+        match route {
+            ResolvedRoute::Remote {
+                provider_url,
+                routing_method,
+                ..
+            } => {
+                assert_eq!(provider_url, "https://api.anthropic.com");
+                assert_eq!(routing_method, RoutingMethod::Default);
+            }
+            ResolvedRoute::Higgs { .. } => panic!("expected Remote route"),
+        }
+    }
+
+    #[tokio::test]
+    async fn first_matching_route_wins() {
+        let router = router_from_toml(
+            r#"
+            [provider.a]
+            url = "http://a"
+            [provider.b]
+            url = "http://b"
+            [[routes]]
+            pattern = "opus"
+            provider = "a"
+            [[routes]]
+            pattern = "opus"
+            provider = "b"
+            [default]
+            provider = "a"
+            "#,
+        );
+        let route = router.resolve("opus", None).await.unwrap();
+        match route {
+            ResolvedRoute::Remote { provider_url, .. } => {
+                assert_eq!(provider_url, "http://a");
+            }
+            ResolvedRoute::Higgs { .. } => panic!("expected Remote route"),
+        }
+    }
+
+    #[test]
+    fn invalid_regex_returns_error() {
+        let config = config_from_toml(
+            r#"
+            [provider.a]
+            url = "http://a"
+            [[routes]]
+            pattern = "[invalid"
+            provider = "a"
+            [default]
+            provider = "a"
+            "#,
+        );
+        let err = Router::from_config(&config, HashMap::new())
+            .err()
+            .expect("should fail");
+        assert!(err.contains("invalid regex"), "got: {err}");
+    }
+
+    #[test]
+    fn missing_route_provider_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            r#"
+            [provider.a]
+            url = "http://a"
+            [[routes]]
+            pattern = "test"
+            provider = "nonexistent"
+            [default]
+            provider = "a"
+            "#,
+        )
+        .unwrap();
+        // Config validation catches this before Router::from_config
+        let result = load_config_file(&path, None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn missing_default_provider_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            r#"
+            [provider.a]
+            url = "http://a"
+            [[routes]]
+            pattern = "x"
+            provider = "a"
+            [default]
+            provider = "nonexistent"
+            "#,
+        )
+        .unwrap();
+        let result = load_config_file(&path, None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn description_without_name_errors() {
+        let config = config_from_toml(
+            r#"
+            [provider.a]
+            url = "http://a"
+            [[routes]]
+            description = "some task"
+            provider = "a"
+            [default]
+            provider = "a"
+            "#,
+        );
+        let err = Router::from_config(&config, HashMap::new())
+            .err()
+            .expect("should fail");
+        assert!(err.contains("description but no name"), "got: {err}");
+    }
+
+    #[test]
+    fn route_without_pattern_or_description_errors() {
+        let config = config_from_toml(
+            r#"
+            [provider.a]
+            url = "http://a"
+            [[routes]]
+            provider = "a"
+            [default]
+            provider = "a"
+            "#,
+        );
+        let err = Router::from_config(&config, HashMap::new())
+            .err()
+            .expect("should fail");
+        assert!(
+            err.contains("neither pattern nor description"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn duplicate_route_names_error() {
+        let config = config_from_toml(
+            r#"
+            [provider.a]
+            url = "http://a"
+            [[routes]]
+            name = "coding"
+            description = "code tasks"
+            pattern = "opus"
+            provider = "a"
+            [[routes]]
+            name = "coding"
+            description = "other code tasks"
+            pattern = "sonnet"
+            provider = "a"
+            [default]
+            provider = "a"
+            "#,
+        );
+        let err = Router::from_config(&config, HashMap::new())
+            .err()
+            .expect("should fail");
+        assert!(err.contains("duplicate route name"), "got: {err}");
+    }
+
+    #[test]
+    fn auto_candidates_built_from_descriptions() {
+        let config = config_from_toml(
+            r#"
+            [provider.a]
+            url = "http://a"
+            [provider.b]
+            url = "http://b"
+            [[routes]]
+            name = "coding"
+            description = "code tasks"
+            pattern = "opus"
+            provider = "a"
+            [[routes]]
+            pattern = "sonnet"
+            provider = "b"
+            [default]
+            provider = "a"
+            "#,
+        );
+        let router = Router::from_config(&config, HashMap::new()).unwrap();
+        assert_eq!(router.auto_candidates.len(), 1);
+        assert_eq!(router.auto_candidates[0].name, "coding");
+        assert_eq!(router.auto_routes.len(), 1);
+        assert_eq!(router.compiled_routes.len(), 2);
+    }
+
+    #[test]
+    fn description_only_route_not_in_pattern_routes() {
+        let config = config_from_toml(
+            r#"
+            [provider.a]
+            url = "http://a"
+            [[routes]]
+            name = "coding"
+            description = "code tasks"
+            provider = "a"
+            [default]
+            provider = "a"
+            "#,
+        );
+        let router = Router::from_config(&config, HashMap::new()).unwrap();
+        assert_eq!(router.compiled_routes.len(), 0);
+        assert_eq!(router.auto_candidates.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn higgs_route_errors_when_model_not_found() {
+        let config = config_from_toml(
+            r#"
+            [[models]]
+            path = "some/model"
+            [[routes]]
+            pattern = "Llama.*"
+            provider = "higgs"
+            "#,
+        );
+        let router = Router::from_config(&config, HashMap::new()).unwrap();
+        let result = router.resolve("Llama-3.2-1B", None).await;
+        match result {
+            Err(e) => assert!(
+                e.contains("not found among loaded local models"),
+                "got: {e}"
+            ),
+            Ok(_) => panic!("expected error for missing local model"),
+        }
+    }
+
+    #[tokio::test]
+    async fn higgs_default_errors_when_model_not_found() {
+        let config = config_from_toml(
+            r#"
+            [[models]]
+            path = "some/model"
+            "#,
+        );
+        // No routes, default is "higgs", no engines loaded
+        let router = Router::from_config(&config, HashMap::new()).unwrap();
+        let result = router.resolve("nonexistent-model", None).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn resolved_route_includes_provider_name() {
+        let router = router_from_toml(production_toml());
+
+        let route = router.resolve("claude-opus-4-6", None).await.unwrap();
+        match route {
+            ResolvedRoute::Remote { provider_name, .. } => {
+                assert_eq!(provider_name, "anthropic");
+            }
+            ResolvedRoute::Higgs { .. } => panic!("expected Remote"),
+        }
+
+        let route = router
+            .resolve("claude-sonnet-4-5-20250929", None)
+            .await
+            .unwrap();
+        match route {
+            ResolvedRoute::Remote { provider_name, .. } => {
+                assert_eq!(provider_name, "ollama");
+            }
+            ResolvedRoute::Higgs { .. } => panic!("expected Remote"),
+        }
+    }
+
+    #[test]
+    fn no_routes_no_providers_uses_higgs_default() {
+        let config = config_from_toml(
+            r#"
+            [[models]]
+            path = "some/model"
+            "#,
+        );
+        let router = Router::from_config(&config, HashMap::new()).unwrap();
+        // default_target should be Higgs
+        match &router.default_target {
+            RouteTarget::Higgs { model_rewrite } => {
+                assert!(model_rewrite.is_none());
+            }
+            RouteTarget::Remote { .. } => panic!("expected Higgs default"),
+        }
+    }
+
+    #[test]
+    fn local_engines_accessor_returns_engines() {
+        let config = config_from_toml(
+            r#"
+            [[models]]
+            path = "some/model"
+            "#,
+        );
+        let router = Router::from_config(&config, HashMap::new()).unwrap();
+        assert!(router.local_engines().is_empty());
+    }
+}

--- a/crates/higgs/src/router.rs
+++ b/crates/higgs/src/router.rs
@@ -236,19 +236,18 @@ impl Router {
         let messages_owned = msg_slice.to_vec();
 
         let timeout = std::time::Duration::from_millis(self.auto_router_timeout_ms);
-        let name = match tokio::time::timeout(
+        let timeout_result = tokio::time::timeout(
             timeout,
             tokio::task::spawn_blocking(move || {
                 crate::auto_router::classify_local(&engine_clone, &candidates, &messages_owned)
             }),
         )
-        .await
-        {
-            Ok(join_result) => join_result.ok()??,
-            Err(_) => {
-                warn!("auto-router classification timed out after {timeout:?}");
-                return None;
-            }
+        .await;
+        let name = if let Ok(join_result) = timeout_result {
+            join_result.ok()??
+        } else {
+            warn!("auto-router classification timed out after {timeout:?}");
+            return None;
         };
 
         let entry = self.auto_routes.iter().find(|r| r.name == name)?;
@@ -320,7 +319,13 @@ fn build_route_target(
 }
 
 #[cfg(test)]
-#[allow(clippy::panic, clippy::unwrap_used)]
+#[allow(
+    clippy::panic,
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::shadow_unrelated
+)]
 mod tests {
     use super::*;
     use crate::config::load_config_file;

--- a/crates/higgs/src/router.rs
+++ b/crates/higgs/src/router.rs
@@ -89,6 +89,7 @@ pub struct Router {
     auto_routes: Vec<AutoRouteEntry>,
     auto_candidates: Vec<RouteCandidate>,
     auto_router_engine: Option<Arc<Engine>>,
+    auto_router_force: bool,
     auto_router_timeout_ms: u64,
     default_target: RouteTarget,
 }
@@ -174,6 +175,7 @@ impl Router {
             auto_routes,
             auto_candidates,
             auto_router_engine,
+            auto_router_force: config.auto_router.force,
             auto_router_timeout_ms: config.auto_router.timeout_ms,
             default_target,
         })
@@ -181,17 +183,21 @@ impl Router {
 
     /// Resolve a model name to a route.
     ///
-    /// Pass `messages` for auto-routing support (only used when `model == "auto"`).
+    /// Pass `messages` for auto-routing support. Used when `model == "auto"` or
+    /// when `force` mode is enabled.
     pub async fn resolve(
         &self,
         model: &str,
         messages: Option<&[serde_json::Value]>,
     ) -> Result<ResolvedRoute, String> {
-        if model == "auto" {
+        if self.auto_router_force || model == "auto" {
             if let Some(resolved) = self.try_auto_route(messages).await {
                 return Ok(resolved);
             }
-            return self.resolve_target(&self.default_target, model, RoutingMethod::Default);
+            if model == "auto" {
+                return self.resolve_target(&self.default_target, model, RoutingMethod::Default);
+            }
+            // force mode: auto-routing returned nothing, fall through to normal resolution
         }
 
         // Pattern matching (first match wins)
@@ -809,6 +815,75 @@ mod tests {
             }
             Ok(ResolvedRoute::Higgs { .. }) => panic!("expected Remote route"),
             Err(e) => panic!("should resolve to default remote, got error: {e}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn force_mode_falls_through_without_engine() {
+        // force=true, no auto-router engine loaded, named model should
+        // fall through to normal resolution (pattern/direct/default).
+        let config = config_from_toml(
+            r#"
+            [provider.anthropic]
+            url = "https://api.anthropic.com"
+            format = "anthropic"
+
+            [[routes]]
+            pattern = "opus"
+            provider = "anthropic"
+
+            [default]
+            provider = "anthropic"
+
+            [auto_router]
+            enabled = false
+            force = true
+            "#,
+        );
+        let router = Router::from_config(&config, HashMap::new()).unwrap();
+        let result = router.resolve("claude-opus-4-6", None).await.unwrap();
+        match result {
+            ResolvedRoute::Remote {
+                provider_name,
+                routing_method,
+                ..
+            } => {
+                assert_eq!(provider_name, "anthropic");
+                assert_eq!(routing_method, RoutingMethod::Pattern);
+            }
+            ResolvedRoute::Higgs { .. } => panic!("expected Remote route"),
+        }
+    }
+
+    #[tokio::test]
+    async fn force_mode_unmatched_falls_to_default() {
+        // force=true, no auto-router engine, unmatched model falls to default
+        let config = config_from_toml(
+            r#"
+            [provider.anthropic]
+            url = "https://api.anthropic.com"
+            format = "anthropic"
+
+            [default]
+            provider = "anthropic"
+
+            [auto_router]
+            enabled = false
+            force = true
+            "#,
+        );
+        let router = Router::from_config(&config, HashMap::new()).unwrap();
+        let result = router.resolve("some-unknown-model", None).await.unwrap();
+        match result {
+            ResolvedRoute::Remote {
+                provider_name,
+                routing_method,
+                ..
+            } => {
+                assert_eq!(provider_name, "anthropic");
+                assert_eq!(routing_method, RoutingMethod::Default);
+            }
+            ResolvedRoute::Higgs { .. } => panic!("expected Remote route"),
         }
     }
 }

--- a/crates/higgs/src/routes/anthropic.rs
+++ b/crates/higgs/src/routes/anthropic.rs
@@ -45,9 +45,16 @@ pub async fn create_message(
         ));
     }
 
+    let messages_json = serde_json::to_value(&req.messages).ok().and_then(|v| {
+        if let serde_json::Value::Array(a) = v {
+            Some(a)
+        } else {
+            None
+        }
+    });
     let resolved = state
         .router
-        .resolve(&req.model, None)
+        .resolve(&req.model, messages_json.as_deref())
         .await
         .map_err(ServerError::ModelNotFound)?;
 
@@ -419,9 +426,16 @@ pub async fn count_tokens(
     let req: CountTokensRequest = serde_json::from_slice(&body)
         .map_err(|e| ServerError::BadRequest(format!("Invalid request body: {e}")))?;
 
+    let messages_json = serde_json::to_value(&req.messages).ok().and_then(|v| {
+        if let serde_json::Value::Array(a) = v {
+            Some(a)
+        } else {
+            None
+        }
+    });
     let resolved = state
         .router
-        .resolve(&req.model, None)
+        .resolve(&req.model, messages_json.as_deref())
         .await
         .map_err(ServerError::ModelNotFound)?;
 

--- a/crates/higgs/src/routes/anthropic.rs
+++ b/crates/higgs/src/routes/anthropic.rs
@@ -129,32 +129,36 @@ pub async fn create_message(
                         translated
                     };
 
-                    if is_streaming {
-                        let upstream = crate::proxy::send_to_provider(
-                            &state.http_client,
-                            &provider_url,
-                            "/v1/chat/completions",
-                            proxy_body,
-                            &headers,
-                            strip_auth,
-                            api_key.as_deref(),
+                    let upstream = crate::proxy::send_to_provider(
+                        &state.http_client,
+                        &provider_url,
+                        "/v1/chat/completions",
+                        proxy_body,
+                        &headers,
+                        strip_auth,
+                        api_key.as_deref(),
+                    )
+                    .await?;
+                    let upstream_status = upstream.status().as_u16();
+
+                    if upstream_status >= 400 {
+                        let status_code = axum::http::StatusCode::from_u16(upstream_status)
+                            .unwrap_or(axum::http::StatusCode::BAD_GATEWAY);
+                        let resp_bytes = upstream.bytes().await.map_err(|e| {
+                            ServerError::ProxyError(format!("Failed to read response: {e}"))
+                        })?;
+                        Ok((
+                            status_code,
+                            [(axum::http::header::CONTENT_TYPE, "application/json")],
+                            resp_bytes,
                         )
-                        .await?;
+                            .into_response())
+                    } else if is_streaming {
                         let stream =
                             crate::translate::openai_stream_to_anthropic(upstream, req.model);
                         let sse = Sse::new(stream).keep_alive(KeepAlive::default());
                         Ok(sse.into_response())
                     } else {
-                        let upstream = crate::proxy::send_to_provider(
-                            &state.http_client,
-                            &provider_url,
-                            "/v1/chat/completions",
-                            proxy_body,
-                            &headers,
-                            strip_auth,
-                            api_key.as_deref(),
-                        )
-                        .await?;
                         let resp_bytes = upstream.bytes().await.map_err(|e| {
                             ServerError::ProxyError(format!("Failed to read response: {e}"))
                         })?;

--- a/crates/higgs/src/routes/anthropic.rs
+++ b/crates/higgs/src/routes/anthropic.rs
@@ -1,19 +1,26 @@
 use std::convert::Infallible;
+use std::sync::Arc;
+use std::time::Instant;
 
 use axum::{
     Json,
     extract::State,
+    http::HeaderMap,
     response::{
         IntoResponse, Sse,
         sse::{Event, KeepAlive},
     },
 };
+use bytes::Bytes;
 use tokio_stream::Stream;
 
 use crate::{
     anthropic_adapter::{anthropic_messages_to_engine, openai_finish_to_anthropic_stop},
+    config::ApiFormat,
     error::ServerError,
-    state::SharedState,
+    metrics::MetricsStore,
+    router::ResolvedRoute,
+    state::{Engine, SharedState},
     types::anthropic::{
         AnthropicUsage, ContentBlockDeltaEvent, ContentBlockResponse, ContentBlockStartEvent,
         ContentBlockStartPayload, ContentBlockStopEvent, CountTokensRequest, CountTokensResponse,
@@ -23,34 +30,164 @@ use crate::{
 };
 use higgs_models::SamplingParams;
 
+#[allow(clippy::too_many_lines)]
 pub async fn create_message(
     State(state): State<SharedState>,
-    Json(req): Json<CreateMessageRequest>,
+    headers: HeaderMap,
+    body: Bytes,
 ) -> Result<axum::response::Response, ServerError> {
+    let req: CreateMessageRequest = serde_json::from_slice(&body)
+        .map_err(|e| ServerError::BadRequest(format!("Invalid request body: {e}")))?;
+
     if req.messages.is_empty() {
         return Err(ServerError::BadRequest(
             "messages array must not be empty".to_owned(),
         ));
     }
 
-    if req.stream == Some(true) {
-        let stream = create_message_stream(state, req)?;
-        let sse = Sse::new(stream).keep_alive(KeepAlive::default());
-        Ok(sse.into_response())
-    } else {
-        let response = create_message_non_streaming(state, req).await?;
-        Ok(Json(response).into_response())
+    let resolved = state
+        .router
+        .resolve(&req.model, None)
+        .await
+        .map_err(ServerError::ModelNotFound)?;
+
+    match resolved {
+        ResolvedRoute::Higgs {
+            engine,
+            routing_method,
+            ..
+        } => {
+            let start = Instant::now();
+            if req.stream == Some(true) {
+                let stream =
+                    create_message_stream(req, engine, state.metrics.clone(), routing_method)?;
+                let sse = Sse::new(stream).keep_alive(KeepAlive::default());
+                Ok(sse.into_response())
+            } else {
+                let response = create_message_non_streaming(req, engine).await?;
+                if let Some(ref metrics) = state.metrics {
+                    metrics.record(crate::metrics::RequestRecord {
+                        id: 0,
+                        timestamp: Instant::now(),
+                        wallclock: chrono::Utc::now(),
+                        model: response.model.clone(),
+                        provider: "higgs".to_owned(),
+                        routing_method: routing_method.into(),
+                        status: 200,
+                        duration: start.elapsed(),
+                        input_tokens: u64::from(response.usage.input_tokens),
+                        output_tokens: u64::from(response.usage.output_tokens),
+                        error_body: None,
+                    });
+                }
+                Ok(Json(response).into_response())
+            }
+        }
+        ResolvedRoute::Remote {
+            provider_name,
+            provider_url,
+            provider_format,
+            strip_auth,
+            api_key,
+            model_rewrite,
+            routing_method,
+            ..
+        } => {
+            let start = Instant::now();
+            let model_name = req.model.clone();
+            let is_streaming = req.stream == Some(true);
+            let result = match provider_format {
+                ApiFormat::Anthropic => {
+                    let proxy_body = if let Some(ref rewrite) = model_rewrite {
+                        crate::proxy::rewrite_model_in_body(&body, rewrite)?
+                    } else {
+                        body
+                    };
+                    crate::proxy::proxy_request(
+                        &state.http_client,
+                        &provider_url,
+                        "/v1/messages",
+                        proxy_body,
+                        &headers,
+                        strip_auth,
+                        api_key.as_deref(),
+                    )
+                    .await
+                }
+                ApiFormat::OpenAi => {
+                    let translated = crate::translate::anthropic_to_openai_request(&body)?;
+                    let proxy_body = if let Some(ref rewrite) = model_rewrite {
+                        crate::proxy::rewrite_model_in_body(&translated, rewrite)?
+                    } else {
+                        translated
+                    };
+
+                    if is_streaming {
+                        let upstream = crate::proxy::send_to_provider(
+                            &state.http_client,
+                            &provider_url,
+                            "/v1/chat/completions",
+                            proxy_body,
+                            &headers,
+                            strip_auth,
+                            api_key.as_deref(),
+                        )
+                        .await?;
+                        let stream =
+                            crate::translate::openai_stream_to_anthropic(upstream, req.model);
+                        let sse = Sse::new(stream).keep_alive(KeepAlive::default());
+                        Ok(sse.into_response())
+                    } else {
+                        let upstream = crate::proxy::send_to_provider(
+                            &state.http_client,
+                            &provider_url,
+                            "/v1/chat/completions",
+                            proxy_body,
+                            &headers,
+                            strip_auth,
+                            api_key.as_deref(),
+                        )
+                        .await?;
+                        let resp_bytes = upstream.bytes().await.map_err(|e| {
+                            ServerError::ProxyError(format!("Failed to read response: {e}"))
+                        })?;
+                        let translated_resp = crate::translate::openai_response_to_anthropic(
+                            &resp_bytes,
+                            &req.model,
+                        )?;
+                        Ok((
+                            [(axum::http::header::CONTENT_TYPE, "application/json")],
+                            translated_resp,
+                        )
+                            .into_response())
+                    }
+                }
+            };
+            if let Some(ref metrics) = state.metrics {
+                let status = result.as_ref().map_or(502, |resp| resp.status().as_u16());
+                metrics.record(crate::metrics::RequestRecord {
+                    id: 0,
+                    timestamp: Instant::now(),
+                    wallclock: chrono::Utc::now(),
+                    model: model_name,
+                    provider: provider_name,
+                    routing_method: routing_method.into(),
+                    status,
+                    duration: start.elapsed(),
+                    input_tokens: 0,
+                    output_tokens: 0,
+                    error_body: None,
+                });
+            }
+            result
+        }
     }
 }
 
 async fn create_message_non_streaming(
-    state: SharedState,
     req: CreateMessageRequest,
+    engine: Arc<Engine>,
 ) -> Result<CreateMessageResponse, ServerError> {
-    let engine = state
-        .engine_for(&req.model)
-        .ok_or_else(|| ServerError::ModelNotFound(req.model.clone()))?;
-
     let max_tokens = req.max_tokens;
     let sampling = SamplingParams {
         temperature: req.temperature.unwrap_or(1.0),
@@ -105,13 +242,11 @@ async fn create_message_non_streaming(
 
 #[allow(clippy::too_many_lines, clippy::needless_pass_by_value)]
 fn create_message_stream(
-    state: SharedState,
     req: CreateMessageRequest,
+    engine: Arc<Engine>,
+    metrics: Option<Arc<MetricsStore>>,
+    routing_method: crate::router::RoutingMethod,
 ) -> Result<impl Stream<Item = Result<Event, Infallible>>, ServerError> {
-    let engine = state
-        .engine_for(&req.model)
-        .ok_or_else(|| ServerError::ModelNotFound(req.model.clone()))?;
-
     let max_tokens = req.max_tokens;
     let sampling = SamplingParams {
         temperature: req.temperature.unwrap_or(1.0),
@@ -151,6 +286,23 @@ fn create_message_stream(
         if let Err(e) = result {
             tracing::error!(error = %e, "Generation error during Anthropic streaming");
         }
+    });
+
+    let start = Instant::now();
+    let metrics_id = metrics.as_ref().map(|m| {
+        m.record_pending(crate::metrics::RequestRecord {
+            id: 0,
+            timestamp: Instant::now(),
+            wallclock: chrono::Utc::now(),
+            model: model.clone(),
+            provider: "higgs".to_owned(),
+            routing_method: routing_method.into(),
+            status: 200,
+            duration: std::time::Duration::ZERO,
+            input_tokens: u64::from(prompt_token_count),
+            output_tokens: 0,
+            error_body: None,
+        })
     });
 
     let stream = async_stream::stream! {
@@ -214,6 +366,12 @@ fn create_message_stream(
             }
         }
 
+        if let Some(ref m) = metrics {
+            if let Some(id) = metrics_id {
+                m.finalize_stream(id, u64::from(total_output_tokens), start.elapsed());
+            }
+        }
+
         // 4. content_block_stop
         let block_stop = ContentBlockStopEvent {
             event_type: "content_block_stop",
@@ -255,23 +413,64 @@ fn create_message_stream(
 
 pub async fn count_tokens(
     State(state): State<SharedState>,
-    Json(req): Json<CountTokensRequest>,
-) -> Result<Json<CountTokensResponse>, ServerError> {
-    let engine = state
-        .engine_for(&req.model)
-        .ok_or_else(|| ServerError::ModelNotFound(req.model.clone()))?;
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<axum::response::Response, ServerError> {
+    let req: CountTokensRequest = serde_json::from_slice(&body)
+        .map_err(|e| ServerError::BadRequest(format!("Invalid request body: {e}")))?;
 
-    let engine_messages = anthropic_messages_to_engine(&req.messages, req.system.as_deref());
-    let tools = req.tools.as_deref();
+    let resolved = state
+        .router
+        .resolve(&req.model, None)
+        .await
+        .map_err(ServerError::ModelNotFound)?;
 
-    let tokens = engine
-        .prepare_chat_prompt(&engine_messages, tools)
-        .map_err(ServerError::Engine)?;
+    match resolved {
+        ResolvedRoute::Higgs { engine, .. } => {
+            let engine_messages =
+                anthropic_messages_to_engine(&req.messages, req.system.as_deref());
+            let tools = req.tools.as_deref();
 
-    let count = u32::try_from(tokens.len())
-        .map_err(|_| ServerError::BadRequest("Token count overflow".to_owned()))?;
+            let tokens = engine
+                .prepare_chat_prompt(&engine_messages, tools)
+                .map_err(ServerError::Engine)?;
 
-    Ok(Json(CountTokensResponse {
-        input_tokens: count,
-    }))
+            let count = u32::try_from(tokens.len())
+                .map_err(|_| ServerError::BadRequest("Token count overflow".to_owned()))?;
+
+            Ok(Json(CountTokensResponse {
+                input_tokens: count,
+            })
+            .into_response())
+        }
+        ResolvedRoute::Remote {
+            stub_count_tokens,
+            provider_url,
+            provider_format,
+            strip_auth,
+            api_key,
+            model_rewrite,
+            ..
+        } => {
+            if stub_count_tokens || provider_format != ApiFormat::Anthropic {
+                // OpenAI providers have no count_tokens equivalent; return stub
+                return Ok(crate::proxy::stub_count_tokens_response());
+            }
+            let proxy_body = if let Some(ref rewrite) = model_rewrite {
+                crate::proxy::rewrite_model_in_body(&body, rewrite)?
+            } else {
+                body
+            };
+            crate::proxy::proxy_request(
+                &state.http_client,
+                &provider_url,
+                "/v1/messages/count_tokens",
+                proxy_body,
+                &headers,
+                strip_auth,
+                api_key.as_deref(),
+            )
+            .await
+        }
+    }
 }

--- a/crates/higgs/src/routes/chat.rs
+++ b/crates/higgs/src/routes/chat.rs
@@ -127,7 +127,7 @@ pub async fn chat_completions(
                             model: request_model,
                             provider: provider_name.clone(),
                             routing_method: routing_method.into(),
-                            status: if result.is_ok() { 200 } else { 502 },
+                            status: result.as_ref().map_or(502, |resp| resp.status().as_u16()),
                             duration: start.elapsed(),
                             input_tokens: 0,
                             output_tokens: 0,
@@ -174,6 +174,7 @@ pub async fn chat_completions(
                             api_key.as_deref(),
                         )
                         .await?;
+                        let upstream_status = upstream.status().as_u16();
                         let resp_bytes = upstream.bytes().await.map_err(|e| {
                             ServerError::ProxyError(format!("Failed to read response: {e}"))
                         })?;
@@ -189,7 +190,7 @@ pub async fn chat_completions(
                                 model: request_model,
                                 provider: provider_name.clone(),
                                 routing_method: routing_method.into(),
-                                status: 200,
+                                status: upstream_status,
                                 duration: start.elapsed(),
                                 input_tokens: 0,
                                 output_tokens: 0,

--- a/crates/higgs/src/routes/chat.rs
+++ b/crates/higgs/src/routes/chat.rs
@@ -183,6 +183,19 @@ pub async fn chat_completions(
                                 error_body: None,
                             });
                         }
+                        if upstream_status >= 400 {
+                            let status_code = axum::http::StatusCode::from_u16(upstream_status)
+                                .unwrap_or(axum::http::StatusCode::BAD_GATEWAY);
+                            let resp_bytes = upstream.bytes().await.map_err(|e| {
+                                ServerError::ProxyError(format!("Failed to read response: {e}"))
+                            })?;
+                            return Ok((
+                                status_code,
+                                [(axum::http::header::CONTENT_TYPE, "application/json")],
+                                resp_bytes,
+                            )
+                                .into_response());
+                        }
                         let stream =
                             crate::translate::anthropic_stream_to_openai(upstream, req.model);
                         let sse = Sse::new(stream).keep_alive(KeepAlive::default());

--- a/crates/higgs/src/routes/chat.rs
+++ b/crates/higgs/src/routes/chat.rs
@@ -44,9 +44,16 @@ pub async fn chat_completions(
         ));
     }
 
+    let messages_json = serde_json::to_value(&req.messages).ok().and_then(|v| {
+        if let serde_json::Value::Array(a) = v {
+            Some(a)
+        } else {
+            None
+        }
+    });
     let resolved = state
         .router
-        .resolve(&req.model, None)
+        .resolve(&req.model, messages_json.as_deref())
         .await
         .map_err(ServerError::ModelNotFound)?;
 

--- a/crates/higgs/src/routes/chat.rs
+++ b/crates/higgs/src/routes/chat.rs
@@ -1,18 +1,25 @@
 use std::convert::Infallible;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use axum::{
     Json,
     extract::State,
+    http::HeaderMap,
     response::{
         IntoResponse, Sse,
         sse::{Event, KeepAlive},
     },
 };
+use bytes::Bytes;
 use tokio_stream::Stream;
 
 use crate::{
+    config::ApiFormat,
     error::ServerError,
-    state::SharedState,
+    metrics::{MetricsStore, RequestRecord},
+    router::ResolvedRoute,
+    state::{Engine, SharedState},
     types::openai::{
         ChatCompletionChoice, ChatCompletionChunk, ChatCompletionChunkChoice, ChatCompletionDelta,
         ChatCompletionMessage, ChatCompletionRequest, ChatCompletionResponse, ChoiceLogprobs,
@@ -22,23 +29,182 @@ use crate::{
 };
 use higgs_models::SamplingParams;
 
+#[allow(clippy::too_many_lines)]
 pub async fn chat_completions(
     State(state): State<SharedState>,
-    Json(req): Json<ChatCompletionRequest>,
+    headers: HeaderMap,
+    body: Bytes,
 ) -> Result<axum::response::Response, ServerError> {
+    let req: ChatCompletionRequest = serde_json::from_slice(&body)
+        .map_err(|e| ServerError::BadRequest(format!("Invalid request body: {e}")))?;
+
     if req.messages.is_empty() {
         return Err(ServerError::BadRequest(
             "messages array must not be empty".to_owned(),
         ));
     }
 
-    if req.stream == Some(true) {
-        let stream = chat_completions_stream(state, req)?;
-        let sse = Sse::new(stream).keep_alive(KeepAlive::default());
-        Ok(sse.into_response())
-    } else {
-        let response = chat_completions_non_streaming(state, req).await?;
-        Ok(Json(response).into_response())
+    let resolved = state
+        .router
+        .resolve(&req.model, None)
+        .await
+        .map_err(ServerError::ModelNotFound)?;
+
+    let request_model = req.model.clone();
+
+    match resolved {
+        ResolvedRoute::Higgs {
+            engine,
+            routing_method,
+            ..
+        } => {
+            if req.stream == Some(true) {
+                let stream = chat_completions_stream(
+                    Arc::clone(&state),
+                    req,
+                    engine,
+                    state.metrics.clone(),
+                    routing_method,
+                )?;
+                let sse = Sse::new(stream).keep_alive(KeepAlive::default());
+                Ok(sse.into_response())
+            } else {
+                let start = Instant::now();
+                let response =
+                    chat_completions_non_streaming(Arc::clone(&state), req, engine).await?;
+                if let Some(ref metrics) = state.metrics {
+                    metrics.record(RequestRecord {
+                        id: 0,
+                        timestamp: Instant::now(),
+                        wallclock: chrono::Utc::now(),
+                        model: response.model.clone(),
+                        provider: "higgs".to_owned(),
+                        routing_method: routing_method.into(),
+                        status: 200,
+                        duration: start.elapsed(),
+                        input_tokens: u64::from(response.usage.prompt_tokens),
+                        output_tokens: u64::from(response.usage.completion_tokens),
+                        error_body: None,
+                    });
+                }
+                Ok(Json(response).into_response())
+            }
+        }
+        ResolvedRoute::Remote {
+            provider_name,
+            provider_url,
+            provider_format,
+            strip_auth,
+            api_key,
+            model_rewrite,
+            routing_method,
+            ..
+        } => {
+            let is_streaming = req.stream == Some(true);
+            match provider_format {
+                ApiFormat::OpenAi => {
+                    let proxy_body = if let Some(ref rewrite) = model_rewrite {
+                        crate::proxy::rewrite_model_in_body(&body, rewrite)?
+                    } else {
+                        body
+                    };
+                    let start = Instant::now();
+                    let result = crate::proxy::proxy_request(
+                        &state.http_client,
+                        &provider_url,
+                        "/v1/chat/completions",
+                        proxy_body,
+                        &headers,
+                        strip_auth,
+                        api_key.as_deref(),
+                    )
+                    .await;
+                    if let Some(ref metrics) = state.metrics {
+                        metrics.record(RequestRecord {
+                            id: 0,
+                            timestamp: Instant::now(),
+                            wallclock: chrono::Utc::now(),
+                            model: request_model,
+                            provider: provider_name.clone(),
+                            routing_method: routing_method.into(),
+                            status: if result.is_ok() { 200 } else { 502 },
+                            duration: start.elapsed(),
+                            input_tokens: 0,
+                            output_tokens: 0,
+                            error_body: None,
+                        });
+                    }
+                    result
+                }
+                ApiFormat::Anthropic => {
+                    let translated = crate::translate::openai_to_anthropic_request(
+                        &body,
+                        state.config.server.max_tokens,
+                    )?;
+                    let proxy_body = if let Some(ref rewrite) = model_rewrite {
+                        crate::proxy::rewrite_model_in_body(&translated, rewrite)?
+                    } else {
+                        translated
+                    };
+
+                    if is_streaming {
+                        let upstream = crate::proxy::send_to_provider(
+                            &state.http_client,
+                            &provider_url,
+                            "/v1/messages",
+                            proxy_body,
+                            &headers,
+                            strip_auth,
+                            api_key.as_deref(),
+                        )
+                        .await?;
+                        let stream =
+                            crate::translate::anthropic_stream_to_openai(upstream, req.model);
+                        let sse = Sse::new(stream).keep_alive(KeepAlive::default());
+                        Ok(sse.into_response())
+                    } else {
+                        let start = Instant::now();
+                        let upstream = crate::proxy::send_to_provider(
+                            &state.http_client,
+                            &provider_url,
+                            "/v1/messages",
+                            proxy_body,
+                            &headers,
+                            strip_auth,
+                            api_key.as_deref(),
+                        )
+                        .await?;
+                        let resp_bytes = upstream.bytes().await.map_err(|e| {
+                            ServerError::ProxyError(format!("Failed to read response: {e}"))
+                        })?;
+                        let translated_resp = crate::translate::anthropic_response_to_openai(
+                            &resp_bytes,
+                            &req.model,
+                        )?;
+                        if let Some(ref metrics) = state.metrics {
+                            metrics.record(RequestRecord {
+                                id: 0,
+                                timestamp: Instant::now(),
+                                wallclock: chrono::Utc::now(),
+                                model: request_model,
+                                provider: provider_name.clone(),
+                                routing_method: routing_method.into(),
+                                status: 200,
+                                duration: start.elapsed(),
+                                input_tokens: 0,
+                                output_tokens: 0,
+                                error_body: None,
+                            });
+                        }
+                        Ok((
+                            [(axum::http::header::CONTENT_TYPE, "application/json")],
+                            translated_resp,
+                        )
+                            .into_response())
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -46,12 +212,9 @@ pub async fn chat_completions(
 async fn chat_completions_non_streaming(
     state: SharedState,
     req: ChatCompletionRequest,
+    engine: Arc<Engine>,
 ) -> Result<ChatCompletionResponse, ServerError> {
-    let engine = state
-        .engine_for(&req.model)
-        .ok_or_else(|| ServerError::ModelNotFound(req.model.clone()))?;
-
-    let max_tokens = req.max_tokens.unwrap_or(state.config.max_tokens);
+    let max_tokens = req.max_tokens.unwrap_or(state.config.server.max_tokens);
     let sampling = build_sampling_params(&req);
     let stop_sequences = StopSequence::extract(req.stop);
     let want_logprobs = req.logprobs.unwrap_or(false);
@@ -191,6 +354,9 @@ async fn chat_completions_non_streaming(
 fn chat_completions_stream(
     state: SharedState,
     req: ChatCompletionRequest,
+    engine: Arc<Engine>,
+    metrics: Option<Arc<MetricsStore>>,
+    routing_method: crate::router::RoutingMethod,
 ) -> Result<impl Stream<Item = Result<Event, Infallible>>, ServerError> {
     if req.tools.is_some() {
         return Err(ServerError::BadRequest(
@@ -198,11 +364,7 @@ fn chat_completions_stream(
         ));
     }
 
-    let engine = state
-        .engine_for(&req.model)
-        .ok_or_else(|| ServerError::ModelNotFound(req.model.clone()))?;
-
-    let max_tokens = req.max_tokens.unwrap_or(state.config.max_tokens);
+    let max_tokens = req.max_tokens.unwrap_or(state.config.server.max_tokens);
     let sampling = build_sampling_params(&req);
     let stop_sequences = StopSequence::extract(req.stop);
     let want_logprobs = req.logprobs.unwrap_or(false);
@@ -245,6 +407,24 @@ fn chat_completions_stream(
     let request_id = generate_request_id();
     let created = current_unix_timestamp();
     let model = req.model;
+    let prompt_token_count = u32::try_from(prompt_tokens.len()).unwrap_or(0);
+
+    let start = Instant::now();
+    let metrics_id = metrics.as_ref().map(|m| {
+        m.record_pending(RequestRecord {
+            id: 0,
+            timestamp: Instant::now(),
+            wallclock: chrono::Utc::now(),
+            model: model.clone(),
+            provider: "higgs".to_owned(),
+            routing_method: routing_method.into(),
+            status: 200,
+            duration: Duration::ZERO,
+            input_tokens: u64::from(prompt_token_count),
+            output_tokens: 0,
+            error_body: None,
+        })
+    });
 
     let tokenizer = engine.tokenizer().clone();
     let (tx, mut rx) = tokio::sync::mpsc::channel(32);
@@ -291,8 +471,10 @@ fn chat_completions_stream(
         }
 
         let mut reasoning_tracker = higgs_engine::reasoning_parser::StreamingReasoningTracker::new();
+        let mut output_token_count: u32 = 0;
 
         while let Some(output) = rx.recv().await {
+            output_token_count = output.completion_tokens;
             let chunk_logprobs = output
                 .token_logprob
                 .as_ref()
@@ -420,6 +602,12 @@ fn chat_completions_stream(
             match serde_json::to_string(&vis_chunk) {
                 Ok(json) => yield Ok(Event::default().data(json)),
                 Err(e) => tracing::error!(error = %e, "Failed to serialize SSE chunk"),
+            }
+        }
+
+        if let Some(ref m) = metrics {
+            if let Some(id) = metrics_id {
+                m.finalize_stream(id, u64::from(output_token_count), start.elapsed());
             }
         }
 

--- a/crates/higgs/src/routes/chat.rs
+++ b/crates/higgs/src/routes/chat.rs
@@ -147,41 +147,20 @@ pub async fn chat_completions(
                         translated
                     };
 
+                    let start = Instant::now();
+                    let upstream = crate::proxy::send_to_provider(
+                        &state.http_client,
+                        &provider_url,
+                        "/v1/messages",
+                        proxy_body,
+                        &headers,
+                        strip_auth,
+                        api_key.as_deref(),
+                    )
+                    .await?;
+                    let upstream_status = upstream.status().as_u16();
+
                     if is_streaming {
-                        let upstream = crate::proxy::send_to_provider(
-                            &state.http_client,
-                            &provider_url,
-                            "/v1/messages",
-                            proxy_body,
-                            &headers,
-                            strip_auth,
-                            api_key.as_deref(),
-                        )
-                        .await?;
-                        let stream =
-                            crate::translate::anthropic_stream_to_openai(upstream, req.model);
-                        let sse = Sse::new(stream).keep_alive(KeepAlive::default());
-                        Ok(sse.into_response())
-                    } else {
-                        let start = Instant::now();
-                        let upstream = crate::proxy::send_to_provider(
-                            &state.http_client,
-                            &provider_url,
-                            "/v1/messages",
-                            proxy_body,
-                            &headers,
-                            strip_auth,
-                            api_key.as_deref(),
-                        )
-                        .await?;
-                        let upstream_status = upstream.status().as_u16();
-                        let resp_bytes = upstream.bytes().await.map_err(|e| {
-                            ServerError::ProxyError(format!("Failed to read response: {e}"))
-                        })?;
-                        let translated_resp = crate::translate::anthropic_response_to_openai(
-                            &resp_bytes,
-                            &req.model,
-                        )?;
                         if let Some(ref metrics) = state.metrics {
                             metrics.record(RequestRecord {
                                 id: 0,
@@ -197,11 +176,50 @@ pub async fn chat_completions(
                                 error_body: None,
                             });
                         }
-                        Ok((
-                            [(axum::http::header::CONTENT_TYPE, "application/json")],
-                            translated_resp,
-                        )
-                            .into_response())
+                        let stream =
+                            crate::translate::anthropic_stream_to_openai(upstream, req.model);
+                        let sse = Sse::new(stream).keep_alive(KeepAlive::default());
+                        Ok(sse.into_response())
+                    } else {
+                        let resp_bytes = upstream.bytes().await.map_err(|e| {
+                            ServerError::ProxyError(format!("Failed to read response: {e}"))
+                        })?;
+                        if let Some(ref metrics) = state.metrics {
+                            metrics.record(RequestRecord {
+                                id: 0,
+                                timestamp: Instant::now(),
+                                wallclock: chrono::Utc::now(),
+                                model: request_model,
+                                provider: provider_name.clone(),
+                                routing_method: routing_method.into(),
+                                status: upstream_status,
+                                duration: start.elapsed(),
+                                input_tokens: 0,
+                                output_tokens: 0,
+                                error_body: None,
+                            });
+                        }
+                        let status_code = axum::http::StatusCode::from_u16(upstream_status)
+                            .unwrap_or(axum::http::StatusCode::BAD_GATEWAY);
+                        if upstream_status >= 400 {
+                            // Pass through error responses without translation
+                            Ok((
+                                status_code,
+                                [(axum::http::header::CONTENT_TYPE, "application/json")],
+                                resp_bytes,
+                            )
+                                .into_response())
+                        } else {
+                            let translated_resp = crate::translate::anthropic_response_to_openai(
+                                &resp_bytes,
+                                &req.model,
+                            )?;
+                            Ok((
+                                [(axum::http::header::CONTENT_TYPE, "application/json")],
+                                translated_resp,
+                            )
+                                .into_response())
+                        }
                     }
                 }
             }

--- a/crates/higgs/src/routes/completions.rs
+++ b/crates/higgs/src/routes/completions.rs
@@ -1,18 +1,25 @@
 use std::convert::Infallible;
+use std::sync::Arc;
+use std::time::Instant;
 
 use axum::{
     Json,
     extract::State,
+    http::HeaderMap,
     response::{
         IntoResponse, Sse,
         sse::{Event, KeepAlive},
     },
 };
+use bytes::Bytes;
 use tokio_stream::Stream;
 
 use crate::{
+    config::ApiFormat,
     error::ServerError,
-    state::SharedState,
+    metrics::{MetricsStore, RequestRecord},
+    router::ResolvedRoute,
+    state::{Engine, SharedState},
     types::openai::{
         ChoiceLogprobs, CompletionChoice, CompletionChunk, CompletionChunkChoice,
         CompletionRequest, CompletionResponse, CompletionUsage, StopSequence, TokenLogprob,
@@ -21,35 +28,124 @@ use crate::{
 };
 use higgs_models::SamplingParams;
 
+#[allow(clippy::too_many_lines)]
 pub async fn completions(
     State(state): State<SharedState>,
-    Json(req): Json<CompletionRequest>,
+    headers: HeaderMap,
+    body: Bytes,
 ) -> Result<axum::response::Response, ServerError> {
+    let req: CompletionRequest = serde_json::from_slice(&body)
+        .map_err(|e| ServerError::BadRequest(format!("Invalid request body: {e}")))?;
+
     if req.prompt.is_empty() {
         return Err(ServerError::BadRequest(
             "prompt must not be empty".to_owned(),
         ));
     }
 
-    if req.stream == Some(true) {
-        let stream = completions_stream(state, req)?;
-        let sse = Sse::new(stream).keep_alive(KeepAlive::default());
-        Ok(sse.into_response())
-    } else {
-        let response = completions_non_streaming(state, req).await?;
-        Ok(Json(response).into_response())
+    let resolved = state
+        .router
+        .resolve(&req.model, None)
+        .await
+        .map_err(ServerError::ModelNotFound)?;
+
+    match resolved {
+        ResolvedRoute::Higgs {
+            engine,
+            model_name,
+            routing_method,
+        } => {
+            if req.stream == Some(true) {
+                let metrics = state.metrics.clone();
+                let stream = completions_stream(
+                    Arc::clone(&state),
+                    req,
+                    engine,
+                    model_name,
+                    metrics,
+                    routing_method,
+                )?;
+                let sse = Sse::new(stream).keep_alive(KeepAlive::default());
+                Ok(sse.into_response())
+            } else {
+                let start = Instant::now();
+                let response = completions_non_streaming(Arc::clone(&state), req, engine).await?;
+                if let Some(ref metrics) = state.metrics {
+                    metrics.record(RequestRecord {
+                        id: 0,
+                        timestamp: Instant::now(),
+                        wallclock: chrono::Utc::now(),
+                        model: model_name,
+                        provider: "higgs".to_owned(),
+                        routing_method: routing_method.into(),
+                        status: 200,
+                        duration: start.elapsed(),
+                        input_tokens: u64::from(response.usage.prompt_tokens),
+                        output_tokens: u64::from(response.usage.completion_tokens),
+                        error_body: None,
+                    });
+                }
+                Ok(Json(response).into_response())
+            }
+        }
+        ResolvedRoute::Remote {
+            provider_name,
+            provider_url,
+            provider_format,
+            strip_auth,
+            api_key,
+            model_rewrite,
+            routing_method,
+            ..
+        } => {
+            if provider_format != ApiFormat::OpenAi {
+                return Err(ServerError::BadRequest(
+                    "Cross-format proxying not yet supported for /v1/completions".to_owned(),
+                ));
+            }
+            let proxy_body = if let Some(ref rewrite) = model_rewrite {
+                crate::proxy::rewrite_model_in_body(&body, rewrite)?
+            } else {
+                body
+            };
+            let start = Instant::now();
+            let response = crate::proxy::proxy_request(
+                &state.http_client,
+                &provider_url,
+                "/v1/completions",
+                proxy_body,
+                &headers,
+                strip_auth,
+                api_key.as_deref(),
+            )
+            .await;
+            if let Some(ref metrics) = state.metrics {
+                let status = response.as_ref().map_or(502, |resp| resp.status().as_u16());
+                metrics.record(RequestRecord {
+                    id: 0,
+                    timestamp: Instant::now(),
+                    wallclock: chrono::Utc::now(),
+                    model: req.model,
+                    provider: provider_name,
+                    routing_method: routing_method.into(),
+                    status,
+                    duration: start.elapsed(),
+                    input_tokens: 0,
+                    output_tokens: 0,
+                    error_body: None,
+                });
+            }
+            response
+        }
     }
 }
 
 async fn completions_non_streaming(
     state: SharedState,
     req: CompletionRequest,
+    engine: Arc<Engine>,
 ) -> Result<CompletionResponse, ServerError> {
-    let engine = state
-        .engine_for(&req.model)
-        .ok_or_else(|| ServerError::ModelNotFound(req.model.clone()))?;
-
-    let max_tokens = req.max_tokens.unwrap_or(state.config.max_tokens);
+    let max_tokens = req.max_tokens.unwrap_or(state.config.server.max_tokens);
     let sampling = build_sampling_params(&req);
     let stop_sequences = StopSequence::extract(req.stop);
     let want_logprobs = req.logprobs.unwrap_or(false);
@@ -108,12 +204,12 @@ async fn completions_non_streaming(
 fn completions_stream(
     state: SharedState,
     req: CompletionRequest,
+    engine: Arc<Engine>,
+    model_name: String,
+    metrics: Option<Arc<MetricsStore>>,
+    routing_method: crate::router::RoutingMethod,
 ) -> Result<impl Stream<Item = Result<Event, Infallible>>, ServerError> {
-    let engine = state
-        .engine_for(&req.model)
-        .ok_or_else(|| ServerError::ModelNotFound(req.model.clone()))?;
-
-    let max_tokens = req.max_tokens.unwrap_or(state.config.max_tokens);
+    let max_tokens = req.max_tokens.unwrap_or(state.config.server.max_tokens);
     let sampling = build_sampling_params(&req);
     let stop_sequences = StopSequence::extract(req.stop);
     let want_logprobs = req.logprobs.unwrap_or(false);
@@ -124,6 +220,7 @@ fn completions_stream(
         .encode(req.prompt.as_str(), false)
         .map_err(|e| ServerError::BadRequest(format!("Tokenization error: {e}")))?;
     let prompt_tokens = encoding.get_ids().to_vec();
+    let input_token_count = u64::try_from(prompt_tokens.len()).unwrap_or(u64::MAX);
 
     let request_id = format!("cmpl-{}", uuid::Uuid::new_v4());
     let created = chrono::Utc::now().timestamp();
@@ -148,8 +245,27 @@ fn completions_stream(
         }
     });
 
+    let start = Instant::now();
+    let pending_id = metrics.as_ref().map(|m| {
+        m.record_pending(RequestRecord {
+            id: 0,
+            timestamp: Instant::now(),
+            wallclock: chrono::Utc::now(),
+            model: model_name,
+            provider: "higgs".to_owned(),
+            routing_method: routing_method.into(),
+            status: 200,
+            duration: std::time::Duration::ZERO,
+            input_tokens: input_token_count,
+            output_tokens: 0,
+            error_body: None,
+        })
+    });
+
     let stream = async_stream::stream! {
+        let mut output_tokens: u64 = 0;
         while let Some(output) = rx.recv().await {
+            output_tokens = u64::from(output.completion_tokens);
             let chunk = CompletionChunk {
                 id: request_id.clone(),
                 object: "text_completion",
@@ -164,6 +280,12 @@ fn completions_stream(
             match serde_json::to_string(&chunk) {
                 Ok(json) => yield Ok(Event::default().data(json)),
                 Err(e) => tracing::error!(error = %e, "Failed to serialize SSE chunk"),
+            }
+        }
+
+        if let Some(ref m) = metrics {
+            if let Some(id) = pending_id {
+                m.finalize_stream(id, output_tokens, start.elapsed());
             }
         }
 

--- a/crates/higgs/src/routes/embeddings.rs
+++ b/crates/higgs/src/routes/embeddings.rs
@@ -1,74 +1,163 @@
-use axum::{Json, extract::State};
+use std::time::Instant;
+
+use axum::{
+    Json,
+    extract::State,
+    http::HeaderMap,
+    response::{IntoResponse, Response},
+};
+use bytes::Bytes;
 
 use crate::{
+    config::ApiFormat,
     error::ServerError,
+    metrics::RequestRecord,
+    router::ResolvedRoute,
     state::SharedState,
     types::openai::{
         EmbeddingInput, EmbeddingObject, EmbeddingRequest, EmbeddingResponse, EmbeddingUsage,
     },
 };
 
-/// POST /v1/embeddings
-///
-/// Generates embeddings by running a model forward pass to get hidden states,
-/// then mean-pooling across the sequence dimension and L2-normalizing.
+#[allow(clippy::too_many_lines)]
 pub async fn embeddings(
     State(state): State<SharedState>,
-    Json(req): Json<EmbeddingRequest>,
-) -> Result<Json<EmbeddingResponse>, ServerError> {
-    let engine = state
-        .engine_for(&req.model)
-        .ok_or_else(|| ServerError::ModelNotFound(req.model.clone()))?;
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, ServerError> {
+    let req: EmbeddingRequest = serde_json::from_slice(&body)
+        .map_err(|e| ServerError::BadRequest(format!("Invalid request body: {e}")))?;
 
-    let inputs = match &req.input {
-        EmbeddingInput::Single(s) => vec![s.clone()],
-        EmbeddingInput::Multiple(v) => v.clone(),
-    };
+    let resolved = state
+        .router
+        .resolve(&req.model, None)
+        .await
+        .map_err(ServerError::ModelNotFound)?;
 
-    if inputs.is_empty() {
-        return Err(ServerError::BadRequest(
-            "input must not be empty".to_owned(),
-        ));
+    match resolved {
+        ResolvedRoute::Higgs {
+            engine,
+            model_name,
+            routing_method,
+        } => {
+            let inputs = match &req.input {
+                EmbeddingInput::Single(s) => vec![s.clone()],
+                EmbeddingInput::Multiple(v) => v.clone(),
+            };
+
+            if inputs.is_empty() {
+                return Err(ServerError::BadRequest(
+                    "input must not be empty".to_owned(),
+                ));
+            }
+
+            let start = Instant::now();
+            let mut data = Vec::new();
+            let mut total_tokens: u32 = 0;
+
+            for (idx, text) in inputs.iter().enumerate() {
+                let encoding = engine
+                    .tokenizer()
+                    .encode(text.as_str(), false)
+                    .map_err(|e| ServerError::BadRequest(format!("Tokenization error: {e}")))?;
+
+                let token_ids = encoding.get_ids();
+                let token_count: u32 = token_ids
+                    .len()
+                    .try_into()
+                    .map_err(|_| ServerError::BadRequest("Input too long".to_owned()))?;
+                total_tokens = total_tokens.saturating_add(token_count);
+
+                let embedding = engine
+                    .embed(token_ids)
+                    .map_err(|e| ServerError::InternalError(format!("Embedding error: {e}")))?;
+
+                let index: u32 = idx
+                    .try_into()
+                    .map_err(|_| ServerError::BadRequest("Too many inputs".to_owned()))?;
+
+                data.push(EmbeddingObject {
+                    object: "embedding",
+                    embedding,
+                    index,
+                });
+            }
+
+            if let Some(ref metrics) = state.metrics {
+                metrics.record(RequestRecord {
+                    id: 0,
+                    timestamp: Instant::now(),
+                    wallclock: chrono::Utc::now(),
+                    model: model_name,
+                    provider: "higgs".to_owned(),
+                    routing_method: routing_method.into(),
+                    status: 200,
+                    duration: start.elapsed(),
+                    input_tokens: u64::from(total_tokens),
+                    output_tokens: 0,
+                    error_body: None,
+                });
+            }
+
+            Ok(Json(EmbeddingResponse {
+                object: "list",
+                data,
+                model: req.model,
+                usage: EmbeddingUsage {
+                    prompt_tokens: total_tokens,
+                    total_tokens,
+                },
+            })
+            .into_response())
+        }
+        ResolvedRoute::Remote {
+            provider_name,
+            provider_url,
+            provider_format,
+            strip_auth,
+            api_key,
+            model_rewrite,
+            routing_method,
+            ..
+        } => {
+            if provider_format != ApiFormat::OpenAi {
+                return Err(ServerError::BadRequest(
+                    "Embeddings proxy only supported for OpenAI-format providers".to_owned(),
+                ));
+            }
+            let proxy_body = if let Some(ref rewrite) = model_rewrite {
+                crate::proxy::rewrite_model_in_body(&body, rewrite)?
+            } else {
+                body
+            };
+            let start = Instant::now();
+            let response = crate::proxy::proxy_request(
+                &state.http_client,
+                &provider_url,
+                "/v1/embeddings",
+                proxy_body,
+                &headers,
+                strip_auth,
+                api_key.as_deref(),
+            )
+            .await;
+            if let Some(ref metrics) = state.metrics {
+                let status = response.as_ref().map_or(502, |resp| resp.status().as_u16());
+                metrics.record(RequestRecord {
+                    id: 0,
+                    timestamp: Instant::now(),
+                    wallclock: chrono::Utc::now(),
+                    model: req.model,
+                    provider: provider_name,
+                    routing_method: routing_method.into(),
+                    status,
+                    duration: start.elapsed(),
+                    input_tokens: 0,
+                    output_tokens: 0,
+                    error_body: None,
+                });
+            }
+            response
+        }
     }
-
-    let mut data = Vec::new();
-    let mut total_tokens: u32 = 0;
-
-    for (idx, text) in inputs.iter().enumerate() {
-        let encoding = engine
-            .tokenizer()
-            .encode(text.as_str(), false)
-            .map_err(|e| ServerError::BadRequest(format!("Tokenization error: {e}")))?;
-
-        let token_ids = encoding.get_ids();
-        let token_count: u32 = token_ids
-            .len()
-            .try_into()
-            .map_err(|_| ServerError::BadRequest("Input too long".to_owned()))?;
-        total_tokens = total_tokens.saturating_add(token_count);
-
-        let embedding = engine
-            .embed(token_ids)
-            .map_err(|e| ServerError::InternalError(format!("Embedding error: {e}")))?;
-
-        let index: u32 = idx
-            .try_into()
-            .map_err(|_| ServerError::BadRequest("Too many inputs".to_owned()))?;
-
-        data.push(EmbeddingObject {
-            object: "embedding",
-            embedding,
-            index,
-        });
-    }
-
-    Ok(Json(EmbeddingResponse {
-        object: "list",
-        data,
-        model: req.model,
-        usage: EmbeddingUsage {
-            prompt_tokens: total_tokens,
-            total_tokens,
-        },
-    }))
 }

--- a/crates/higgs/src/routes/models.rs
+++ b/crates/higgs/src/routes/models.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 pub async fn list_models(State(state): State<SharedState>) -> Json<ModelList> {
-    let data = model_objects_sorted(state.engines.keys().map(String::as_str));
+    let data = model_objects_sorted(state.router.local_engines().keys().map(String::as_str));
     Json(ModelList {
         object: "list",
         data,

--- a/crates/higgs/src/state.rs
+++ b/crates/higgs/src/state.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -11,7 +10,9 @@ use higgs_engine::tokenizers::Tokenizer;
 use higgs_models::SamplingParams;
 use mlx_rs::Array;
 
-use crate::config::ServerConfig;
+use crate::config::HiggsConfig;
+use crate::metrics::MetricsStore;
+use crate::router::Router;
 
 /// Unified engine interface wrapping either the simple (serialized) or batch
 /// (interleaved) engine. Route handlers interact with this enum exclusively.
@@ -174,17 +175,14 @@ impl Engine {
 
 /// Shared application state available to all route handlers.
 pub struct AppState {
-    /// Inference engines keyed by model name, one per loaded model.
-    pub engines: HashMap<String, Arc<Engine>>,
-    /// Server configuration (host, port, etc.).
-    pub config: ServerConfig,
-}
-
-impl AppState {
-    /// Look up an engine by the model name from the request.
-    pub fn engine_for(&self, model: &str) -> Option<Arc<Engine>> {
-        self.engines.get(model).cloned()
-    }
+    /// Routes model names to local engines or remote providers.
+    pub router: Router,
+    /// Full server configuration.
+    pub config: HiggsConfig,
+    /// HTTP client for proxying requests to remote providers.
+    pub http_client: reqwest::Client,
+    /// Request metrics (present in config mode, absent in simple mode).
+    pub metrics: Option<Arc<MetricsStore>>,
 }
 
 /// Type alias for the shared state used by Axum handlers.

--- a/crates/higgs/src/state.rs
+++ b/crates/higgs/src/state.rs
@@ -19,6 +19,8 @@ use crate::router::Router;
 pub enum Engine {
     Simple(Box<SimpleEngine>),
     Batch(Box<BatchEngine>),
+    #[cfg(test)]
+    Stub(String),
 }
 
 impl Engine {
@@ -30,17 +32,27 @@ impl Engine {
         BatchEngine::load(dir).map(|e| Self::Batch(Box::new(e)))
     }
 
+    #[cfg(test)]
+    pub fn test_stub(name: &str) -> Self {
+        Self::Stub(name.to_owned())
+    }
+
     pub fn model_name(&self) -> &str {
         match self {
             Self::Simple(e) => e.model_name(),
             Self::Batch(e) => e.model_name(),
+            #[cfg(test)]
+            Self::Stub(name) => name,
         }
     }
 
+    #[cfg_attr(test, allow(clippy::panic))]
     pub fn tokenizer(&self) -> &Tokenizer {
         match self {
             Self::Simple(e) => e.tokenizer(),
             Self::Batch(e) => e.tokenizer(),
+            #[cfg(test)]
+            Self::Stub(_) => panic!("Engine::test_stub has no tokenizer"),
         }
     }
 
@@ -48,6 +60,8 @@ impl Engine {
         match self {
             Self::Simple(e) => e.eos_token_ids(),
             Self::Batch(e) => e.eos_token_ids(),
+            #[cfg(test)]
+            Self::Stub(_) => &[],
         }
     }
 
@@ -55,6 +69,8 @@ impl Engine {
         match self {
             Self::Simple(e) => e.hidden_size(),
             Self::Batch(e) => e.hidden_size(),
+            #[cfg(test)]
+            Self::Stub(_) => 0,
         }
     }
 
@@ -62,6 +78,8 @@ impl Engine {
         match self {
             Self::Simple(e) => e.is_vlm(),
             Self::Batch(_) => false,
+            #[cfg(test)]
+            Self::Stub(_) => false,
         }
     }
 
@@ -69,6 +87,8 @@ impl Engine {
         match self {
             Self::Simple(e) => e.vlm_image_size(),
             Self::Batch(_) => None,
+            #[cfg(test)]
+            Self::Stub(_) => None,
         }
     }
 
@@ -76,6 +96,8 @@ impl Engine {
         match self {
             Self::Simple(e) => e.replace_image_tokens(tokens),
             Self::Batch(_) => {}
+            #[cfg(test)]
+            Self::Stub(_) => {}
         }
     }
 
@@ -87,6 +109,8 @@ impl Engine {
         match self {
             Self::Simple(e) => e.prepare_chat_prompt(messages, tools),
             Self::Batch(e) => e.prepare_chat_prompt(messages, tools),
+            #[cfg(test)]
+            Self::Stub(_) => Ok(Vec::new()),
         }
     }
 
@@ -123,6 +147,8 @@ impl Engine {
                 constraint,
                 pixel_values,
             ),
+            #[cfg(test)]
+            Self::Stub(_) => Err(EngineError::Generation("test stub".to_owned())),
         }
     }
 
@@ -162,6 +188,8 @@ impl Engine {
                 constraint,
                 pixel_values,
             ),
+            #[cfg(test)]
+            Self::Stub(_) => Err(EngineError::Generation("test stub".to_owned())),
         }
     }
 
@@ -169,6 +197,8 @@ impl Engine {
         match self {
             Self::Simple(e) => e.embed(token_ids),
             Self::Batch(e) => e.embed(token_ids),
+            #[cfg(test)]
+            Self::Stub(_) => Ok(Vec::new()),
         }
     }
 }

--- a/crates/higgs/src/translate.rs
+++ b/crates/higgs/src/translate.rs
@@ -532,16 +532,31 @@ pub fn anthropic_stream_to_openai(
         yield Ok(Event::default().data(role_chunk.to_string()));
 
         let mut reader = SseReader::new(upstream);
+        let mut tool_call_index: i64 = -1;
+        let mut in_tool_use = false;
+
         while let Some((event_type, data)) = reader.next_event().await {
             if let Ok(json) = serde_json::from_str::<serde_json::Value>(&data) {
                 match event_type.as_str() {
-                    "content_block_delta" => {
-                        let text = json
-                            .get("delta")
-                            .and_then(|d| d.get("text"))
+                    "content_block_start" => {
+                        let block_type = json
+                            .get("content_block")
+                            .and_then(|b| b.get("type"))
                             .and_then(|t| t.as_str())
                             .unwrap_or("");
-                        if !text.is_empty() {
+                        if block_type == "tool_use" {
+                            in_tool_use = true;
+                            tool_call_index += 1;
+                            let tool_id = json
+                                .get("content_block")
+                                .and_then(|b| b.get("id"))
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("");
+                            let tool_name = json
+                                .get("content_block")
+                                .and_then(|b| b.get("name"))
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("");
                             let chunk = serde_json::json!({
                                 "id": request_id,
                                 "object": "chat.completion.chunk",
@@ -549,12 +564,75 @@ pub fn anthropic_stream_to_openai(
                                 "model": model,
                                 "choices": [{
                                     "index": 0,
-                                    "delta": {"content": text},
+                                    "delta": {
+                                        "tool_calls": [{
+                                            "index": tool_call_index,
+                                            "id": tool_id,
+                                            "type": "function",
+                                            "function": {"name": tool_name, "arguments": ""},
+                                        }]
+                                    },
                                     "finish_reason": null,
                                 }]
                             });
                             yield Ok(Event::default().data(chunk.to_string()));
+                        } else {
+                            in_tool_use = false;
                         }
+                    }
+                    "content_block_delta" => {
+                        let delta = json.get("delta");
+                        let delta_type = delta
+                            .and_then(|d| d.get("type"))
+                            .and_then(|t| t.as_str())
+                            .unwrap_or("");
+                        if delta_type == "input_json_delta" && in_tool_use {
+                            let partial_json = delta
+                                .and_then(|d| d.get("partial_json"))
+                                .and_then(|p| p.as_str())
+                                .unwrap_or("");
+                            if !partial_json.is_empty() {
+                                let chunk = serde_json::json!({
+                                    "id": request_id,
+                                    "object": "chat.completion.chunk",
+                                    "created": created,
+                                    "model": model,
+                                    "choices": [{
+                                        "index": 0,
+                                        "delta": {
+                                            "tool_calls": [{
+                                                "index": tool_call_index,
+                                                "function": {"arguments": partial_json},
+                                            }]
+                                        },
+                                        "finish_reason": null,
+                                    }]
+                                });
+                                yield Ok(Event::default().data(chunk.to_string()));
+                            }
+                        } else {
+                            let text = delta
+                                .and_then(|d| d.get("text"))
+                                .and_then(|t| t.as_str())
+                                .unwrap_or("");
+                            if !text.is_empty() {
+                                let chunk = serde_json::json!({
+                                    "id": request_id,
+                                    "object": "chat.completion.chunk",
+                                    "created": created,
+                                    "model": model,
+                                    "choices": [{
+                                        "index": 0,
+                                        "delta": {"content": text},
+                                        "finish_reason": null,
+                                    }]
+                                });
+                                yield Ok(Event::default().data(chunk.to_string()));
+                            }
+                        }
+                    }
+                    "content_block_stop" => {
+                        in_tool_use = false;
                     }
                     "message_delta" => {
                         let stop_reason = json
@@ -576,7 +654,7 @@ pub fn anthropic_stream_to_openai(
                         });
                         yield Ok(Event::default().data(chunk.to_string()));
                     }
-                    _ => {} // Skip other event types
+                    _ => {}
                 }
             }
         }
@@ -608,7 +686,7 @@ pub fn openai_stream_to_anthropic(
         });
         yield Ok(Event::default().event("message_start").data(start.to_string()));
 
-        // 2. content_block_start
+        // 2. content_block_start for text
         let block_start = serde_json::json!({
             "type": "content_block_start",
             "index": 0,
@@ -618,6 +696,11 @@ pub fn openai_stream_to_anthropic(
 
         let mut reader = SseReader::new(upstream);
         let mut final_stop_reason = None;
+        // Track which tool call indices we've already started (OpenAI index -> Anthropic block index)
+        let mut started_tools: std::collections::HashMap<u64, u64> = std::collections::HashMap::new();
+        // Next Anthropic content block index (0 is text)
+        let mut next_block_index: u64 = 1;
+        let mut has_text = false;
 
         while let Some((_event_type, data)) = reader.next_event().await {
             if data == "[DONE]" {
@@ -635,12 +718,78 @@ pub fn openai_stream_to_anthropic(
                         .and_then(|c| c.as_str())
                     {
                         if !text.is_empty() {
+                            has_text = true;
                             let delta = serde_json::json!({
                                 "type": "content_block_delta",
                                 "index": 0,
                                 "delta": {"type": "text_delta", "text": text},
                             });
                             yield Ok(Event::default().event("content_block_delta").data(delta.to_string()));
+                        }
+                    }
+
+                    // Handle tool_calls deltas
+                    if let Some(tool_calls) = chosen
+                        .get("delta")
+                        .and_then(|d| d.get("tool_calls"))
+                        .and_then(|tc| tc.as_array())
+                    {
+                        for tc in tool_calls {
+                            let tc_index = tc.get("index").and_then(|i| i.as_u64()).unwrap_or(0);
+
+                            if !started_tools.contains_key(&tc_index) {
+                                // Close text block before first tool if we haven't emitted text
+                                if !has_text && next_block_index == 1 {
+                                    let block_stop = serde_json::json!({
+                                        "type": "content_block_stop",
+                                        "index": 0,
+                                    });
+                                    yield Ok(Event::default().event("content_block_stop").data(block_stop.to_string()));
+                                    has_text = true; // prevent double-close
+                                }
+
+                                let block_idx = next_block_index;
+                                next_block_index += 1;
+                                started_tools.insert(tc_index, block_idx);
+
+                                let tool_id = tc.get("id").and_then(|v| v.as_str()).unwrap_or("").to_owned();
+                                let tool_name = tc
+                                    .get("function")
+                                    .and_then(|f| f.get("name"))
+                                    .and_then(|n| n.as_str())
+                                    .unwrap_or("")
+                                    .to_owned();
+
+                                let tool_start = serde_json::json!({
+                                    "type": "content_block_start",
+                                    "index": block_idx,
+                                    "content_block": {
+                                        "type": "tool_use",
+                                        "id": tool_id,
+                                        "name": tool_name,
+                                        "input": {},
+                                    },
+                                });
+                                yield Ok(Event::default().event("content_block_start").data(tool_start.to_string()));
+                            }
+
+                            // Emit argument deltas
+                            if let Some(args) = tc
+                                .get("function")
+                                .and_then(|f| f.get("arguments"))
+                                .and_then(|a| a.as_str())
+                            {
+                                if !args.is_empty() {
+                                    if let Some(&block_idx) = started_tools.get(&tc_index) {
+                                        let delta = serde_json::json!({
+                                            "type": "content_block_delta",
+                                            "index": block_idx,
+                                            "delta": {"type": "input_json_delta", "partial_json": args},
+                                        });
+                                        yield Ok(Event::default().event("content_block_delta").data(delta.to_string()));
+                                    }
+                                }
+                            }
                         }
                     }
 
@@ -654,14 +803,23 @@ pub fn openai_stream_to_anthropic(
             }
         }
 
-        // 4. content_block_stop
+        // Close text block (index 0)
         let block_stop = serde_json::json!({
             "type": "content_block_stop",
             "index": 0,
         });
         yield Ok(Event::default().event("content_block_stop").data(block_stop.to_string()));
 
-        // 5. message_delta
+        // Close any open tool_use blocks
+        for block_idx in started_tools.values() {
+            let tool_stop = serde_json::json!({
+                "type": "content_block_stop",
+                "index": block_idx,
+            });
+            yield Ok(Event::default().event("content_block_stop").data(tool_stop.to_string()));
+        }
+
+        // message_delta
         let msg_delta = serde_json::json!({
             "type": "message_delta",
             "delta": {"stop_reason": final_stop_reason},
@@ -669,7 +827,7 @@ pub fn openai_stream_to_anthropic(
         });
         yield Ok(Event::default().event("message_delta").data(msg_delta.to_string()));
 
-        // 6. message_stop
+        // message_stop
         let msg_stop = serde_json::json!({"type": "message_stop"});
         yield Ok(Event::default().event("message_stop").data(msg_stop.to_string()));
     }

--- a/crates/higgs/src/translate.rs
+++ b/crates/higgs/src/translate.rs
@@ -244,6 +244,13 @@ pub fn anthropic_to_openai_request(body: &[u8]) -> Result<Bytes, ServerError> {
                                 "content": tr.1,
                             }));
                         }
+                        // Preserve any text alongside tool results as a user message
+                        if !text.is_empty() {
+                            openai_messages.push(serde_json::json!({
+                                "role": "user",
+                                "content": text,
+                            }));
+                        }
                     } else if !tool_uses.is_empty() {
                         let mut msg_obj = serde_json::json!({
                             "role": "assistant",
@@ -509,6 +516,7 @@ pub fn openai_response_to_anthropic(body: &[u8], model: &str) -> Result<Bytes, S
 // ---------------------------------------------------------------------------
 
 /// Transform an Anthropic SSE stream into `OpenAI` SSE events.
+#[allow(clippy::too_many_lines)]
 pub fn anthropic_stream_to_openai(
     upstream: reqwest::Response,
     model: String,
@@ -664,6 +672,7 @@ pub fn anthropic_stream_to_openai(
 }
 
 /// Transform an `OpenAI` SSE stream into Anthropic SSE events.
+#[allow(clippy::too_many_lines, clippy::map_entry)]
 pub fn openai_stream_to_anthropic(
     upstream: reqwest::Response,
     model: String,
@@ -701,6 +710,7 @@ pub fn openai_stream_to_anthropic(
         // Next Anthropic content block index (0 is text)
         let mut next_block_index: u64 = 1;
         let mut has_text = false;
+        let mut text_block_closed = false;
 
         while let Some((_event_type, data)) = reader.next_event().await {
             if data == "[DONE]" {
@@ -735,17 +745,17 @@ pub fn openai_stream_to_anthropic(
                         .and_then(|tc| tc.as_array())
                     {
                         for tc in tool_calls {
-                            let tc_index = tc.get("index").and_then(|i| i.as_u64()).unwrap_or(0);
+                            let tc_index = tc.get("index").and_then(serde_json::Value::as_u64).unwrap_or(0);
 
                             if !started_tools.contains_key(&tc_index) {
                                 // Close text block before first tool if we haven't emitted text
-                                if !has_text && next_block_index == 1 {
+                                if !text_block_closed && !has_text && next_block_index == 1 {
                                     let block_stop = serde_json::json!({
                                         "type": "content_block_stop",
                                         "index": 0,
                                     });
                                     yield Ok(Event::default().event("content_block_stop").data(block_stop.to_string()));
-                                    has_text = true; // prevent double-close
+                                    text_block_closed = true;
                                 }
 
                                 let block_idx = next_block_index;
@@ -803,12 +813,14 @@ pub fn openai_stream_to_anthropic(
             }
         }
 
-        // Close text block (index 0)
-        let block_stop = serde_json::json!({
-            "type": "content_block_stop",
-            "index": 0,
-        });
-        yield Ok(Event::default().event("content_block_stop").data(block_stop.to_string()));
+        // Close text block (index 0) if not already closed before tools
+        if !text_block_closed {
+            let block_stop = serde_json::json!({
+                "type": "content_block_stop",
+                "index": 0,
+            });
+            yield Ok(Event::default().event("content_block_stop").data(block_stop.to_string()));
+        }
 
         // Close any open tool_use blocks
         for block_idx in started_tools.values() {
@@ -1119,7 +1131,7 @@ mod tests {
         let resp = serde_json::json!({
             "id": "chatcmpl-abc",
             "object": "chat.completion",
-            "created": 1234567890,
+            "created": 1_234_567_890,
             "model": "gpt-4",
             "choices": [{
                 "index": 0,

--- a/crates/higgs/src/translate.rs
+++ b/crates/higgs/src/translate.rs
@@ -1,0 +1,1058 @@
+//! Cross-format translation between `OpenAI` and Anthropic API formats.
+//!
+//! Used when a request arrives in one format (e.g., `OpenAI` `/v1/chat/completions`)
+//! but routes to a provider that speaks the other format (e.g., Anthropic).
+
+use std::convert::Infallible;
+
+use axum::response::sse::Event;
+use bytes::Bytes;
+
+use crate::error::ServerError;
+
+// ---------------------------------------------------------------------------
+// Finish-reason mapping
+// ---------------------------------------------------------------------------
+
+fn anthropic_stop_to_openai_finish(stop_reason: &str) -> String {
+    match stop_reason {
+        "end_turn" => "stop".to_owned(),
+        "max_tokens" => "length".to_owned(),
+        "tool_use" => "tool_calls".to_owned(),
+        other => other.to_owned(),
+    }
+}
+
+fn openai_finish_to_anthropic_stop(finish_reason: &str) -> String {
+    crate::anthropic_adapter::openai_finish_to_anthropic_stop(finish_reason)
+}
+
+// ---------------------------------------------------------------------------
+// Request translation
+// ---------------------------------------------------------------------------
+
+/// Translate an `OpenAI` `/v1/chat/completions` request body to Anthropic `/v1/messages`.
+#[allow(clippy::too_many_lines)]
+pub fn openai_to_anthropic_request(
+    body: &[u8],
+    default_max_tokens: u32,
+) -> Result<Bytes, ServerError> {
+    let openai: serde_json::Value = serde_json::from_slice(body)
+        .map_err(|e| ServerError::BadRequest(format!("Invalid JSON: {e}")))?;
+
+    let messages = openai
+        .get("messages")
+        .and_then(|m| m.as_array())
+        .ok_or_else(|| ServerError::BadRequest("missing messages array".to_owned()))?;
+
+    // Extract system messages into the `system` field
+    let mut system_parts = Vec::new();
+    let mut anthropic_messages = Vec::new();
+
+    for msg in messages {
+        let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("");
+        match role {
+            "system" => {
+                if let Some(text) = extract_text_content(msg) {
+                    system_parts.push(text);
+                }
+            }
+            "tool" => {
+                // OpenAI tool role -> Anthropic tool_result content block
+                let tool_call_id = msg
+                    .get("tool_call_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_owned();
+                let content = extract_text_content(msg).unwrap_or_default();
+                anthropic_messages.push(serde_json::json!({
+                    "role": "user",
+                    "content": [{
+                        "type": "tool_result",
+                        "tool_use_id": tool_call_id,
+                        "content": content,
+                    }]
+                }));
+            }
+            "assistant" => {
+                let mut blocks = Vec::new();
+                if let Some(text) = extract_text_content(msg) {
+                    if !text.is_empty() {
+                        blocks.push(serde_json::json!({"type": "text", "text": text}));
+                    }
+                }
+                // Convert tool_calls to tool_use blocks
+                if let Some(calls) = msg.get("tool_calls").and_then(|c| c.as_array()) {
+                    for call in calls {
+                        let id = call
+                            .get("id")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_owned();
+                        let name = call
+                            .get("function")
+                            .and_then(|f| f.get("name"))
+                            .and_then(|n| n.as_str())
+                            .unwrap_or("")
+                            .to_owned();
+                        let input = call
+                            .get("function")
+                            .and_then(|f| f.get("arguments"))
+                            .and_then(|a| a.as_str())
+                            .and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok())
+                            .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
+                        blocks.push(serde_json::json!({
+                            "type": "tool_use",
+                            "id": id,
+                            "name": name,
+                            "input": input,
+                        }));
+                    }
+                }
+                if blocks.is_empty() {
+                    blocks.push(serde_json::json!({"type": "text", "text": ""}));
+                }
+                anthropic_messages.push(serde_json::json!({
+                    "role": "assistant",
+                    "content": blocks,
+                }));
+            }
+            _ => {
+                // user or other roles
+                let text = extract_text_content(msg).unwrap_or_default();
+                anthropic_messages.push(serde_json::json!({
+                    "role": role,
+                    "content": text,
+                }));
+            }
+        }
+    }
+
+    let max_tokens = openai
+        .get("max_tokens")
+        .and_then(serde_json::Value::as_u64)
+        .map_or(default_max_tokens, |v| {
+            u32::try_from(v.min(u64::from(u32::MAX))).unwrap_or(default_max_tokens)
+        });
+
+    let mut result = serde_json::json!({
+        "model": openai.get("model").cloned().unwrap_or(serde_json::Value::String(String::new())),
+        "messages": anthropic_messages,
+        "max_tokens": max_tokens,
+    });
+
+    if !system_parts.is_empty() {
+        let system_text = system_parts.join("\n");
+        if let Some(obj) = result.as_object_mut() {
+            obj.insert("system".to_owned(), serde_json::Value::String(system_text));
+        }
+    }
+
+    // Forward compatible fields
+    copy_optional_field(&openai, &mut result, "temperature");
+    copy_optional_field(&openai, &mut result, "top_p");
+    copy_optional_field(&openai, &mut result, "top_k");
+    copy_optional_field(&openai, &mut result, "stream");
+
+    // stop -> stop_sequences
+    if let Some(stop) = openai.get("stop") {
+        let stop_sequences = match stop {
+            serde_json::Value::String(s) => {
+                serde_json::Value::Array(vec![serde_json::Value::String(s.clone())])
+            }
+            serde_json::Value::Array(_) => stop.clone(),
+            serde_json::Value::Null
+            | serde_json::Value::Bool(_)
+            | serde_json::Value::Number(_)
+            | serde_json::Value::Object(_) => serde_json::Value::Null,
+        };
+        if !stop_sequences.is_null() {
+            if let Some(obj) = result.as_object_mut() {
+                obj.insert("stop_sequences".to_owned(), stop_sequences);
+            }
+        }
+    }
+
+    // tools translation (OpenAI -> Anthropic format)
+    if let Some(tools) = openai.get("tools").and_then(|t| t.as_array()) {
+        let anthropic_tools: Vec<serde_json::Value> = tools
+            .iter()
+            .filter_map(|tool| {
+                let func = tool.get("function")?;
+                Some(serde_json::json!({
+                    "name": func.get("name")?,
+                    "description": func.get("description").cloned().unwrap_or(serde_json::Value::String(String::new())),
+                    "input_schema": func.get("parameters").cloned().unwrap_or(serde_json::json!({"type": "object"})),
+                }))
+            })
+            .collect();
+        if !anthropic_tools.is_empty() {
+            if let Some(obj) = result.as_object_mut() {
+                obj.insert(
+                    "tools".to_owned(),
+                    serde_json::Value::Array(anthropic_tools),
+                );
+            }
+        }
+    }
+
+    serde_json::to_vec(&result)
+        .map(Bytes::from)
+        .map_err(|e| ServerError::InternalError(format!("Serialization error: {e}")))
+}
+
+/// Translate an Anthropic `/v1/messages` request body to `OpenAI` `/v1/chat/completions`.
+#[allow(clippy::too_many_lines)]
+pub fn anthropic_to_openai_request(body: &[u8]) -> Result<Bytes, ServerError> {
+    let anthropic: serde_json::Value = serde_json::from_slice(body)
+        .map_err(|e| ServerError::BadRequest(format!("Invalid JSON: {e}")))?;
+
+    let mut openai_messages = Vec::new();
+
+    // system field -> system message
+    if let Some(system) = anthropic.get("system").and_then(|s| s.as_str()) {
+        if !system.is_empty() {
+            openai_messages.push(serde_json::json!({
+                "role": "system",
+                "content": system,
+            }));
+        }
+    }
+
+    if let Some(messages) = anthropic.get("messages").and_then(|m| m.as_array()) {
+        for msg in messages {
+            let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("user");
+
+            match msg.get("content") {
+                Some(serde_json::Value::String(text)) => {
+                    openai_messages.push(serde_json::json!({
+                        "role": role,
+                        "content": text,
+                    }));
+                }
+                Some(serde_json::Value::Array(blocks)) => {
+                    let text = extract_text_from_blocks(blocks);
+                    let tool_uses = extract_tool_uses(blocks);
+                    let tool_results = extract_tool_results(blocks);
+
+                    if !tool_results.is_empty() {
+                        // Each tool result becomes a separate "tool" role message
+                        for tr in &tool_results {
+                            openai_messages.push(serde_json::json!({
+                                "role": "tool",
+                                "tool_call_id": tr.0,
+                                "content": tr.1,
+                            }));
+                        }
+                    } else if !tool_uses.is_empty() {
+                        let mut msg_obj = serde_json::json!({
+                            "role": "assistant",
+                            "tool_calls": tool_uses,
+                        });
+                        if !text.is_empty() {
+                            if let Some(obj) = msg_obj.as_object_mut() {
+                                obj.insert("content".to_owned(), serde_json::Value::String(text));
+                            }
+                        }
+                        openai_messages.push(msg_obj);
+                    } else {
+                        openai_messages.push(serde_json::json!({
+                            "role": role,
+                            "content": text,
+                        }));
+                    }
+                }
+                _ => {
+                    openai_messages.push(serde_json::json!({
+                        "role": role,
+                        "content": "",
+                    }));
+                }
+            }
+        }
+    }
+
+    let mut result = serde_json::json!({
+        "model": anthropic.get("model").cloned().unwrap_or(serde_json::Value::String(String::new())),
+        "messages": openai_messages,
+    });
+
+    copy_optional_field(&anthropic, &mut result, "max_tokens");
+    copy_optional_field(&anthropic, &mut result, "temperature");
+    copy_optional_field(&anthropic, &mut result, "top_p");
+    copy_optional_field(&anthropic, &mut result, "top_k");
+    copy_optional_field(&anthropic, &mut result, "stream");
+
+    // stop_sequences -> stop
+    if let Some(stop_seqs) = anthropic.get("stop_sequences") {
+        if let Some(obj) = result.as_object_mut() {
+            obj.insert("stop".to_owned(), stop_seqs.clone());
+        }
+    }
+
+    // tools translation (Anthropic -> OpenAI format)
+    if let Some(tools) = anthropic.get("tools").and_then(|t| t.as_array()) {
+        let openai_tools: Vec<serde_json::Value> = tools
+            .iter()
+            .map(|tool| {
+                serde_json::json!({
+                    "type": "function",
+                    "function": {
+                        "name": tool.get("name").cloned().unwrap_or(serde_json::Value::String(String::new())),
+                        "description": tool.get("description").cloned().unwrap_or(serde_json::Value::String(String::new())),
+                        "parameters": tool.get("input_schema").cloned().unwrap_or(serde_json::json!({"type": "object"})),
+                    }
+                })
+            })
+            .collect();
+        if !openai_tools.is_empty() {
+            if let Some(obj) = result.as_object_mut() {
+                obj.insert("tools".to_owned(), serde_json::Value::Array(openai_tools));
+            }
+        }
+    }
+
+    serde_json::to_vec(&result)
+        .map(Bytes::from)
+        .map_err(|e| ServerError::InternalError(format!("Serialization error: {e}")))
+}
+
+// ---------------------------------------------------------------------------
+// Non-streaming response translation
+// ---------------------------------------------------------------------------
+
+/// Translate an Anthropic response body to `OpenAI` format.
+pub fn anthropic_response_to_openai(body: &[u8], model: &str) -> Result<Bytes, ServerError> {
+    let resp: serde_json::Value = serde_json::from_slice(body)
+        .map_err(|e| ServerError::ProxyError(format!("Failed to parse upstream response: {e}")))?;
+
+    let id = resp
+        .get("id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("chatcmpl-proxy");
+
+    let content_blocks = resp
+        .get("content")
+        .and_then(|c| c.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    let text = content_blocks
+        .iter()
+        .filter(|b| b.get("type").and_then(|t| t.as_str()) == Some("text"))
+        .filter_map(|b| b.get("text").and_then(|t| t.as_str()))
+        .collect::<Vec<_>>()
+        .join("");
+
+    let stop_reason = resp
+        .get("stop_reason")
+        .and_then(|v| v.as_str())
+        .unwrap_or("stop");
+    let finish_reason = anthropic_stop_to_openai_finish(stop_reason);
+
+    let usage = resp.get("usage");
+    let input_tokens = usage
+        .and_then(|u| u.get("input_tokens"))
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+    let output_tokens = usage
+        .and_then(|u| u.get("output_tokens"))
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+
+    // Extract tool_use blocks into tool_calls
+    let tool_uses: Vec<serde_json::Value> = content_blocks
+        .iter()
+        .filter(|b| b.get("type").and_then(|t| t.as_str()) == Some("tool_use"))
+        .map(|b| {
+            serde_json::json!({
+                "id": b.get("id").cloned().unwrap_or(serde_json::Value::String(String::new())),
+                "type": "function",
+                "function": {
+                    "name": b.get("name").cloned().unwrap_or(serde_json::Value::String(String::new())),
+                    "arguments": b.get("input").map_or(String::new(), std::string::ToString::to_string),
+                }
+            })
+        })
+        .collect();
+
+    let mut message = serde_json::json!({
+        "role": "assistant",
+    });
+    if let Some(obj) = message.as_object_mut() {
+        if !text.is_empty() || tool_uses.is_empty() {
+            obj.insert("content".to_owned(), serde_json::Value::String(text));
+        }
+        if !tool_uses.is_empty() {
+            obj.insert("tool_calls".to_owned(), serde_json::Value::Array(tool_uses));
+        }
+    }
+
+    let final_finish = if message.get("tool_calls").is_some() && finish_reason == "stop" {
+        "tool_calls".to_owned()
+    } else {
+        finish_reason
+    };
+
+    let result = serde_json::json!({
+        "id": id,
+        "object": "chat.completion",
+        "created": chrono::Utc::now().timestamp(),
+        "model": model,
+        "choices": [{
+            "index": 0,
+            "message": message,
+            "finish_reason": final_finish,
+        }],
+        "usage": {
+            "prompt_tokens": input_tokens,
+            "completion_tokens": output_tokens,
+            "total_tokens": input_tokens + output_tokens,
+        }
+    });
+
+    serde_json::to_vec(&result)
+        .map(Bytes::from)
+        .map_err(|e| ServerError::InternalError(format!("Serialization error: {e}")))
+}
+
+/// Translate an `OpenAI` response body to Anthropic format.
+pub fn openai_response_to_anthropic(body: &[u8], model: &str) -> Result<Bytes, ServerError> {
+    let resp: serde_json::Value = serde_json::from_slice(body)
+        .map_err(|e| ServerError::ProxyError(format!("Failed to parse upstream response: {e}")))?;
+
+    let choice = resp
+        .get("choices")
+        .and_then(|c| c.as_array())
+        .and_then(|a| a.first());
+
+    let message = choice.and_then(|c| c.get("message"));
+    let text = message
+        .and_then(|m| m.get("content"))
+        .and_then(|c| c.as_str())
+        .unwrap_or("");
+    let finish_reason = choice
+        .and_then(|c| c.get("finish_reason"))
+        .and_then(|f| f.as_str())
+        .unwrap_or("stop");
+
+    let stop_reason = openai_finish_to_anthropic_stop(finish_reason);
+
+    let usage = resp.get("usage");
+    let input_tokens = usage
+        .and_then(|u| u.get("prompt_tokens"))
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+    let output_tokens = usage
+        .and_then(|u| u.get("completion_tokens"))
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+
+    let mut content = vec![serde_json::json!({
+        "type": "text",
+        "text": text,
+    })];
+
+    // Convert tool_calls to tool_use blocks
+    if let Some(calls) = message
+        .and_then(|m| m.get("tool_calls"))
+        .and_then(|c| c.as_array())
+    {
+        for call in calls {
+            let id = call
+                .get("id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_owned();
+            let name = call
+                .get("function")
+                .and_then(|f| f.get("name"))
+                .and_then(|n| n.as_str())
+                .unwrap_or("")
+                .to_owned();
+            let input = call
+                .get("function")
+                .and_then(|f| f.get("arguments"))
+                .and_then(|a| a.as_str())
+                .and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok())
+                .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
+            content.push(serde_json::json!({
+                "type": "tool_use",
+                "id": id,
+                "name": name,
+                "input": input,
+            }));
+        }
+    }
+
+    let msg_id = format!("msg_{}", uuid::Uuid::new_v4().simple());
+    let result = serde_json::json!({
+        "id": msg_id,
+        "type": "message",
+        "role": "assistant",
+        "content": content,
+        "model": model,
+        "stop_reason": stop_reason,
+        "usage": {
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+        }
+    });
+
+    serde_json::to_vec(&result)
+        .map(Bytes::from)
+        .map_err(|e| ServerError::InternalError(format!("Serialization error: {e}")))
+}
+
+// ---------------------------------------------------------------------------
+// Streaming response translation
+// ---------------------------------------------------------------------------
+
+/// Transform an Anthropic SSE stream into `OpenAI` SSE events.
+pub fn anthropic_stream_to_openai(
+    upstream: reqwest::Response,
+    model: String,
+) -> impl tokio_stream::Stream<Item = Result<Event, Infallible>> {
+    let request_id = format!("chatcmpl-{}", uuid::Uuid::new_v4());
+    let created = chrono::Utc::now().timestamp();
+
+    async_stream::stream! {
+        // Role chunk
+        let role_chunk = serde_json::json!({
+            "id": request_id,
+            "object": "chat.completion.chunk",
+            "created": created,
+            "model": model,
+            "choices": [{
+                "index": 0,
+                "delta": {"role": "assistant"},
+                "finish_reason": null,
+            }]
+        });
+        yield Ok(Event::default().data(role_chunk.to_string()));
+
+        let mut reader = SseReader::new(upstream);
+        while let Some((event_type, data)) = reader.next_event().await {
+            if let Ok(json) = serde_json::from_str::<serde_json::Value>(&data) {
+                match event_type.as_str() {
+                    "content_block_delta" => {
+                        let text = json
+                            .get("delta")
+                            .and_then(|d| d.get("text"))
+                            .and_then(|t| t.as_str())
+                            .unwrap_or("");
+                        if !text.is_empty() {
+                            let chunk = serde_json::json!({
+                                "id": request_id,
+                                "object": "chat.completion.chunk",
+                                "created": created,
+                                "model": model,
+                                "choices": [{
+                                    "index": 0,
+                                    "delta": {"content": text},
+                                    "finish_reason": null,
+                                }]
+                            });
+                            yield Ok(Event::default().data(chunk.to_string()));
+                        }
+                    }
+                    "message_delta" => {
+                        let stop_reason = json
+                            .get("delta")
+                            .and_then(|d| d.get("stop_reason"))
+                            .and_then(|s| s.as_str())
+                            .unwrap_or("end_turn");
+                        let finish = anthropic_stop_to_openai_finish(stop_reason);
+                        let chunk = serde_json::json!({
+                            "id": request_id,
+                            "object": "chat.completion.chunk",
+                            "created": created,
+                            "model": model,
+                            "choices": [{
+                                "index": 0,
+                                "delta": {},
+                                "finish_reason": finish,
+                            }]
+                        });
+                        yield Ok(Event::default().data(chunk.to_string()));
+                    }
+                    _ => {} // Skip other event types
+                }
+            }
+        }
+
+        yield Ok(Event::default().data("[DONE]"));
+    }
+}
+
+/// Transform an `OpenAI` SSE stream into Anthropic SSE events.
+pub fn openai_stream_to_anthropic(
+    upstream: reqwest::Response,
+    model: String,
+) -> impl tokio_stream::Stream<Item = Result<Event, Infallible>> {
+    let msg_id = format!("msg_{}", uuid::Uuid::new_v4().simple());
+
+    async_stream::stream! {
+        // 1. message_start
+        let start = serde_json::json!({
+            "type": "message_start",
+            "message": {
+                "id": msg_id,
+                "type": "message",
+                "role": "assistant",
+                "content": [],
+                "model": model,
+                "stop_reason": null,
+                "usage": {"input_tokens": 0, "output_tokens": 0},
+            }
+        });
+        yield Ok(Event::default().event("message_start").data(start.to_string()));
+
+        // 2. content_block_start
+        let block_start = serde_json::json!({
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "text", "text": ""},
+        });
+        yield Ok(Event::default().event("content_block_start").data(block_start.to_string()));
+
+        let mut reader = SseReader::new(upstream);
+        let mut final_stop_reason = None;
+
+        while let Some((_event_type, data)) = reader.next_event().await {
+            if data == "[DONE]" {
+                break;
+            }
+            if let Ok(json) = serde_json::from_str::<serde_json::Value>(&data) {
+                if let Some(chosen) = json
+                    .get("choices")
+                    .and_then(|c| c.as_array())
+                    .and_then(|a| a.first())
+                {
+                    if let Some(text) = chosen
+                        .get("delta")
+                        .and_then(|d| d.get("content"))
+                        .and_then(|c| c.as_str())
+                    {
+                        if !text.is_empty() {
+                            let delta = serde_json::json!({
+                                "type": "content_block_delta",
+                                "index": 0,
+                                "delta": {"type": "text_delta", "text": text},
+                            });
+                            yield Ok(Event::default().event("content_block_delta").data(delta.to_string()));
+                        }
+                    }
+
+                    if let Some(reason) = chosen
+                        .get("finish_reason")
+                        .and_then(|f| f.as_str())
+                    {
+                        final_stop_reason = Some(openai_finish_to_anthropic_stop(reason));
+                    }
+                }
+            }
+        }
+
+        // 4. content_block_stop
+        let block_stop = serde_json::json!({
+            "type": "content_block_stop",
+            "index": 0,
+        });
+        yield Ok(Event::default().event("content_block_stop").data(block_stop.to_string()));
+
+        // 5. message_delta
+        let msg_delta = serde_json::json!({
+            "type": "message_delta",
+            "delta": {"stop_reason": final_stop_reason},
+            "usage": {"input_tokens": 0, "output_tokens": 0},
+        });
+        yield Ok(Event::default().event("message_delta").data(msg_delta.to_string()));
+
+        // 6. message_stop
+        let msg_stop = serde_json::json!({"type": "message_stop"});
+        yield Ok(Event::default().event("message_stop").data(msg_stop.to_string()));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SSE reader helper
+// ---------------------------------------------------------------------------
+
+/// Minimal SSE parser that reads events from a reqwest byte stream.
+struct SseReader {
+    response: reqwest::Response,
+    buffer: String,
+}
+
+impl SseReader {
+    #[allow(clippy::missing_const_for_fn)]
+    fn new(response: reqwest::Response) -> Self {
+        Self {
+            response,
+            buffer: String::new(),
+        }
+    }
+
+    /// Read the next SSE event, returning (`event_type`, data).
+    async fn next_event(&mut self) -> Option<(String, String)> {
+        loop {
+            // Try to parse a complete event from the buffer
+            if let Some(event) = self.try_parse_event() {
+                return Some(event);
+            }
+            // Read more data
+            match self.response.chunk().await {
+                Ok(Some(chunk)) => {
+                    let text = String::from_utf8_lossy(&chunk);
+                    self.buffer.push_str(&text);
+                }
+                _ => {
+                    // Try one last parse before returning None
+                    return self.try_parse_event();
+                }
+            }
+        }
+    }
+
+    fn try_parse_event(&mut self) -> Option<(String, String)> {
+        // SSE events are separated by double newlines
+        let separator = if self.buffer.contains("\n\n") {
+            "\n\n"
+        } else if self.buffer.contains("\r\n\r\n") {
+            "\r\n\r\n"
+        } else {
+            return None;
+        };
+
+        let split_pos = self.buffer.find(separator)?;
+        let event_text = self.buffer[..split_pos].to_owned();
+        self.buffer = self.buffer[split_pos + separator.len()..].to_owned();
+
+        let mut event_type = String::new();
+        let mut data_parts = Vec::new();
+
+        for line in event_text.lines() {
+            if let Some(value) = line.strip_prefix("event:") {
+                value.trim().clone_into(&mut event_type);
+            } else if let Some(value) = line.strip_prefix("data:") {
+                data_parts.push(value.trim().to_owned());
+            }
+        }
+
+        if data_parts.is_empty() {
+            return None;
+        }
+
+        let data = data_parts.join("\n");
+        if event_type.is_empty() {
+            "message".clone_into(&mut event_type);
+        }
+
+        Some((event_type, data))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn extract_text_content(msg: &serde_json::Value) -> Option<String> {
+    match msg.get("content") {
+        Some(serde_json::Value::String(s)) => Some(s.clone()),
+        Some(serde_json::Value::Array(parts)) => {
+            let text: String = parts
+                .iter()
+                .filter_map(|p| {
+                    if p.get("type").and_then(|t| t.as_str()) == Some("text") {
+                        p.get("text").and_then(|t| t.as_str()).map(str::to_owned)
+                    } else {
+                        None
+                    }
+                })
+                .collect::<String>();
+            Some(text)
+        }
+        _ => None,
+    }
+}
+
+fn extract_text_from_blocks(blocks: &[serde_json::Value]) -> String {
+    blocks
+        .iter()
+        .filter(|b| b.get("type").and_then(|t| t.as_str()) == Some("text"))
+        .filter_map(|b| b.get("text").and_then(|t| t.as_str()))
+        .collect::<Vec<_>>()
+        .join("")
+}
+
+fn extract_tool_uses(blocks: &[serde_json::Value]) -> Vec<serde_json::Value> {
+    blocks
+        .iter()
+        .filter(|b| b.get("type").and_then(|t| t.as_str()) == Some("tool_use"))
+        .map(|b| {
+            serde_json::json!({
+                "id": b.get("id").cloned().unwrap_or(serde_json::Value::String(String::new())),
+                "type": "function",
+                "function": {
+                    "name": b.get("name").cloned().unwrap_or(serde_json::Value::String(String::new())),
+                    "arguments": b.get("input").map_or(String::new(), std::string::ToString::to_string),
+                }
+            })
+        })
+        .collect()
+}
+
+fn extract_tool_results(blocks: &[serde_json::Value]) -> Vec<(String, String)> {
+    blocks
+        .iter()
+        .filter(|b| b.get("type").and_then(|t| t.as_str()) == Some("tool_result"))
+        .filter_map(|b| {
+            let id = b.get("tool_use_id").and_then(|v| v.as_str())?.to_owned();
+            let content = b
+                .get("content")
+                .and_then(|c| c.as_str())
+                .unwrap_or("")
+                .to_owned();
+            Some((id, content))
+        })
+        .collect()
+}
+
+fn copy_optional_field(source: &serde_json::Value, target: &mut serde_json::Value, field: &str) {
+    if let Some(value) = source.get(field) {
+        if !value.is_null() {
+            if let Some(obj) = target.as_object_mut() {
+                obj.insert(field.to_owned(), value.clone());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used, clippy::indexing_slicing)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn openai_to_anthropic_basic_request() {
+        let body = serde_json::json!({
+            "model": "gpt-4",
+            "messages": [
+                {"role": "system", "content": "You are helpful."},
+                {"role": "user", "content": "Hello"}
+            ],
+            "max_tokens": 100
+        });
+        let result = openai_to_anthropic_request(body.to_string().as_bytes(), 1024).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&result).unwrap();
+
+        assert_eq!(parsed["model"], "gpt-4");
+        assert_eq!(parsed["max_tokens"], 100);
+        assert_eq!(parsed["system"], "You are helpful.");
+        assert_eq!(parsed["messages"].as_array().unwrap().len(), 1);
+        assert_eq!(parsed["messages"][0]["role"], "user");
+    }
+
+    #[test]
+    fn openai_to_anthropic_uses_default_max_tokens() {
+        let body = serde_json::json!({
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "Hi"}]
+        });
+        let result = openai_to_anthropic_request(body.to_string().as_bytes(), 4096).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&result).unwrap();
+        assert_eq!(parsed["max_tokens"], 4096);
+    }
+
+    #[test]
+    fn openai_to_anthropic_stop_becomes_stop_sequences() {
+        let body = serde_json::json!({
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "Hi"}],
+            "max_tokens": 100,
+            "stop": ["END", "STOP"]
+        });
+        let result = openai_to_anthropic_request(body.to_string().as_bytes(), 1024).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&result).unwrap();
+        assert_eq!(parsed["stop_sequences"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn openai_to_anthropic_tools_translation() {
+        let body = serde_json::json!({
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "Weather?"}],
+            "max_tokens": 100,
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get weather",
+                    "parameters": {"type": "object", "properties": {"city": {"type": "string"}}}
+                }
+            }]
+        });
+        let result = openai_to_anthropic_request(body.to_string().as_bytes(), 1024).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&result).unwrap();
+        let tools = parsed["tools"].as_array().unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0]["name"], "get_weather");
+        assert!(tools[0].get("input_schema").is_some());
+    }
+
+    #[test]
+    fn anthropic_to_openai_basic_request() {
+        let body = serde_json::json!({
+            "model": "claude-sonnet-4-6",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "system": "Be concise.",
+            "max_tokens": 100
+        });
+        let result = anthropic_to_openai_request(body.to_string().as_bytes()).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&result).unwrap();
+
+        assert_eq!(parsed["model"], "claude-sonnet-4-6");
+        assert_eq!(parsed["max_tokens"], 100);
+        let messages = parsed["messages"].as_array().unwrap();
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0]["role"], "system");
+        assert_eq!(messages[0]["content"], "Be concise.");
+        assert_eq!(messages[1]["role"], "user");
+    }
+
+    #[test]
+    fn anthropic_to_openai_stop_sequences_become_stop() {
+        let body = serde_json::json!({
+            "model": "claude-sonnet-4-6",
+            "messages": [{"role": "user", "content": "Hi"}],
+            "max_tokens": 100,
+            "stop_sequences": ["END"]
+        });
+        let result = anthropic_to_openai_request(body.to_string().as_bytes()).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&result).unwrap();
+        assert!(parsed["stop"].is_array());
+    }
+
+    #[test]
+    fn anthropic_response_to_openai_basic() {
+        let resp = serde_json::json!({
+            "id": "msg_abc",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "Hello!"}],
+            "model": "claude-sonnet-4-6",
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 10, "output_tokens": 5}
+        });
+        let result =
+            anthropic_response_to_openai(resp.to_string().as_bytes(), "claude-sonnet-4-6").unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&result).unwrap();
+
+        assert_eq!(parsed["object"], "chat.completion");
+        assert_eq!(parsed["choices"][0]["message"]["content"], "Hello!");
+        assert_eq!(parsed["choices"][0]["finish_reason"], "stop");
+        assert_eq!(parsed["usage"]["prompt_tokens"], 10);
+        assert_eq!(parsed["usage"]["completion_tokens"], 5);
+    }
+
+    #[test]
+    fn openai_response_to_anthropic_basic() {
+        let resp = serde_json::json!({
+            "id": "chatcmpl-abc",
+            "object": "chat.completion",
+            "created": 1234567890,
+            "model": "gpt-4",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "Hi!"},
+                "finish_reason": "stop"
+            }],
+            "usage": {"prompt_tokens": 8, "completion_tokens": 3, "total_tokens": 11}
+        });
+        let result = openai_response_to_anthropic(resp.to_string().as_bytes(), "gpt-4").unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&result).unwrap();
+
+        assert_eq!(parsed["type"], "message");
+        assert_eq!(parsed["role"], "assistant");
+        assert_eq!(parsed["stop_reason"], "end_turn");
+        assert_eq!(parsed["content"][0]["type"], "text");
+        assert_eq!(parsed["content"][0]["text"], "Hi!");
+        assert_eq!(parsed["usage"]["input_tokens"], 8);
+        assert_eq!(parsed["usage"]["output_tokens"], 3);
+    }
+
+    #[test]
+    fn anthropic_stop_reason_mapping() {
+        assert_eq!(anthropic_stop_to_openai_finish("end_turn"), "stop");
+        assert_eq!(anthropic_stop_to_openai_finish("max_tokens"), "length");
+        assert_eq!(anthropic_stop_to_openai_finish("tool_use"), "tool_calls");
+        assert_eq!(anthropic_stop_to_openai_finish("other"), "other");
+    }
+
+    #[test]
+    fn openai_tool_message_to_anthropic_tool_result() {
+        let body = serde_json::json!({
+            "model": "gpt-4",
+            "messages": [
+                {"role": "user", "content": "Weather?"},
+                {"role": "assistant", "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": "{\"city\":\"NYC\"}"}
+                }]},
+                {"role": "tool", "tool_call_id": "call_1", "content": "72F sunny"}
+            ],
+            "max_tokens": 100
+        });
+        let result = openai_to_anthropic_request(body.to_string().as_bytes(), 1024).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&result).unwrap();
+        let messages = parsed["messages"].as_array().unwrap();
+
+        // user, assistant with tool_use, user with tool_result
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[1]["content"][0]["type"], "tool_use");
+        assert_eq!(messages[2]["content"][0]["type"], "tool_result");
+        assert_eq!(messages[2]["content"][0]["tool_use_id"], "call_1");
+    }
+
+    #[test]
+    fn anthropic_tool_use_to_openai_tool_calls() {
+        let resp = serde_json::json!({
+            "id": "msg_abc",
+            "type": "message",
+            "content": [
+                {"type": "text", "text": "Let me check."},
+                {"type": "tool_use", "id": "tu_1", "name": "get_weather", "input": {"city": "NYC"}}
+            ],
+            "stop_reason": "tool_use",
+            "usage": {"input_tokens": 10, "output_tokens": 5}
+        });
+        let result = anthropic_response_to_openai(resp.to_string().as_bytes(), "claude").unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&result).unwrap();
+
+        assert_eq!(parsed["choices"][0]["finish_reason"], "tool_calls");
+        assert_eq!(parsed["choices"][0]["message"]["content"], "Let me check.");
+        let tool_calls = parsed["choices"][0]["message"]["tool_calls"]
+            .as_array()
+            .unwrap();
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0]["function"]["name"], "get_weather");
+    }
+
+    #[test]
+    fn multiple_system_messages_joined() {
+        let body = serde_json::json!({
+            "model": "gpt-4",
+            "messages": [
+                {"role": "system", "content": "Be helpful."},
+                {"role": "system", "content": "Be concise."},
+                {"role": "user", "content": "Hi"}
+            ],
+            "max_tokens": 100
+        });
+        let result = openai_to_anthropic_request(body.to_string().as_bytes(), 1024).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&result).unwrap();
+        assert_eq!(parsed["system"], "Be helpful.\nBe concise.");
+    }
+}

--- a/crates/higgs/src/tui/mod.rs
+++ b/crates/higgs/src/tui/mod.rs
@@ -1,0 +1,403 @@
+pub mod views;
+
+use std::io;
+use std::sync::Arc;
+use std::time::Duration;
+
+use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
+use ratatui::prelude::*;
+use ratatui::widgets::{Block, Borders, Paragraph, Tabs};
+
+use crate::metrics::MetricsStore;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Tab {
+    Overview,
+    Models,
+    Providers,
+    Errors,
+}
+
+impl Tab {
+    fn titles() -> Vec<&'static str> {
+        vec!["Overview [1]", "Models [2]", "Providers [3]", "Errors [4]"]
+    }
+
+    const fn index(self) -> usize {
+        match self {
+            Self::Overview => 0,
+            Self::Models => 1,
+            Self::Providers => 2,
+            Self::Errors => 3,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExitMode {
+    Quit,
+    Detach,
+}
+
+pub struct App {
+    pub metrics: Arc<MetricsStore>,
+    pub active_tab: Tab,
+    pub scroll_offset: usize,
+    pub exit_mode: Option<ExitMode>,
+    pub attached: bool,
+}
+
+impl App {
+    pub const fn new(metrics: Arc<MetricsStore>, attached: bool) -> Self {
+        Self {
+            metrics,
+            active_tab: Tab::Overview,
+            scroll_offset: 0,
+            exit_mode: None,
+            attached,
+        }
+    }
+
+    pub fn handle_key(&mut self, key: event::KeyEvent) {
+        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
+            self.exit_mode = Some(ExitMode::Quit);
+            return;
+        }
+        match key.code {
+            KeyCode::Char('q') => self.exit_mode = Some(ExitMode::Quit),
+            KeyCode::Char('d') if !self.attached => {
+                self.exit_mode = Some(ExitMode::Detach);
+            }
+            KeyCode::Char('1') => {
+                self.active_tab = Tab::Overview;
+                self.scroll_offset = 0;
+            }
+            KeyCode::Char('2') => {
+                self.active_tab = Tab::Models;
+                self.scroll_offset = 0;
+            }
+            KeyCode::Char('3') => {
+                self.active_tab = Tab::Providers;
+                self.scroll_offset = 0;
+            }
+            KeyCode::Char('4') => {
+                self.active_tab = Tab::Errors;
+                self.scroll_offset = 0;
+            }
+            KeyCode::Tab | KeyCode::Right | KeyCode::Char('l') => {
+                self.active_tab = match self.active_tab {
+                    Tab::Overview => Tab::Models,
+                    Tab::Models => Tab::Providers,
+                    Tab::Providers => Tab::Errors,
+                    Tab::Errors => Tab::Overview,
+                };
+                self.scroll_offset = 0;
+            }
+            KeyCode::Left | KeyCode::Char('h') => {
+                self.active_tab = match self.active_tab {
+                    Tab::Overview => Tab::Errors,
+                    Tab::Models => Tab::Overview,
+                    Tab::Providers => Tab::Models,
+                    Tab::Errors => Tab::Providers,
+                };
+                self.scroll_offset = 0;
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                self.scroll_offset = self.scroll_offset.saturating_add(1);
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.scroll_offset = self.scroll_offset.saturating_sub(1);
+            }
+            KeyCode::Char(_)
+            | KeyCode::Backspace
+            | KeyCode::Enter
+            | KeyCode::Home
+            | KeyCode::End
+            | KeyCode::PageUp
+            | KeyCode::PageDown
+            | KeyCode::Insert
+            | KeyCode::Delete
+            | KeyCode::F(_)
+            | KeyCode::BackTab
+            | KeyCode::CapsLock
+            | KeyCode::ScrollLock
+            | KeyCode::NumLock
+            | KeyCode::PrintScreen
+            | KeyCode::Pause
+            | KeyCode::Menu
+            | KeyCode::KeypadBegin
+            | KeyCode::Null
+            | KeyCode::Esc
+            | KeyCode::Media(_)
+            | KeyCode::Modifier(_) => {}
+        }
+    }
+
+    #[allow(clippy::indexing_slicing)]
+    pub fn draw(&self, frame: &mut Frame) {
+        let title = if self.attached {
+            " higgs (attached) "
+        } else {
+            " higgs "
+        };
+
+        let hint = if self.attached {
+            " q:quit "
+        } else {
+            " q:quit  d:detach "
+        };
+
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(3),
+                Constraint::Min(0),
+                Constraint::Length(1),
+            ])
+            .split(frame.area());
+
+        let tabs = Tabs::new(Tab::titles().into_iter().map(Line::from))
+            .block(Block::default().borders(Borders::ALL).title(title))
+            .select(self.active_tab.index())
+            .highlight_style(
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            );
+        // Layout::split with 3 constraints always returns 3 elements
+        frame.render_widget(tabs, chunks[0]);
+
+        let content_area = chunks[1];
+        match self.active_tab {
+            Tab::Overview => {
+                views::overview::draw(frame, content_area, &self.metrics, self.scroll_offset);
+            }
+            Tab::Models => {
+                views::models::draw(frame, content_area, &self.metrics, self.scroll_offset);
+            }
+            Tab::Providers => {
+                views::providers::draw(frame, content_area, &self.metrics, self.scroll_offset);
+            }
+            Tab::Errors => {
+                views::errors::draw(frame, content_area, &self.metrics, self.scroll_offset);
+            }
+        }
+
+        let footer = Paragraph::new(Line::from(vec![Span::styled(
+            hint,
+            Style::default().fg(Color::DarkGray),
+        )]));
+        frame.render_widget(footer, chunks[2]);
+    }
+}
+
+pub fn run(metrics: Arc<MetricsStore>, attached: bool) -> io::Result<ExitMode> {
+    let mut terminal = ratatui::init();
+
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        ratatui::restore();
+        default_hook(info);
+    }));
+
+    let mut app = App::new(metrics, attached);
+
+    let result = (|| -> io::Result<ExitMode> {
+        loop {
+            terminal.draw(|frame| app.draw(frame))?;
+
+            if event::poll(Duration::from_millis(250))? {
+                match event::read()? {
+                    Event::Key(key) if key.kind == KeyEventKind::Press => {
+                        app.handle_key(key);
+                    }
+                    Event::Resize(_, _) | Event::FocusGained => {
+                        terminal.clear()?;
+                    }
+                    Event::FocusLost | Event::Mouse(_) | Event::Paste(_) | Event::Key(_) => {}
+                }
+            }
+
+            if let Some(mode) = app.exit_mode {
+                return Ok(mode);
+            }
+        }
+    })();
+
+    ratatui::restore();
+    result
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used, clippy::indexing_slicing)]
+mod tests {
+    use super::*;
+
+    fn make_app() -> App {
+        App::new(Arc::new(MetricsStore::new(Duration::from_secs(60))), false)
+    }
+
+    fn make_attached_app() -> App {
+        App::new(Arc::new(MetricsStore::new(Duration::from_secs(60))), true)
+    }
+
+    fn key(code: KeyCode) -> event::KeyEvent {
+        event::KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn ctrl_c() -> event::KeyEvent {
+        event::KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)
+    }
+
+    fn assert_tab_cycle(nav_key: KeyCode, expected: &[Tab]) {
+        let mut app = make_app();
+        for &tab in expected {
+            app.handle_key(key(nav_key));
+            assert_eq!(app.active_tab, tab);
+        }
+    }
+
+    fn assert_nav_resets_scroll(nav_key: KeyCode) {
+        let mut app = make_app();
+        app.handle_key(key(KeyCode::Char('j')));
+        app.handle_key(key(KeyCode::Char('j')));
+        assert_eq!(app.scroll_offset, 2);
+        app.handle_key(key(nav_key));
+        assert_eq!(app.scroll_offset, 0);
+    }
+
+    #[test]
+    fn ctrl_c_quits() {
+        let mut app = make_app();
+        app.handle_key(ctrl_c());
+        assert_eq!(app.exit_mode, Some(ExitMode::Quit));
+    }
+
+    #[test]
+    fn q_quits() {
+        let mut app = make_app();
+        app.handle_key(key(KeyCode::Char('q')));
+        assert_eq!(app.exit_mode, Some(ExitMode::Quit));
+    }
+
+    #[test]
+    fn plain_c_does_not_quit() {
+        let mut app = make_app();
+        app.handle_key(key(KeyCode::Char('c')));
+        assert!(app.exit_mode.is_none());
+    }
+
+    #[test]
+    fn number_keys_switch_tabs() {
+        let mut app = make_app();
+        for (ch, tab) in [
+            ('2', Tab::Models),
+            ('3', Tab::Providers),
+            ('4', Tab::Errors),
+            ('1', Tab::Overview),
+        ] {
+            app.handle_key(key(KeyCode::Char(ch)));
+            assert_eq!(app.active_tab, tab);
+        }
+    }
+
+    #[test]
+    fn number_keys_reset_scroll() {
+        let mut app = make_app();
+        app.handle_key(key(KeyCode::Char('j')));
+        app.handle_key(key(KeyCode::Char('j')));
+        assert_eq!(app.scroll_offset, 2);
+        app.handle_key(key(KeyCode::Char('2')));
+        assert_eq!(app.scroll_offset, 0);
+        app.handle_key(key(KeyCode::Char('j')));
+        app.handle_key(key(KeyCode::Char('1')));
+        assert_eq!(app.scroll_offset, 0);
+    }
+
+    #[test]
+    fn tab_cycles_through_tabs() {
+        assert_tab_cycle(
+            KeyCode::Tab,
+            &[Tab::Models, Tab::Providers, Tab::Errors, Tab::Overview],
+        );
+    }
+
+    #[test]
+    fn scroll_j_k() {
+        let mut app = make_app();
+        assert_eq!(app.scroll_offset, 0);
+        app.handle_key(key(KeyCode::Char('j')));
+        assert_eq!(app.scroll_offset, 1);
+        app.handle_key(key(KeyCode::Char('j')));
+        assert_eq!(app.scroll_offset, 2);
+        app.handle_key(key(KeyCode::Char('k')));
+        assert_eq!(app.scroll_offset, 1);
+        app.handle_key(key(KeyCode::Char('k')));
+        assert_eq!(app.scroll_offset, 0);
+        // k at 0 stays at 0
+        app.handle_key(key(KeyCode::Char('k')));
+        assert_eq!(app.scroll_offset, 0);
+    }
+
+    #[test]
+    fn tab_resets_scroll() {
+        assert_nav_resets_scroll(KeyCode::Tab);
+    }
+
+    #[test]
+    fn right_arrow_cycles_forward() {
+        assert_tab_cycle(
+            KeyCode::Right,
+            &[Tab::Models, Tab::Providers, Tab::Errors, Tab::Overview],
+        );
+    }
+
+    #[test]
+    fn left_arrow_cycles_backward() {
+        assert_tab_cycle(
+            KeyCode::Left,
+            &[Tab::Errors, Tab::Providers, Tab::Models, Tab::Overview],
+        );
+    }
+
+    #[test]
+    fn h_l_navigate_tabs() {
+        let mut app = make_app();
+        app.handle_key(key(KeyCode::Char('l')));
+        assert_eq!(app.active_tab, Tab::Models);
+        app.handle_key(key(KeyCode::Char('h')));
+        assert_eq!(app.active_tab, Tab::Overview);
+    }
+
+    #[test]
+    fn left_right_resets_scroll() {
+        assert_nav_resets_scroll(KeyCode::Right);
+        assert_nav_resets_scroll(KeyCode::Left);
+    }
+
+    #[test]
+    fn d_detaches_in_foreground() {
+        let mut app = make_app();
+        app.handle_key(key(KeyCode::Char('d')));
+        assert_eq!(app.exit_mode, Some(ExitMode::Detach));
+    }
+
+    #[test]
+    fn d_ignored_in_attached() {
+        let mut app = make_attached_app();
+        app.handle_key(key(KeyCode::Char('d')));
+        assert!(app.exit_mode.is_none());
+    }
+
+    #[test]
+    fn footer_shows_detach_in_foreground() {
+        let app = make_app();
+        assert!(!app.attached);
+    }
+
+    #[test]
+    fn footer_hides_detach_in_attached() {
+        let app = make_attached_app();
+        assert!(app.attached);
+    }
+}

--- a/crates/higgs/src/tui/views/errors.rs
+++ b/crates/higgs/src/tui/views/errors.rs
@@ -60,3 +60,73 @@ pub fn draw(frame: &mut Frame, area: Rect, metrics: &Arc<MetricsStore>, scroll: 
     frame.render_widget(table, area);
     super::render_scrollbar(frame, area, count, scroll);
 }
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, Instant};
+
+    use chrono::Utc;
+
+    use crate::metrics::{MetricsStore, RequestRecord, RoutingMethod};
+
+    fn sample_record() -> RequestRecord {
+        RequestRecord {
+            id: 0,
+            timestamp: Instant::now(),
+            wallclock: Utc::now(),
+            model: "claude-opus-4-6".to_owned(),
+            provider: "anthropic".to_owned(),
+            routing_method: RoutingMethod::Default,
+            status: 200,
+            duration: Duration::from_millis(500),
+            input_tokens: 100,
+            output_tokens: 200,
+            error_body: None,
+        }
+    }
+
+    #[test]
+    fn draw_no_errors() {
+        let metrics = Arc::new(MetricsStore::new(Duration::from_secs(3600)));
+        metrics.record(sample_record());
+        let backend = ratatui::backend::TestBackend::new(120, 40);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                draw(f, f.area(), &metrics, 0);
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        let content: String = buffer
+            .content()
+            .iter()
+            .map(|c| c.symbol().chars().next().unwrap_or(' '))
+            .collect();
+        assert!(content.contains("Errors (0)"), "should show zero errors");
+    }
+
+    #[test]
+    fn draw_with_errors() {
+        let metrics = Arc::new(MetricsStore::new(Duration::from_secs(3600)));
+        let mut error_rec = sample_record();
+        error_rec.status = 500;
+        error_rec.error_body = Some("Internal server error".to_owned());
+        metrics.record(error_rec);
+        let backend = ratatui::backend::TestBackend::new(120, 40);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                draw(f, f.area(), &metrics, 0);
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        let content: String = buffer
+            .content()
+            .iter()
+            .map(|c| c.symbol().chars().next().unwrap_or(' '))
+            .collect();
+        assert!(content.contains("Errors (1)"), "should show one error");
+    }
+}

--- a/crates/higgs/src/tui/views/errors.rs
+++ b/crates/higgs/src/tui/views/errors.rs
@@ -1,0 +1,62 @@
+use std::sync::Arc;
+
+use ratatui::prelude::*;
+use ratatui::widgets::{Block, Borders, Cell, Row, Table};
+
+use super::format_time_ago;
+use crate::metrics::MetricsStore;
+
+pub fn draw(frame: &mut Frame, area: Rect, metrics: &Arc<MetricsStore>, scroll: usize) {
+    let snap = metrics.snapshot();
+
+    let now = std::time::Instant::now();
+    let mut errors: Vec<_> = snap.iter().filter(|r| r.status >= 400).collect();
+    errors.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+
+    let header = Row::new(vec!["Age", "Model", "Provider", "Status", "Error"])
+        .style(Style::default().add_modifier(Modifier::BOLD));
+
+    let rows: Vec<Row> = errors
+        .iter()
+        .skip(scroll)
+        .take(100)
+        .map(|r| {
+            let error_preview = r
+                .error_body
+                .as_deref()
+                .unwrap_or("-")
+                .chars()
+                .take(80)
+                .collect::<String>()
+                .replace('\n', " ");
+            Row::new(vec![
+                Cell::from(format_time_ago(now.duration_since(r.timestamp))),
+                Cell::from(r.model.as_str()),
+                Cell::from(r.provider.as_str()),
+                Cell::from(r.status.to_string()).style(Style::default().fg(Color::Red)),
+                Cell::from(error_preview),
+            ])
+        })
+        .collect();
+
+    let count = errors.len();
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Length(12),
+            Constraint::Min(20),
+            Constraint::Length(12),
+            Constraint::Length(6),
+            Constraint::Min(30),
+        ],
+    )
+    .header(header)
+    .block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(format!(" Errors ({count}) ")),
+    );
+
+    frame.render_widget(table, area);
+    super::render_scrollbar(frame, area, count, scroll);
+}

--- a/crates/higgs/src/tui/views/mod.rs
+++ b/crates/higgs/src/tui/views/mod.rs
@@ -193,7 +193,7 @@ mod tests {
             "1d ago"
         );
         assert_eq!(
-            format_time_ago(std::time::Duration::from_secs(172800)),
+            format_time_ago(std::time::Duration::from_secs(172_800)),
             "2d ago"
         );
     }

--- a/crates/higgs/src/tui/views/mod.rs
+++ b/crates/higgs/src/tui/views/mod.rs
@@ -72,8 +72,9 @@ pub fn render_scrollbar(frame: &mut Frame, area: Rect, total_rows: usize, scroll
     #[allow(clippy::as_conversions)]
     let visible_rows = area.height.saturating_sub(3) as usize;
     if total_rows > visible_rows {
-        let mut state =
-            ScrollbarState::new(total_rows.saturating_sub(visible_rows)).position(scroll);
+        let mut state = ScrollbarState::new(total_rows)
+            .viewport_content_length(visible_rows)
+            .position(scroll);
         let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
             .thumb_style(Style::default().fg(Color::DarkGray))
             .track_style(Style::default().fg(Color::Black));

--- a/crates/higgs/src/tui/views/mod.rs
+++ b/crates/higgs/src/tui/views/mod.rs
@@ -1,0 +1,200 @@
+use ratatui::prelude::*;
+use ratatui::widgets::{Scrollbar, ScrollbarOrientation, ScrollbarState};
+
+pub mod errors;
+pub mod models;
+pub mod overview;
+pub mod providers;
+
+/// Formats a token count for display: raw below 1K, "1.0K" style up to ~1M,
+/// "1.5M" style above.
+pub fn format_tokens(n: u64) -> String {
+    if n >= 999_950 {
+        #[allow(clippy::as_conversions, clippy::cast_precision_loss)]
+        let val = n as f64 / 1_000_000.0;
+        format!("{val:.1}M")
+    } else if n >= 1_000 {
+        #[allow(clippy::as_conversions, clippy::cast_precision_loss)]
+        let val = n as f64 / 1_000.0;
+        format!("{val:.1}K")
+    } else {
+        n.to_string()
+    }
+}
+
+/// Formats a duration as a human-readable relative time string (e.g. "3s ago",
+/// "5m ago", "2h ago", "1d ago").
+pub fn format_time_ago(elapsed: std::time::Duration) -> String {
+    let secs = elapsed.as_secs();
+    if secs < 60 {
+        format!("{secs}s ago")
+    } else if secs < 3600 {
+        format!("{}m ago", secs / 60)
+    } else if secs < 86400 {
+        format!("{}h ago", secs / 3600)
+    } else {
+        format!("{}d ago", secs / 86400)
+    }
+}
+
+/// Formats a duration for display: raw ms below 1s, seconds with decimals
+/// below 1m, minutes+seconds above.
+pub fn format_duration(dur: std::time::Duration) -> String {
+    let total_secs = dur.as_secs_f64();
+    if total_secs >= 60.0 {
+        let mut minutes = (total_secs / 60.0).floor();
+        let mut seconds = total_secs - minutes * 60.0;
+        // Clamp to avoid "1m60.0s" from rounding
+        if seconds >= 59.95 {
+            minutes += 1.0;
+            seconds = 0.0;
+        }
+        #[allow(
+            clippy::as_conversions,
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss
+        )]
+        let minutes_u64 = minutes as u64;
+        format!("{minutes_u64}m{seconds:.1}s")
+    } else if total_secs >= 1.0 {
+        // Truncate to avoid "60.00s" from rounding
+        let secs = (total_secs * 100.0).floor() / 100.0;
+        format!("{secs:.2}s")
+    } else {
+        format!("{}ms", dur.as_millis())
+    }
+}
+
+/// Renders a subtle vertical scrollbar when `total_rows` exceeds the visible
+/// area. Accounts for border (top + bottom) and header row = 3 lines of
+/// overhead.
+pub fn render_scrollbar(frame: &mut Frame, area: Rect, total_rows: usize, scroll: usize) {
+    #[allow(clippy::as_conversions)]
+    let visible_rows = area.height.saturating_sub(3) as usize;
+    if total_rows > visible_rows {
+        let mut state =
+            ScrollbarState::new(total_rows.saturating_sub(visible_rows)).position(scroll);
+        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
+            .thumb_style(Style::default().fg(Color::DarkGray))
+            .track_style(Style::default().fg(Color::Black));
+        frame.render_stateful_widget(scrollbar, area, &mut state);
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used, clippy::indexing_slicing)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_tokens_thresholds() {
+        assert_eq!(format_tokens(0), "0");
+        assert_eq!(format_tokens(999), "999");
+        assert_eq!(format_tokens(1000), "1.0K");
+        assert_eq!(format_tokens(999_949), "999.9K");
+        assert_eq!(format_tokens(999_950), "1.0M");
+        assert_eq!(format_tokens(1_500_000), "1.5M");
+    }
+
+    #[test]
+    fn format_time_ago_seconds() {
+        assert_eq!(format_time_ago(std::time::Duration::from_secs(0)), "0s ago");
+        assert_eq!(
+            format_time_ago(std::time::Duration::from_secs(30)),
+            "30s ago"
+        );
+        assert_eq!(
+            format_time_ago(std::time::Duration::from_secs(59)),
+            "59s ago"
+        );
+    }
+
+    #[test]
+    fn format_time_ago_minutes() {
+        assert_eq!(
+            format_time_ago(std::time::Duration::from_secs(60)),
+            "1m ago"
+        );
+        assert_eq!(
+            format_time_ago(std::time::Duration::from_secs(90)),
+            "1m ago"
+        );
+        assert_eq!(
+            format_time_ago(std::time::Duration::from_secs(3599)),
+            "59m ago"
+        );
+    }
+
+    #[test]
+    fn format_time_ago_hours() {
+        assert_eq!(
+            format_time_ago(std::time::Duration::from_secs(3600)),
+            "1h ago"
+        );
+        assert_eq!(
+            format_time_ago(std::time::Duration::from_secs(7200)),
+            "2h ago"
+        );
+        assert_eq!(
+            format_time_ago(std::time::Duration::from_secs(86399)),
+            "23h ago"
+        );
+    }
+
+    #[test]
+    fn format_duration_millis() {
+        assert_eq!(format_duration(std::time::Duration::from_millis(0)), "0ms");
+        assert_eq!(
+            format_duration(std::time::Duration::from_millis(500)),
+            "500ms"
+        );
+        assert_eq!(
+            format_duration(std::time::Duration::from_millis(999)),
+            "999ms"
+        );
+    }
+
+    #[test]
+    fn format_duration_seconds() {
+        assert_eq!(
+            format_duration(std::time::Duration::from_millis(1000)),
+            "1.00s"
+        );
+        assert_eq!(
+            format_duration(std::time::Duration::from_millis(1500)),
+            "1.50s"
+        );
+        assert_eq!(
+            format_duration(std::time::Duration::from_millis(59999)),
+            "59.99s"
+        );
+    }
+
+    #[test]
+    fn format_duration_minutes() {
+        assert_eq!(
+            format_duration(std::time::Duration::from_secs(60)),
+            "1m0.0s"
+        );
+        assert_eq!(
+            format_duration(std::time::Duration::from_millis(304_088)),
+            "5m4.1s"
+        );
+        assert_eq!(
+            format_duration(std::time::Duration::from_secs(3661)),
+            "61m1.0s"
+        );
+    }
+
+    #[test]
+    fn format_time_ago_days() {
+        assert_eq!(
+            format_time_ago(std::time::Duration::from_secs(86400)),
+            "1d ago"
+        );
+        assert_eq!(
+            format_time_ago(std::time::Duration::from_secs(172800)),
+            "2d ago"
+        );
+    }
+}

--- a/crates/higgs/src/tui/views/models.rs
+++ b/crates/higgs/src/tui/views/models.rs
@@ -106,3 +106,78 @@ pub fn draw(frame: &mut Frame, area: Rect, metrics: &Arc<MetricsStore>, scroll: 
     frame.render_widget(table, area);
     super::render_scrollbar(frame, area, total, scroll);
 }
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, Instant};
+
+    use chrono::Utc;
+
+    use crate::metrics::{RequestRecord, RoutingMethod};
+
+    fn sample_record() -> RequestRecord {
+        RequestRecord {
+            id: 0,
+            timestamp: Instant::now(),
+            wallclock: Utc::now(),
+            model: "claude-opus-4-6".to_owned(),
+            provider: "anthropic".to_owned(),
+            routing_method: RoutingMethod::Default,
+            status: 200,
+            duration: Duration::from_millis(500),
+            input_tokens: 100,
+            output_tokens: 200,
+            error_body: None,
+        }
+    }
+
+    #[test]
+    fn draw_empty_metrics_no_panic() {
+        let metrics = Arc::new(MetricsStore::new(Duration::from_secs(3600)));
+        let backend = ratatui::backend::TestBackend::new(120, 40);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                draw(f, f.area(), &metrics, 0);
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn draw_with_records_contains_model_name() {
+        let metrics = Arc::new(MetricsStore::new(Duration::from_secs(3600)));
+        metrics.record(sample_record());
+        let backend = ratatui::backend::TestBackend::new(120, 40);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                draw(f, f.area(), &metrics, 0);
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        let content: String = buffer
+            .content()
+            .iter()
+            .map(|c| c.symbol().chars().next().unwrap_or(' '))
+            .collect();
+        assert!(
+            content.contains("claude-opus"),
+            "buffer should contain model name"
+        );
+    }
+
+    #[test]
+    fn model_table_groups_by_model() {
+        let mut records = Vec::new();
+        for _ in 0..3 {
+            records.push(sample_record());
+        }
+        let mut other = sample_record();
+        other.model = "gpt-4".to_owned();
+        records.push(other);
+        let (_, total) = model_table(&records, " Test ".to_owned(), 0);
+        assert_eq!(total, 2);
+    }
+}

--- a/crates/higgs/src/tui/views/models.rs
+++ b/crates/higgs/src/tui/views/models.rs
@@ -1,0 +1,108 @@
+use std::sync::Arc;
+
+use ratatui::prelude::*;
+use ratatui::widgets::{Block, Borders, Cell, Row, Table};
+
+use super::{format_duration, format_tokens};
+use crate::metrics::{MetricsStore, RequestRecord, RoutingMethod};
+
+/// Builds model-summary rows from a snapshot. Shared by the Models tab and the
+/// overview Token Usage panel.
+pub fn model_table(snap: &[RequestRecord], title: String, skip: usize) -> (Table<'static>, usize) {
+    let groups = MetricsStore::group_by(snap, |r| r.model.clone());
+
+    let header = Row::new(vec![
+        "", "Model", "Reqs", "In", "Out", "Avg/Req", "P50", "P95", "Errs",
+    ])
+    .style(Style::default().add_modifier(Modifier::BOLD));
+
+    let mut model_names: Vec<String> = groups.keys().cloned().collect();
+    model_names.sort();
+    let total = model_names.len();
+
+    let rows: Vec<Row> = model_names
+        .iter()
+        .skip(skip)
+        .filter_map(|model| {
+            let records = groups.get(model)?;
+            let count = u64::try_from(records.len()).unwrap_or(0);
+            let input: u64 = records.iter().map(|r| r.input_tokens).sum();
+            let output: u64 = records.iter().map(|r| r.output_tokens).sum();
+            let durations: Vec<_> = records.iter().map(|r| r.duration).collect();
+            let p50 = MetricsStore::duration_percentile(&durations, 50);
+            let p95 = MetricsStore::duration_percentile(&durations, 95);
+            let errors: u64 =
+                u64::try_from(records.iter().filter(|r| r.status >= 400).count()).unwrap_or(0);
+            let routing_method = if records
+                .iter()
+                .any(|r| r.routing_method == RoutingMethod::Higgs)
+            {
+                RoutingMethod::Higgs
+            } else if records
+                .iter()
+                .any(|r| r.routing_method == RoutingMethod::Auto)
+            {
+                RoutingMethod::Auto
+            } else if records
+                .iter()
+                .any(|r| r.routing_method == RoutingMethod::Pattern)
+            {
+                RoutingMethod::Pattern
+            } else {
+                RoutingMethod::Default
+            };
+
+            let (indicator, indicator_style) = match routing_method {
+                RoutingMethod::Pattern => ("PTN", Style::default().fg(Color::Cyan)),
+                RoutingMethod::Auto => ("AUT", Style::default().fg(Color::Yellow)),
+                RoutingMethod::Default => ("DEF", Style::default().fg(Color::DarkGray)),
+                RoutingMethod::Higgs => ("HGS", Style::default().fg(Color::Magenta)),
+            };
+
+            let error_style = if errors > 0 {
+                Style::default().fg(Color::Red)
+            } else {
+                Style::default().fg(Color::DarkGray)
+            };
+
+            Some(Row::new(vec![
+                Cell::from(indicator).style(indicator_style),
+                Cell::from(model.clone()).style(Style::default().fg(Color::White)),
+                Cell::from(format_tokens(count)),
+                Cell::from(format_tokens(input)).style(Style::default().fg(Color::Cyan)),
+                Cell::from(format_tokens(output)).style(Style::default().fg(Color::Green)),
+                Cell::from(format_tokens((input + output) / count.max(1)))
+                    .style(Style::default().fg(Color::White)),
+                Cell::from(format_duration(p50)),
+                Cell::from(format_duration(p95)),
+                Cell::from(format_tokens(errors)).style(error_style),
+            ]))
+        })
+        .collect();
+
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Length(3),
+            Constraint::Min(25),
+            Constraint::Length(8),
+            Constraint::Length(8),
+            Constraint::Length(8),
+            Constraint::Length(8),
+            Constraint::Length(8),
+            Constraint::Length(8),
+            Constraint::Length(8),
+        ],
+    )
+    .header(header)
+    .block(Block::default().borders(Borders::ALL).title(title));
+
+    (table, total)
+}
+
+pub fn draw(frame: &mut Frame, area: Rect, metrics: &Arc<MetricsStore>, scroll: usize) {
+    let snap = metrics.snapshot();
+    let (table, total) = model_table(&snap, " Models ".to_owned(), scroll);
+    frame.render_widget(table, area);
+    super::render_scrollbar(frame, area, total, scroll);
+}

--- a/crates/higgs/src/tui/views/overview.rs
+++ b/crates/higgs/src/tui/views/overview.rs
@@ -344,3 +344,148 @@ pub fn draw(frame: &mut Frame, area: Rect, metrics: &Arc<MetricsStore>, scroll: 
     draw_token_usage(frame, chunks[2], &snap);
     draw_live_log(frame, chunks[3], &snap, scroll);
 }
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used, clippy::indexing_slicing)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, Instant};
+
+    use chrono::Utc;
+
+    use crate::metrics::{MetricsStore, RequestRecord, RoutingMethod};
+
+    fn sample_record() -> RequestRecord {
+        RequestRecord {
+            id: 0,
+            timestamp: Instant::now(),
+            wallclock: Utc::now(),
+            model: "claude-opus-4-6".to_owned(),
+            provider: "anthropic".to_owned(),
+            routing_method: RoutingMethod::Default,
+            status: 200,
+            duration: Duration::from_millis(500),
+            input_tokens: 100,
+            output_tokens: 200,
+            error_body: None,
+        }
+    }
+
+    #[test]
+    fn status_label_known_codes() {
+        assert_eq!(status_label(200), Some("200 OK"));
+        assert_eq!(status_label(429), Some("429 Rate Limited"));
+        assert_eq!(status_label(500), Some("500 Internal Error"));
+        assert_eq!(status_label(502), Some("502 Bad Gateway"));
+    }
+
+    #[test]
+    fn status_label_unknown_code() {
+        assert_eq!(status_label(418), None);
+        assert_eq!(status_label(999), None);
+    }
+
+    #[test]
+    fn status_color_ranges() {
+        assert_eq!(status_color(200), Color::Green);
+        assert_eq!(status_color(299), Color::Green);
+        assert_eq!(status_color(400), Color::Yellow);
+        assert_eq!(status_color(429), Color::Yellow);
+        assert_eq!(status_color(500), Color::Red);
+        assert_eq!(status_color(502), Color::Red);
+    }
+
+    #[test]
+    fn duration_style_below_p50() {
+        let p50 = Duration::from_millis(500);
+        let p95 = Duration::from_secs(1);
+        let p99 = Duration::from_secs(2);
+        let style = duration_style(Duration::from_millis(100), p50, p95, p99);
+        assert_eq!(style, Style::default().fg(Color::DarkGray));
+    }
+
+    #[test]
+    fn duration_style_at_p50() {
+        let p50 = Duration::from_millis(500);
+        let p95 = Duration::from_secs(1);
+        let p99 = Duration::from_secs(2);
+        let style = duration_style(Duration::from_millis(700), p50, p95, p99);
+        assert_eq!(style, Style::default().fg(Color::White));
+    }
+
+    #[test]
+    fn duration_style_at_p95() {
+        let p50 = Duration::from_millis(500);
+        let p95 = Duration::from_secs(1);
+        let p99 = Duration::from_secs(2);
+        let style = duration_style(Duration::from_millis(1500), p50, p95, p99);
+        assert_eq!(style, Style::default().fg(Color::Yellow));
+    }
+
+    #[test]
+    fn duration_style_at_p99() {
+        let p50 = Duration::from_millis(500);
+        let p95 = Duration::from_secs(1);
+        let p99 = Duration::from_secs(2);
+        let style = duration_style(Duration::from_secs(3), p50, p95, p99);
+        assert_eq!(style, Style::default().fg(Color::Red));
+    }
+
+    #[test]
+    fn time_axis_labels_count() {
+        let labels = time_axis_labels(60);
+        assert_eq!(labels.len(), 5);
+        assert_eq!(labels.last().unwrap(), "now");
+        assert_eq!(labels.first().unwrap(), "-60m");
+    }
+
+    #[test]
+    fn value_axis_labels_count() {
+        let labels = value_axis_labels(1000, 4);
+        assert_eq!(labels.len(), 5);
+        assert_eq!(labels[0], "0");
+    }
+
+    #[test]
+    fn draw_empty_metrics_no_panic() {
+        let metrics = Arc::new(MetricsStore::new(Duration::from_secs(3600)));
+        let backend = ratatui::backend::TestBackend::new(120, 40);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                draw(f, f.area(), &metrics, 0);
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn draw_with_records_contains_expected_text() {
+        let metrics = Arc::new(MetricsStore::new(Duration::from_secs(3600)));
+        metrics.record(sample_record());
+        let backend = ratatui::backend::TestBackend::new(120, 40);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                draw(f, f.area(), &metrics, 0);
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        let content: String = buffer
+            .content()
+            .iter()
+            .map(|c| c.symbol().chars().next().unwrap_or(' '))
+            .collect();
+        assert!(
+            content.contains("Requests/min"),
+            "buffer should contain Requests/min"
+        );
+        assert!(
+            content.contains("Duration"),
+            "buffer should contain Duration"
+        );
+        assert!(
+            content.contains("Live Log"),
+            "buffer should contain Live Log"
+        );
+    }
+}

--- a/crates/higgs/src/tui/views/overview.rs
+++ b/crates/higgs/src/tui/views/overview.rs
@@ -1,0 +1,346 @@
+use std::sync::Arc;
+
+use ratatui::prelude::*;
+use ratatui::symbols::Marker;
+use ratatui::widgets::{
+    Axis, Block, Borders, Cell, Chart, Dataset, GraphType, Paragraph, Row, Table,
+};
+
+use super::{format_duration, format_time_ago, format_tokens};
+use crate::metrics::{MetricsStore, RoutingMethod};
+
+fn time_axis_labels(num_buckets: usize) -> Vec<String> {
+    vec![
+        format!("-{}m", num_buckets),
+        format!("-{}m", num_buckets * 3 / 4),
+        format!("-{}m", num_buckets / 2),
+        format!("-{}m", num_buckets / 4),
+        "now".to_owned(),
+    ]
+}
+
+fn value_axis_labels(max: u64, steps: u64) -> Vec<String> {
+    (0..=steps)
+        .map(|i| {
+            let v = max * i / steps;
+            format_tokens(v)
+        })
+        .collect()
+}
+
+#[allow(clippy::as_conversions, clippy::cast_precision_loss)]
+fn build_time_chart(
+    points: &[(f64, f64)],
+    num_buckets: usize,
+    title: String,
+    color: Color,
+    ceil: u64,
+) -> Chart<'_> {
+    let dataset = Dataset::default()
+        .marker(Marker::Braille)
+        .graph_type(GraphType::Line)
+        .style(Style::default().fg(color))
+        .data(points);
+    Chart::new(vec![dataset])
+        .block(Block::default().borders(Borders::ALL).title(title))
+        .x_axis(
+            Axis::default()
+                .bounds([0.0, (num_buckets - 1) as f64])
+                .labels(time_axis_labels(num_buckets)),
+        )
+        .y_axis(
+            Axis::default()
+                .bounds([0.0, ceil as f64])
+                .labels(value_axis_labels(ceil, 4)),
+        )
+}
+
+#[allow(clippy::as_conversions, clippy::cast_precision_loss)]
+fn to_points(data: &[u64]) -> Vec<(f64, f64)> {
+    data.iter()
+        .enumerate()
+        .map(|(i, &v)| (i as f64, v as f64))
+        .collect()
+}
+
+#[allow(clippy::indexing_slicing)]
+fn draw_charts_row(
+    frame: &mut Frame,
+    area: Rect,
+    snap: &[crate::metrics::RequestRecord],
+    num_buckets: usize,
+) {
+    let cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(area);
+
+    let rpm_data = MetricsStore::requests_per_minute(snap, num_buckets);
+    let total_requests: u64 = rpm_data.iter().sum();
+    let rpm_ceil = rpm_data.iter().max().unwrap_or(&1).max(&10).div_ceil(5) * 5;
+    let rpm_points = to_points(&rpm_data);
+    let rpm_chart = build_time_chart(
+        &rpm_points,
+        num_buckets,
+        format!(" Requests/min (total: {total_requests}) "),
+        Color::Cyan,
+        rpm_ceil,
+    );
+    // Layout::split with 2 constraints always returns 2 elements
+    frame.render_widget(rpm_chart, cols[0]);
+
+    let tpm_data = MetricsStore::tokens_per_minute(snap, num_buckets);
+    let total_tokens: u64 = tpm_data.iter().sum();
+    let tpm_ceil = tpm_data.iter().max().unwrap_or(&1).max(&100).div_ceil(100) * 100;
+    let tpm_points = to_points(&tpm_data);
+    let tpm_chart = build_time_chart(
+        &tpm_points,
+        num_buckets,
+        format!(" Tokens/min (total: {}) ", format_tokens(total_tokens)),
+        Color::Green,
+        tpm_ceil,
+    );
+    frame.render_widget(tpm_chart, cols[1]);
+}
+
+#[allow(clippy::as_conversions)]
+fn draw_latency(frame: &mut Frame, area: Rect, snap: &[crate::metrics::RequestRecord]) {
+    let durations: Vec<std::time::Duration> = snap.iter().map(|r| r.duration).collect();
+    let p50 = MetricsStore::duration_percentile(&durations, 50);
+    let p95 = MetricsStore::duration_percentile(&durations, 95);
+    let p99 = MetricsStore::duration_percentile(&durations, 99);
+    let avg = if snap.is_empty() {
+        std::time::Duration::ZERO
+    } else {
+        let total: std::time::Duration = snap.iter().map(|r| r.duration).sum();
+        let len_u32 = u32::try_from(snap.len()).unwrap_or(u32::MAX);
+        total / len_u32
+    };
+    let lines = vec![
+        Line::from(vec![
+            Span::raw(" Avg: "),
+            Span::styled(format_duration(avg), Style::default().fg(Color::White)),
+        ]),
+        Line::from(vec![
+            Span::raw(" P50: "),
+            Span::styled(format_duration(p50), Style::default().fg(Color::Green)),
+            Span::raw("  P95: "),
+            Span::styled(format_duration(p95), Style::default().fg(Color::Yellow)),
+        ]),
+        Line::from(vec![
+            Span::raw(" P99: "),
+            Span::styled(format_duration(p99), Style::default().fg(Color::Red)),
+        ]),
+    ];
+    let widget =
+        Paragraph::new(lines).block(Block::default().borders(Borders::ALL).title(" Duration "));
+    frame.render_widget(widget, area);
+}
+
+const fn status_label(code: u16) -> Option<&'static str> {
+    match code {
+        200 => Some("200 OK"),
+        201 => Some("201 Created"),
+        204 => Some("204 No Content"),
+        400 => Some("400 Bad Request"),
+        401 => Some("401 Unauthorized"),
+        403 => Some("403 Forbidden"),
+        404 => Some("404 Not Found"),
+        429 => Some("429 Rate Limited"),
+        500 => Some("500 Internal Error"),
+        502 => Some("502 Bad Gateway"),
+        503 => Some("503 Unavailable"),
+        529 => Some("529 Overloaded"),
+        0..=199
+        | 202
+        | 203
+        | 205..=399
+        | 402
+        | 405..=428
+        | 430..=499
+        | 501
+        | 504..=528
+        | 530..=u16::MAX => None,
+    }
+}
+
+const fn status_color(code: u16) -> Color {
+    if code < 300 {
+        Color::Green
+    } else if code < 500 {
+        Color::Yellow
+    } else {
+        Color::Red
+    }
+}
+
+fn draw_status_codes(frame: &mut Frame, area: Rect, snap: &[crate::metrics::RequestRecord]) {
+    let statuses = MetricsStore::status_counts(snap);
+    let mut entries: Vec<(u16, u64)> = statuses.into_iter().collect();
+    entries.sort_by_key(|(s, _)| *s);
+    let lines: Vec<Line> = if entries.is_empty() {
+        vec![Line::from(Span::styled(
+            " No traffic yet",
+            Style::default().fg(Color::DarkGray),
+        ))]
+    } else {
+        entries
+            .iter()
+            .map(|(status, count)| {
+                status_label(*status).map_or_else(
+                    || Line::from(format!(" {status}: {count}")),
+                    |label| {
+                        Line::from(vec![
+                            Span::styled(format!(" {label}: "), status_color(*status)),
+                            Span::styled(count.to_string(), Style::default().fg(Color::White)),
+                        ])
+                    },
+                )
+            })
+            .collect()
+    };
+    let widget = Paragraph::new(lines).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(" Status Codes "),
+    );
+    frame.render_widget(widget, area);
+}
+
+#[allow(clippy::indexing_slicing)]
+fn draw_stats_row(frame: &mut Frame, area: Rect, snap: &[crate::metrics::RequestRecord]) {
+    let cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(area);
+
+    // Layout::split with 2 constraints always returns 2 elements
+    draw_latency(frame, cols[0], snap);
+    draw_status_codes(frame, cols[1], snap);
+}
+
+fn draw_token_usage(frame: &mut Frame, area: Rect, snap: &[crate::metrics::RequestRecord]) {
+    let (table, _) = super::models::model_table(snap, " Token Usage ".to_owned(), 0);
+    frame.render_widget(table, area);
+}
+
+fn duration_style(
+    dur: std::time::Duration,
+    p50: std::time::Duration,
+    p95: std::time::Duration,
+    p99: std::time::Duration,
+) -> Style {
+    if dur >= p99 {
+        Style::default().fg(Color::Red)
+    } else if dur >= p95 {
+        Style::default().fg(Color::Yellow)
+    } else if dur >= p50 {
+        Style::default().fg(Color::White)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    }
+}
+
+fn draw_live_log(
+    frame: &mut Frame,
+    area: Rect,
+    snap: &[crate::metrics::RequestRecord],
+    scroll: usize,
+) {
+    let header = Row::new(vec![
+        "Age", "Model", "Provider", "Route", "Status", "Duration", "In/Out",
+    ])
+    .style(Style::default().add_modifier(Modifier::BOLD))
+    .bottom_margin(0);
+
+    let now = std::time::Instant::now();
+    let durations: Vec<std::time::Duration> = snap.iter().map(|r| r.duration).collect();
+    let p50 = MetricsStore::duration_percentile(&durations, 50);
+    let p95 = MetricsStore::duration_percentile(&durations, 95);
+    let p99 = MetricsStore::duration_percentile(&durations, 99);
+
+    let mut sorted: Vec<_> = snap.iter().collect();
+    sorted.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+
+    let total_rows = sorted.len();
+
+    let rows: Vec<Row> = sorted
+        .iter()
+        .skip(scroll)
+        .take(50)
+        .map(|r| {
+            let status_style = if r.status >= 400 {
+                Style::default().fg(Color::Red)
+            } else {
+                Style::default().fg(Color::Green)
+            };
+            let age = now.duration_since(r.timestamp);
+            let (route_label, route_style) = match r.routing_method {
+                RoutingMethod::Pattern => ("PTN", Style::default().fg(Color::Cyan)),
+                RoutingMethod::Auto => ("AUT", Style::default().fg(Color::Yellow)),
+                RoutingMethod::Default => ("DEF", Style::default().fg(Color::DarkGray)),
+                RoutingMethod::Higgs => ("HGS", Style::default().fg(Color::Magenta)),
+            };
+            Row::new(vec![
+                Cell::from(format_time_ago(age)).style(Style::default().fg(Color::DarkGray)),
+                Cell::from(r.model.as_str()),
+                Cell::from(r.provider.as_str()).style(Style::default().fg(Color::DarkGray)),
+                Cell::from(route_label).style(route_style),
+                Cell::from(r.status.to_string()).style(status_style),
+                Cell::from(format_duration(r.duration))
+                    .style(duration_style(r.duration, p50, p95, p99)),
+                Cell::from(Line::from(vec![
+                    Span::styled(
+                        format_tokens(r.input_tokens),
+                        Style::default().fg(Color::Cyan),
+                    ),
+                    Span::raw("/"),
+                    Span::styled(
+                        format_tokens(r.output_tokens),
+                        Style::default().fg(Color::Green),
+                    ),
+                ])),
+            ])
+        })
+        .collect();
+
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Length(8),
+            Constraint::Min(20),
+            Constraint::Length(12),
+            Constraint::Length(5),
+            Constraint::Length(6),
+            Constraint::Length(10),
+            Constraint::Length(12),
+        ],
+    )
+    .header(header)
+    .block(Block::default().borders(Borders::ALL).title(" Live Log "));
+
+    frame.render_widget(table, area);
+    super::render_scrollbar(frame, area, total_rows, scroll);
+}
+
+#[allow(clippy::indexing_slicing)]
+pub fn draw(frame: &mut Frame, area: Rect, metrics: &Arc<MetricsStore>, scroll: usize) {
+    let snap = metrics.snapshot();
+    let num_buckets = usize::try_from(metrics.window_minutes().max(1)).unwrap_or(1);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(10), // charts row
+            Constraint::Length(6),  // stats row (duration + status)
+            Constraint::Length(6),  // token usage (full width)
+            Constraint::Min(0),     // live log
+        ])
+        .split(area);
+
+    // Layout::split with 4 constraints always returns 4 elements
+    draw_charts_row(frame, chunks[0], &snap, num_buckets);
+    draw_stats_row(frame, chunks[1], &snap);
+    draw_token_usage(frame, chunks[2], &snap);
+    draw_live_log(frame, chunks[3], &snap, scroll);
+}

--- a/crates/higgs/src/tui/views/providers.rs
+++ b/crates/higgs/src/tui/views/providers.rs
@@ -71,3 +71,65 @@ pub fn draw(frame: &mut Frame, area: Rect, metrics: &Arc<MetricsStore>, scroll: 
     frame.render_widget(table, area);
     super::render_scrollbar(frame, area, total, scroll);
 }
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, Instant};
+
+    use chrono::Utc;
+
+    use crate::metrics::{MetricsStore, RequestRecord, RoutingMethod};
+
+    fn sample_record() -> RequestRecord {
+        RequestRecord {
+            id: 0,
+            timestamp: Instant::now(),
+            wallclock: Utc::now(),
+            model: "claude-opus-4-6".to_owned(),
+            provider: "anthropic".to_owned(),
+            routing_method: RoutingMethod::Default,
+            status: 200,
+            duration: Duration::from_millis(500),
+            input_tokens: 100,
+            output_tokens: 200,
+            error_body: None,
+        }
+    }
+
+    #[test]
+    fn draw_empty_metrics_no_panic() {
+        let metrics = Arc::new(MetricsStore::new(Duration::from_secs(3600)));
+        let backend = ratatui::backend::TestBackend::new(120, 40);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                draw(f, f.area(), &metrics, 0);
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn draw_with_records_contains_provider() {
+        let metrics = Arc::new(MetricsStore::new(Duration::from_secs(3600)));
+        metrics.record(sample_record());
+        let backend = ratatui::backend::TestBackend::new(120, 40);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                draw(f, f.area(), &metrics, 0);
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        let content: String = buffer
+            .content()
+            .iter()
+            .map(|c| c.symbol().chars().next().unwrap_or(' '))
+            .collect();
+        assert!(
+            content.contains("anthropic"),
+            "buffer should contain provider name"
+        );
+    }
+}

--- a/crates/higgs/src/tui/views/providers.rs
+++ b/crates/higgs/src/tui/views/providers.rs
@@ -1,0 +1,73 @@
+use std::sync::Arc;
+
+use ratatui::prelude::*;
+use ratatui::widgets::{Block, Borders, Cell, Row, Table};
+
+use super::{format_duration, format_tokens};
+use crate::metrics::MetricsStore;
+
+pub fn draw(frame: &mut Frame, area: Rect, metrics: &Arc<MetricsStore>, scroll: usize) {
+    let snap = metrics.snapshot();
+    let groups = MetricsStore::group_by(&snap, |r| r.provider.clone());
+
+    let header = Row::new(vec![
+        "Provider", "Reqs", "In", "Out", "Avg/Req", "P50", "P95", "Errs",
+    ])
+    .style(Style::default().add_modifier(Modifier::BOLD));
+
+    let mut names: Vec<&String> = groups.keys().collect();
+    names.sort();
+
+    let total = names.len();
+
+    let rows: Vec<Row> = names
+        .iter()
+        .skip(scroll)
+        .filter_map(|name| {
+            let records = groups.get(*name)?;
+            let count = u64::try_from(records.len()).unwrap_or(0);
+            let input: u64 = records.iter().map(|r| r.input_tokens).sum();
+            let output: u64 = records.iter().map(|r| r.output_tokens).sum();
+            let durations: Vec<_> = records.iter().map(|r| r.duration).collect();
+            let p50 = MetricsStore::duration_percentile(&durations, 50);
+            let p95 = MetricsStore::duration_percentile(&durations, 95);
+            let errors: u64 =
+                u64::try_from(records.iter().filter(|r| r.status >= 400).count()).unwrap_or(0);
+            let error_style = if errors > 0 {
+                Style::default().fg(Color::Red)
+            } else {
+                Style::default().fg(Color::DarkGray)
+            };
+            Some(Row::new(vec![
+                Cell::from(name.as_str()).style(Style::default().fg(Color::White)),
+                Cell::from(format_tokens(count)),
+                Cell::from(format_tokens(input)).style(Style::default().fg(Color::Cyan)),
+                Cell::from(format_tokens(output)).style(Style::default().fg(Color::Green)),
+                Cell::from(format_tokens((input + output) / count.max(1)))
+                    .style(Style::default().fg(Color::White)),
+                Cell::from(format_duration(p50)),
+                Cell::from(format_duration(p95)),
+                Cell::from(format_tokens(errors)).style(error_style),
+            ]))
+        })
+        .collect();
+
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Min(15),
+            Constraint::Length(8),
+            Constraint::Length(8),
+            Constraint::Length(8),
+            Constraint::Length(8),
+            Constraint::Length(8),
+            Constraint::Length(8),
+            Constraint::Length(8),
+        ],
+    )
+    .header(header)
+    .block(Block::default().borders(Borders::ALL).title(" Providers "));
+
+    frame.render_widget(table, area);
+    super::render_scrollbar(frame, area, total, scroll);
+}

--- a/crates/higgs/tests/integration/mod.rs
+++ b/crates/higgs/tests/integration/mod.rs
@@ -1,4 +1,5 @@
 mod error_contract;
+mod proxy_e2e;
 mod request_validation;
 mod response_contract;
 mod router;

--- a/crates/higgs/tests/integration/proxy_e2e.rs
+++ b/crates/higgs/tests/integration/proxy_e2e.rs
@@ -1,0 +1,272 @@
+//! End-to-end proxy integration tests using wiremock as an upstream provider.
+//!
+//! These tests build a full `AppState` with no local engines, one remote
+//! provider pointing at a wiremock mock server, and a catch-all route.
+//! Requests go through the real axum router via `tower::ServiceExt::oneshot`.
+
+#![allow(
+    clippy::panic,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    clippy::tests_outside_test_module,
+    clippy::needless_pass_by_value
+)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::body::Body;
+use http::Request;
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use higgs::config::ApiFormat;
+use higgs::metrics::MetricsStore;
+use higgs::router::Router;
+use higgs::state::AppState;
+
+fn build_test_state(mock_url: &str, format: ApiFormat) -> Arc<AppState> {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.toml");
+    let config_toml = format!(
+        r#"
+        [provider.mock]
+        url = "{mock_url}"
+        format = "{fmt}"
+
+        [[routes]]
+        pattern = ".*"
+        provider = "mock"
+
+        [default]
+        provider = "mock"
+    "#,
+        fmt = match format {
+            ApiFormat::OpenAi => "openai",
+            ApiFormat::Anthropic => "anthropic",
+        }
+    );
+    std::fs::write(&config_path, &config_toml).unwrap();
+    let config = higgs::config::load_config_file(&config_path, None).unwrap();
+
+    let router = Router::from_config(&config, HashMap::new()).unwrap();
+    let metrics = Arc::new(MetricsStore::new(Duration::from_secs(60)));
+
+    Arc::new(AppState {
+        router,
+        config,
+        http_client: reqwest::Client::new(),
+        metrics: Some(metrics),
+    })
+}
+
+fn openai_chat_response() -> serde_json::Value {
+    serde_json::json!({
+        "id": "chatcmpl-test",
+        "object": "chat.completion",
+        "created": 1234567890,
+        "model": "gpt-4",
+        "choices": [{
+            "index": 0,
+            "message": {"role": "assistant", "content": "Hello!"},
+            "finish_reason": "stop"
+        }],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+    })
+}
+
+fn openai_chat_request_body() -> serde_json::Value {
+    serde_json::json!({
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "Hi"}]
+    })
+}
+
+fn build_app(state: Arc<AppState>) -> axum::Router {
+    higgs::build_router(state, 300.0, None, 0)
+}
+
+fn post_json(uri: &str, body: &serde_json::Value) -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(body).unwrap()))
+        .unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// 1. OpenAI passthrough
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn proxy_openai_passthrough() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&openai_chat_response()))
+        .mount(&mock_server)
+        .await;
+
+    let state = build_test_state(&mock_server.uri(), ApiFormat::OpenAi);
+    let app = build_app(state);
+
+    let response = app
+        .oneshot(post_json(
+            "/v1/chat/completions",
+            &openai_chat_request_body(),
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 200);
+
+    let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+    assert_eq!(body["id"], "chatcmpl-test");
+    assert_eq!(body["choices"][0]["message"]["content"], "Hello!");
+}
+
+// ---------------------------------------------------------------------------
+// 2. Upstream error status preserved
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn proxy_upstream_error_preserved() {
+    let mock_server = MockServer::start().await;
+
+    let error_body = serde_json::json!({
+        "error": {
+            "message": "Rate limit exceeded",
+            "type": "rate_limit_error"
+        }
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(429).set_body_json(&error_body))
+        .mount(&mock_server)
+        .await;
+
+    let state = build_test_state(&mock_server.uri(), ApiFormat::OpenAi);
+    let app = build_app(state);
+
+    let response = app
+        .oneshot(post_json(
+            "/v1/chat/completions",
+            &openai_chat_request_body(),
+        ))
+        .await
+        .unwrap();
+
+    // proxy_request passes through the upstream status code directly
+    assert_eq!(response.status(), 429);
+}
+
+// ---------------------------------------------------------------------------
+// 3. Model rewrite
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn proxy_model_rewrite() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&openai_chat_response()))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    // Build config with a model rewrite rule
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.toml");
+    let config_toml = format!(
+        r#"
+        [provider.mock]
+        url = "{}"
+        format = "openai"
+
+        [[routes]]
+        pattern = "my-alias"
+        provider = "mock"
+        model = "actual-upstream-model"
+
+        [default]
+        provider = "mock"
+    "#,
+        mock_server.uri()
+    );
+    std::fs::write(&config_path, &config_toml).unwrap();
+    let config = higgs::config::load_config_file(&config_path, None).unwrap();
+    let router = Router::from_config(&config, HashMap::new()).unwrap();
+    let metrics = Arc::new(MetricsStore::new(Duration::from_secs(60)));
+    let state = Arc::new(AppState {
+        router,
+        config,
+        http_client: reqwest::Client::new(),
+        metrics: Some(metrics),
+    });
+    let app = build_app(state);
+
+    let request_body = serde_json::json!({
+        "model": "my-alias",
+        "messages": [{"role": "user", "content": "Hi"}]
+    });
+
+    let response = app
+        .oneshot(post_json("/v1/chat/completions", &request_body))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 200);
+
+    // Verify the mock received exactly one request and the model field was rewritten
+    let received = mock_server.received_requests().await.unwrap();
+    assert_eq!(received.len(), 1);
+    let upstream_body: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+    assert_eq!(
+        upstream_body["model"].as_str().unwrap(),
+        "actual-upstream-model",
+        "model field should be rewritten before sending to upstream"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4. Metrics recorded for proxy requests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn metrics_recorded_for_proxy() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&openai_chat_response()))
+        .mount(&mock_server)
+        .await;
+
+    let state = build_test_state(&mock_server.uri(), ApiFormat::OpenAi);
+    let metrics = Arc::clone(state.metrics.as_ref().unwrap());
+    let app = build_app(state);
+
+    let response = app
+        .oneshot(post_json(
+            "/v1/chat/completions",
+            &openai_chat_request_body(),
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 200);
+
+    let records = metrics.snapshot();
+    assert_eq!(records.len(), 1, "expected exactly one metrics record");
+    assert_eq!(records[0].provider, "mock");
+    assert_eq!(records[0].status, 200);
+    assert_eq!(records[0].model, "gpt-4");
+}

--- a/crates/higgs/tests/integration/proxy_e2e.rs
+++ b/crates/higgs/tests/integration/proxy_e2e.rs
@@ -9,7 +9,9 @@
     clippy::unwrap_used,
     clippy::indexing_slicing,
     clippy::tests_outside_test_module,
-    clippy::needless_pass_by_value
+    clippy::needless_pass_by_value,
+    clippy::unreadable_literal,
+    clippy::needless_borrows_for_generic_args
 )]
 
 use std::collections::HashMap;

--- a/crates/higgs/tests/integration/proxy_e2e.rs
+++ b/crates/higgs/tests/integration/proxy_e2e.rs
@@ -272,3 +272,125 @@ async fn metrics_recorded_for_proxy() {
     assert_eq!(records[0].status, 200);
     assert_eq!(records[0].model, "gpt-4");
 }
+
+// ---------------------------------------------------------------------------
+// 5. Cross-format: OpenAI request -> Anthropic provider -> translated response
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn proxy_openai_to_anthropic_translation() {
+    let mock_server = MockServer::start().await;
+
+    // Upstream returns an Anthropic-format response
+    let anthropic_response = serde_json::json!({
+        "id": "msg_test123",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-sonnet-4-20250514",
+        "content": [{"type": "text", "text": "Hello from Anthropic!"}],
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 12, "output_tokens": 8}
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&anthropic_response))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    // Provider is Anthropic format -- the gateway must translate OpenAI -> Anthropic
+    let state = build_test_state(&mock_server.uri(), ApiFormat::Anthropic);
+    let app = build_app(state);
+
+    // Send an OpenAI-format request
+    let response = app
+        .oneshot(post_json(
+            "/v1/chat/completions",
+            &openai_chat_request_body(),
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 200);
+
+    let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+
+    // Response should be translated back to OpenAI format
+    assert_eq!(body["object"], "chat.completion");
+    assert_eq!(
+        body["choices"][0]["message"]["content"],
+        "Hello from Anthropic!"
+    );
+    assert_eq!(body["choices"][0]["message"]["role"], "assistant");
+    assert!(body["choices"][0]["finish_reason"].is_string());
+
+    // Verify the upstream received an Anthropic-format request
+    let received = mock_server.received_requests().await.unwrap();
+    assert_eq!(received.len(), 1);
+    let upstream_body: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+    // Anthropic requests have "messages" array and no "model" at top level is rewritten
+    assert!(
+        upstream_body.get("messages").is_some(),
+        "upstream should receive Anthropic-format request with messages"
+    );
+    assert!(
+        upstream_body.get("max_tokens").is_some(),
+        "Anthropic requests require max_tokens"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 6. Cross-format: Anthropic request -> OpenAI provider -> translated response
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn proxy_anthropic_to_openai_translation() {
+    let mock_server = MockServer::start().await;
+
+    // Upstream returns an OpenAI-format response
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&openai_chat_response()))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    // Provider is OpenAI format, request comes in as Anthropic
+    let state = build_test_state(&mock_server.uri(), ApiFormat::OpenAi);
+    let app = build_app(state);
+
+    // Send an Anthropic-format request to the Anthropic endpoint
+    let anthropic_request = serde_json::json!({
+        "model": "gpt-4",
+        "max_tokens": 1024,
+        "messages": [{"role": "user", "content": "Hi"}]
+    });
+
+    let response = app
+        .oneshot(post_json("/v1/messages", &anthropic_request))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 200);
+
+    let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+
+    // Response should be translated to Anthropic format
+    assert_eq!(body["type"], "message");
+    assert_eq!(body["role"], "assistant");
+    assert!(body["content"].is_array());
+    assert_eq!(body["content"][0]["type"], "text");
+    assert_eq!(body["content"][0]["text"], "Hello!");
+
+    // Verify the upstream received an OpenAI-format request
+    let received = mock_server.received_requests().await.unwrap();
+    assert_eq!(received.len(), 1);
+    let upstream_body: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+    assert!(
+        upstream_body.get("messages").is_some(),
+        "upstream should receive OpenAI-format request"
+    );
+}


### PR DESCRIPTION
## Summary

- Transform higgs from a local MLX inference server into a unified AI gateway that serves local models AND proxies to remote providers (Anthropic, OpenAI, Ollama, etc.)
- Add cross-format translation between OpenAI and Anthropic APIs (both streaming and non-streaming), pattern-based routing, auto-routing, and default fallback
- Add TUI dashboard (ratatui), daemon management (start/stop/attach), metrics with JSONL logging, doctor command for config validation, and CLI subcommands (init, shellenv, config get/set)
- Auto-router `force` mode: classify every request through intent routing regardless of model field, with fallthrough to normal resolution
- Default auto-router model to `katanemo/Arch-Router-1.5B`; auto-inject into `config.models` when enabled
- Doctor now verifies auto-router model is downloaded on disk

## Details

**Config modes:**
- Simple mode: `higgs serve --model X` -- backward-compatible, no config file needed
- Config mode: `higgs serve --config config.toml` -- full gateway with providers, routes, metrics, TUI

**New modules (16 files, ~5,900 lines):**
- `router.rs` -- Pattern matching + auto-routing (with force mode) + default fallback
- `proxy.rs` -- Header forwarding, auth handling, model rewriting, streaming passthrough
- `translate.rs` -- Bidirectional OpenAI/Anthropic format translation (requests + responses + SSE streams)
- `metrics.rs` + `metrics_log.rs` -- Request recording with window-based expiry and JSONL rotation
- `tui/` -- ratatui dashboard with Overview, Models, Providers, Errors tabs
- `daemon.rs` -- PID management, detach/setsid, graceful shutdown
- `attach.rs` -- Log history loading and tailing for TUI attach mode
- `doctor.rs` -- 10 validation checks (models, providers, routes, port, auto-router download, etc.)
- `auto_router.rs` -- AI-based request classification using a local model
- `cli_config.rs` -- `config get/set` via toml_edit
- `config.rs` -- Unified config with figment (TOML + env + CLI overlay)

**Modified handlers:** All route handlers (chat, anthropic, completions, embeddings) now dispatch through the router and record metrics for both local and proxied requests.

## Test plan

- [x] `cargo clippy -p higgs` passes clean (strict lints: no unwrap/expect/as-casts)
- [x] 333 unit tests pass (`cargo test -p higgs --lib -- --test-threads=1`)
- [x] 82 integration tests pass (including 6 E2E proxy tests)
- [x] Simple mode backward-compatible: `higgs serve --model X` works as before
- [x] Cross-format translation: OpenAI request -> Anthropic provider -> translated response (E2E)
- [x] Cross-format translation: Anthropic request -> OpenAI provider -> translated response (E2E)
- [x] `higgs doctor` validates config and probes providers (21 unit tests)
- [ ] Config mode with local + remote routes (manual test with real providers)
- [ ] Daemon lifecycle: `higgs start/stop/attach` (manual test)


Generated with [Claude Code](https://claude.com/claude-code)