### PR TITLE
feat: ship mlx.metallib alongside the higgs binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,8 +75,8 @@ jobs:
 
           mkdir -p dist
           cp target/${{ matrix.target }}/release/higgs dist/
-          cp target/${{ matrix.target }}/release/mlx.metallib dist/ 2>/dev/null || \
-            cp $(find target/${{ matrix.target }}/release/build/mlx-sys-*/out/build/lib -name mlx.metallib | head -1) dist/
+          test -f target/${{ matrix.target }}/release/mlx.metallib
+          cp target/${{ matrix.target }}/release/mlx.metallib dist/
           cd dist
           tar -czvf "${ARCHIVE_NAME}.tar.gz" higgs mlx.metallib
           shasum -a 256 "${ARCHIVE_NAME}.tar.gz" > "${ARCHIVE_NAME}.tar.gz.sha256"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,8 +75,10 @@ jobs:
 
           mkdir -p dist
           cp target/${{ matrix.target }}/release/higgs dist/
+          cp target/${{ matrix.target }}/release/mlx.metallib dist/ 2>/dev/null || \
+            cp $(find target/${{ matrix.target }}/release/build/mlx-sys-*/out/build/lib -name mlx.metallib | head -1) dist/
           cd dist
-          tar -czvf "${ARCHIVE_NAME}.tar.gz" higgs
+          tar -czvf "${ARCHIVE_NAME}.tar.gz" higgs mlx.metallib
           shasum -a 256 "${ARCHIVE_NAME}.tar.gz" > "${ARCHIVE_NAME}.tar.gz.sha256"
 
       - name: Upload release assets
@@ -193,6 +195,7 @@ jobs:
 
             def install
               bin.install "higgs"
+              bin.install "mlx.metallib"
             end
 
             test do

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "higgs"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "async-stream",
  "axum",
@@ -1192,7 +1192,7 @@ dependencies = [
 
 [[package]]
 name = "higgs-engine"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "higgs-models",
  "minijinja",
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "higgs-models"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "image",
  "mlx-rs",

--- a/crates/higgs/build.rs
+++ b/crates/higgs/build.rs
@@ -3,7 +3,9 @@ use std::{env, fs, path::PathBuf};
 fn main() {
     // Find mlx.metallib in the mlx-sys build output and copy it next to the binary.
     // MLX's runtime uses dladdr to look for mlx.metallib next to the executable.
-    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let Ok(out_dir) = env::var("OUT_DIR").map(PathBuf::from) else {
+        return;
+    };
 
     // OUT_DIR is target/<profile>/build/<crate>-<hash>/out
     // Walk up to target/<profile>/build/ to search mlx-sys-*/out/
@@ -16,9 +18,11 @@ fn main() {
     };
 
     for entry in entries.flatten() {
-        let name = entry.file_name();
-        let Some(name) = name.to_str() else { continue };
-        if !name.starts_with("mlx-sys-") {
+        let file_name = entry.file_name();
+        let Some(file_name) = file_name.to_str() else {
+            continue;
+        };
+        if !file_name.starts_with("mlx-sys-") {
             continue;
         }
 
@@ -29,11 +33,16 @@ fn main() {
 
         // Copy to target profile dir (e.g. target/release/) so the binary finds it via dladdr
         if let Some(profile_dir) = out_dir.ancestors().nth(3) {
-            let _ = fs::copy(&metallib, profile_dir.join("mlx.metallib"));
-            println!(
-                "cargo:warning=Copied mlx.metallib to {}",
-                profile_dir.join("mlx.metallib").display()
-            );
+            let dst = profile_dir.join("mlx.metallib");
+            if let Err(err) = fs::copy(&metallib, &dst) {
+                panic!(
+                    "failed to copy {} to {}: {}",
+                    metallib.display(),
+                    dst.display(),
+                    err
+                );
+            }
+            println!("cargo:warning=Copied mlx.metallib to {}", dst.display());
         }
 
         break;

--- a/crates/higgs/build.rs
+++ b/crates/higgs/build.rs
@@ -30,39 +30,44 @@ fn copy_metallib() -> Result<(), &'static str> {
         return Err("could not read build dir");
     };
 
-    for entry in entries.flatten() {
-        let entry_name = entry.file_name();
-        let is_mlx_sys = entry_name
-            .to_str()
-            .is_some_and(|s| s.starts_with("mlx-sys-"));
-        if !is_mlx_sys {
-            continue;
-        }
+    // Collect candidates and pick the most recently modified, since read_dir
+    // iteration order is unspecified and stale build dirs may linger.
+    let mut candidates: Vec<PathBuf> = entries
+        .flatten()
+        .filter_map(|entry| {
+            let is_mlx_sys = entry
+                .file_name()
+                .to_str()
+                .is_some_and(|s| s.starts_with("mlx-sys-"));
+            if !is_mlx_sys {
+                return None;
+            }
+            let metallib = entry.path().join("out/build/lib/mlx.metallib");
+            metallib.exists().then_some(metallib)
+        })
+        .collect();
 
-        let metallib = entry.path().join("out/build/lib/mlx.metallib");
-        if !metallib.exists() {
-            continue;
-        }
+    candidates.sort_by_key(|p| fs::metadata(p).and_then(|m| m.modified()).ok());
+    let Some(metallib) = candidates.pop() else {
+        return Err("mlx.metallib not found in mlx-sys build output");
+    };
 
-        println!("cargo:rerun-if-changed={}", metallib.display());
+    println!("cargo:rerun-if-changed={}", metallib.display());
 
-        // Copy to target profile dir (e.g. target/release/) so the binary finds it via dladdr
-        let Some(profile_dir) = out_dir.ancestors().nth(3) else {
-            continue;
-        };
-        let dst = profile_dir.join("mlx.metallib");
-        if let Err(err) = fs::copy(&metallib, &dst) {
-            println!(
-                "cargo:warning=failed to copy {} to {}: {}",
-                metallib.display(),
-                dst.display(),
-                err
-            );
-            return Err("copy failed (see warning above)");
-        }
-        println!("cargo:warning=Copied mlx.metallib to {}", dst.display());
-        return Ok(());
+    // Copy to target profile dir (e.g. target/release/) so the binary finds it via dladdr
+    let Some(profile_dir) = out_dir.ancestors().nth(3) else {
+        return Err("could not derive target profile dir from OUT_DIR");
+    };
+    let dst = profile_dir.join("mlx.metallib");
+    if let Err(err) = fs::copy(&metallib, &dst) {
+        println!(
+            "cargo:warning=failed to copy {} to {}: {}",
+            metallib.display(),
+            dst.display(),
+            err
+        );
+        return Err("copy failed (see warning above)");
     }
-
-    Err("mlx.metallib not found in mlx-sys build output")
+    println!("cargo:warning=Copied mlx.metallib to {}", dst.display());
+    Ok(())
 }

--- a/crates/higgs/build.rs
+++ b/crates/higgs/build.rs
@@ -1,6 +1,8 @@
 use std::{env, fs, path::PathBuf, process};
 
 fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
     let is_macos = env::var("CARGO_CFG_TARGET_OS").is_ok_and(|os| os == "macos");
 
     if !copy_metallib() && is_macos {
@@ -40,6 +42,8 @@ fn copy_metallib() -> bool {
         if !metallib.exists() {
             continue;
         }
+
+        println!("cargo:rerun-if-changed={}", metallib.display());
 
         // Copy to target profile dir (e.g. target/release/) so the binary finds it via dladdr
         let Some(profile_dir) = out_dir.ancestors().nth(3) else {

--- a/crates/higgs/build.rs
+++ b/crates/higgs/build.rs
@@ -1,23 +1,33 @@
 use std::{env, fs, path::PathBuf, process};
 
 fn main() {
-    // Find mlx.metallib in the mlx-sys build output and copy it next to the binary.
-    // MLX's runtime uses dladdr to look for mlx.metallib next to the executable.
-    let Ok(out_dir) = env::var("OUT_DIR").map(PathBuf::from) else {
-        return;
+    let is_macos = env::var("CARGO_CFG_TARGET_OS").is_ok_and(|os| os == "macos");
+
+    if !copy_metallib() && is_macos {
+        println!("cargo:warning=mlx.metallib not found in mlx-sys build output");
+        process::exit(1);
+    }
+}
+
+/// Search the mlx-sys build output for mlx.metallib and copy it next to the binary.
+/// MLX's runtime uses dladdr to look for mlx.metallib next to the executable.
+/// Returns true if the copy succeeded.
+fn copy_metallib() -> bool {
+    let out_dir = env::var("OUT_DIR").map(PathBuf::from).ok();
+    let Some(out_dir) = out_dir.as_deref() else {
+        return false;
     };
 
     // OUT_DIR is target/<profile>/build/<crate>-<hash>/out
     // Walk up to target/<profile>/build/ to search mlx-sys-*/out/
     let Some(build_dir) = out_dir.ancestors().nth(2) else {
-        return;
+        return false;
     };
 
     let Ok(entries) = fs::read_dir(build_dir) else {
-        return;
+        return false;
     };
 
-    let mut copied = false;
     for entry in entries.flatten() {
         let entry_name = entry.file_name();
         let is_mlx_sys = entry_name
@@ -33,27 +43,22 @@ fn main() {
         }
 
         // Copy to target profile dir (e.g. target/release/) so the binary finds it via dladdr
-        if let Some(profile_dir) = out_dir.ancestors().nth(3) {
-            let dst = profile_dir.join("mlx.metallib");
-            if let Err(err) = fs::copy(&metallib, &dst) {
-                println!(
-                    "cargo:warning=failed to copy {} to {}: {}",
-                    metallib.display(),
-                    dst.display(),
-                    err
-                );
-                process::exit(1);
-            }
-            println!("cargo:warning=Copied mlx.metallib to {}", dst.display());
-            copied = true;
+        let Some(profile_dir) = out_dir.ancestors().nth(3) else {
+            continue;
+        };
+        let dst = profile_dir.join("mlx.metallib");
+        if let Err(err) = fs::copy(&metallib, &dst) {
+            println!(
+                "cargo:warning=failed to copy {} to {}: {}",
+                metallib.display(),
+                dst.display(),
+                err
+            );
+            return false;
         }
-
-        break;
+        println!("cargo:warning=Copied mlx.metallib to {}", dst.display());
+        return true;
     }
 
-    let is_macos = env::var("CARGO_CFG_TARGET_OS").is_ok_and(|os| os == "macos");
-    if is_macos && !copied {
-        println!("cargo:warning=mlx.metallib not found in mlx-sys build output");
-        process::exit(1);
-    }
+    false
 }

--- a/crates/higgs/build.rs
+++ b/crates/higgs/build.rs
@@ -1,0 +1,41 @@
+use std::{env, fs, path::PathBuf};
+
+fn main() {
+    // Find mlx.metallib in the mlx-sys build output and copy it next to the binary.
+    // MLX's runtime uses dladdr to look for mlx.metallib next to the executable.
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+
+    // OUT_DIR is target/<profile>/build/<crate>-<hash>/out
+    // Walk up to target/<profile>/build/ to search mlx-sys-*/out/
+    let Some(build_dir) = out_dir.ancestors().nth(2) else {
+        return;
+    };
+
+    let Ok(entries) = fs::read_dir(build_dir) else {
+        return;
+    };
+
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        if !name.starts_with("mlx-sys-") {
+            continue;
+        }
+
+        let metallib = entry.path().join("out/build/lib/mlx.metallib");
+        if !metallib.exists() {
+            continue;
+        }
+
+        // Copy to target profile dir (e.g. target/release/) so the binary finds it via dladdr
+        if let Some(profile_dir) = out_dir.ancestors().nth(3) {
+            let _ = fs::copy(&metallib, profile_dir.join("mlx.metallib"));
+            println!(
+                "cargo:warning=Copied mlx.metallib to {}",
+                profile_dir.join("mlx.metallib").display()
+            );
+        }
+
+        break;
+    }
+}

--- a/crates/higgs/build.rs
+++ b/crates/higgs/build.rs
@@ -13,8 +13,7 @@ fn main() {
 /// MLX's runtime uses dladdr to look for mlx.metallib next to the executable.
 /// Returns true if the copy succeeded.
 fn copy_metallib() -> bool {
-    let out_dir = env::var("OUT_DIR").map(PathBuf::from).ok();
-    let Some(out_dir) = out_dir.as_deref() else {
+    let Some(out_dir) = env::var("OUT_DIR").map(PathBuf::from).ok() else {
         return false;
     };
 

--- a/crates/higgs/build.rs
+++ b/crates/higgs/build.rs
@@ -5,28 +5,29 @@ fn main() {
 
     let is_macos = env::var("CARGO_CFG_TARGET_OS").is_ok_and(|os| os == "macos");
 
-    if !copy_metallib() && is_macos {
-        println!("cargo:warning=mlx.metallib not found in mlx-sys build output");
-        process::exit(1);
+    if let Err(reason) = copy_metallib() {
+        if is_macos {
+            println!("cargo:warning=failed to set up mlx.metallib: {reason}");
+            process::exit(1);
+        }
     }
 }
 
 /// Search the mlx-sys build output for mlx.metallib and copy it next to the binary.
 /// MLX's runtime uses dladdr to look for mlx.metallib next to the executable.
-/// Returns true if the copy succeeded.
-fn copy_metallib() -> bool {
+fn copy_metallib() -> Result<(), &'static str> {
     let Some(out_dir) = env::var("OUT_DIR").map(PathBuf::from).ok() else {
-        return false;
+        return Err("OUT_DIR not set");
     };
 
     // OUT_DIR is target/<profile>/build/<crate>-<hash>/out
     // Walk up to target/<profile>/build/ to search mlx-sys-*/out/
     let Some(build_dir) = out_dir.ancestors().nth(2) else {
-        return false;
+        return Err("could not derive build dir from OUT_DIR");
     };
 
     let Ok(entries) = fs::read_dir(build_dir) else {
-        return false;
+        return Err("could not read build dir");
     };
 
     for entry in entries.flatten() {
@@ -57,11 +58,11 @@ fn copy_metallib() -> bool {
                 dst.display(),
                 err
             );
-            return false;
+            return Err("copy failed (see warning above)");
         }
         println!("cargo:warning=Copied mlx.metallib to {}", dst.display());
-        return true;
+        return Ok(());
     }
 
-    false
+    Err("mlx.metallib not found in mlx-sys build output")
 }

--- a/crates/higgs/build.rs
+++ b/crates/higgs/build.rs
@@ -1,4 +1,4 @@
-use std::{env, fs, path::PathBuf};
+use std::{env, fs, path::PathBuf, process};
 
 fn main() {
     // Find mlx.metallib in the mlx-sys build output and copy it next to the binary.
@@ -18,11 +18,11 @@ fn main() {
     };
 
     for entry in entries.flatten() {
-        let file_name = entry.file_name();
-        let Some(file_name) = file_name.to_str() else {
-            continue;
-        };
-        if !file_name.starts_with("mlx-sys-") {
+        let entry_name = entry.file_name();
+        let is_mlx_sys = entry_name
+            .to_str()
+            .is_some_and(|s| s.starts_with("mlx-sys-"));
+        if !is_mlx_sys {
             continue;
         }
 
@@ -35,12 +35,13 @@ fn main() {
         if let Some(profile_dir) = out_dir.ancestors().nth(3) {
             let dst = profile_dir.join("mlx.metallib");
             if let Err(err) = fs::copy(&metallib, &dst) {
-                panic!(
+                eprintln!(
                     "failed to copy {} to {}: {}",
                     metallib.display(),
                     dst.display(),
                     err
                 );
+                process::exit(1);
             }
             println!("cargo:warning=Copied mlx.metallib to {}", dst.display());
         }

--- a/crates/higgs/build.rs
+++ b/crates/higgs/build.rs
@@ -17,6 +17,7 @@ fn main() {
         return;
     };
 
+    let mut copied = false;
     for entry in entries.flatten() {
         let entry_name = entry.file_name();
         let is_mlx_sys = entry_name
@@ -35,8 +36,8 @@ fn main() {
         if let Some(profile_dir) = out_dir.ancestors().nth(3) {
             let dst = profile_dir.join("mlx.metallib");
             if let Err(err) = fs::copy(&metallib, &dst) {
-                eprintln!(
-                    "failed to copy {} to {}: {}",
+                println!(
+                    "cargo:warning=failed to copy {} to {}: {}",
                     metallib.display(),
                     dst.display(),
                     err
@@ -44,8 +45,15 @@ fn main() {
                 process::exit(1);
             }
             println!("cargo:warning=Copied mlx.metallib to {}", dst.display());
+            copied = true;
         }
 
         break;
+    }
+
+    let is_macos = env::var("CARGO_CFG_TARGET_OS").is_ok_and(|os| os == "macos");
+    if is_macos && !copied {
+        println!("cargo:warning=mlx.metallib not found in mlx-sys build output");
+        process::exit(1);
     }
 }


### PR DESCRIPTION
## Summary

- Homebrew-installed `higgs` fails with "Failed to load the default metallib" because `mlx.metallib` (128MB of Metal GPU kernels) was not included in the release tarball
- Added a `build.rs` to the higgs crate that finds `mlx.metallib` in the mlx-sys cmake build output and copies it to `target/<profile>/` next to the binary
- Updated release workflow to include `mlx.metallib` in the tarball and Homebrew formula

## Changes

- **`crates/higgs/build.rs`** (new): Searches `target/<profile>/build/mlx-sys-*/out/build/lib/` for `mlx.metallib` and copies it to the profile directory. Works for both local dev and cross-target CI builds.
- **`.github/workflows/release.yml`**: Copies `mlx.metallib` into the release tarball and adds `bin.install "mlx.metallib"` to the Homebrew formula so it's placed next to the binary in the cellar.
- **`Cargo.lock`**: Version bumps from release-please.

## Test plan

- [x] `cargo build --release` produces `target/release/mlx.metallib` (128MB)
- [ ] `./target/release/higgs serve --model mlx-community/Llama-3.2-1B-Instruct-4bit` starts without metallib errors
- [ ] Release tarball includes both `higgs` and `mlx.metallib`
- [ ] Homebrew install places `mlx.metallib` next to `higgs` in the cellar bin dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release archives now include the metallib runtime asset alongside the main executable so downloaded packages contain both components.
  * The installation formula was updated to install the metallib asset with the main package, ensuring the runtime asset is present after installation.
  * Build outputs now place the metallib next to the binary so runtime lookup succeeds without extra steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->