### PR TITLE
fix: resolve auto_router model by basename for local paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "higgs"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "async-stream",
  "axum",
@@ -1192,7 +1192,7 @@ dependencies = [
 
 [[package]]
 name = "higgs-engine"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "higgs-models",
  "minijinja",
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "higgs-models"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "image",
  "mlx-rs",

--- a/crates/higgs/src/config.rs
+++ b/crates/higgs/src/config.rs
@@ -285,7 +285,7 @@ pub struct LoggingConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MetricsLogConfig {
-    #[serde(default)]
+    #[serde(default = "default_metrics_enabled")]
     pub enabled: bool,
     #[serde(default = "default_metrics_log_path")]
     pub path: String,
@@ -298,12 +298,16 @@ pub struct MetricsLogConfig {
 impl Default for MetricsLogConfig {
     fn default() -> Self {
         Self {
-            enabled: false,
+            enabled: true,
             path: default_metrics_log_path(),
             max_size_mb: default_max_size_mb(),
             max_files: default_max_files(),
         }
     }
+}
+
+const fn default_metrics_enabled() -> bool {
+    true
 }
 
 fn default_metrics_log_path() -> String {
@@ -947,7 +951,7 @@ mod tests {
     #[test]
     fn test_logging_defaults() {
         let config = HiggsConfig::default();
-        assert!(!config.logging.metrics.enabled);
+        assert!(config.logging.metrics.enabled);
         assert_eq!(config.logging.metrics.max_size_mb, 50);
         assert_eq!(config.logging.metrics.max_files, 5);
         assert!(config.logging.metrics.path.contains("metrics.jsonl"));

--- a/crates/higgs/src/router.rs
+++ b/crates/higgs/src/router.rs
@@ -153,14 +153,20 @@ impl Router {
             if auto_candidates.is_empty() {
                 warn!("auto_router is enabled but no routes have descriptions");
             }
+            // The engines map is keyed by resolved model name (directory basename),
+            // but the config may contain a full path or HF repo ID. Try both the
+            // raw config value and its basename.
+            let auto_model = &config.auto_router.model;
+            let basename = std::path::Path::new(auto_model)
+                .file_name()
+                .and_then(|f| f.to_str())
+                .unwrap_or(auto_model);
             let engine = engines
-                .get(&config.auto_router.model)
+                .get(auto_model)
+                .or_else(|| engines.get(basename))
                 .cloned()
                 .ok_or_else(|| {
-                    format!(
-                        "auto_router model '{}' not found among loaded models",
-                        config.auto_router.model
-                    )
+                    format!("auto_router model '{auto_model}' not found among loaded models")
                 })?;
             Some(engine)
         } else {
@@ -806,6 +812,29 @@ mod tests {
             Ok(ResolvedRoute::Remote { .. }) => panic!("expected Higgs route"),
             Err(e) => panic!("should resolve to first engine, got error: {e}"),
         }
+    }
+
+    #[test]
+    fn auto_router_model_resolved_by_basename() {
+        let config = config_from_toml(
+            r#"
+            [[models]]
+            path = "/Users/someone/models/Arch-Router-1.5B-4bit"
+
+            [auto_router]
+            enabled = true
+            model = "/Users/someone/models/Arch-Router-1.5B-4bit"
+            "#,
+        );
+        let engine = crate::state::Engine::test_stub("Arch-Router-1.5B-4bit");
+        let mut engines = HashMap::new();
+        engines.insert("Arch-Router-1.5B-4bit".to_owned(), Arc::new(engine));
+
+        let router = Router::from_config(&config, engines);
+        assert!(
+            router.is_ok(),
+            "should resolve auto_router model by basename"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Auto_router engine lookup was using the raw config path as the HashMap key, but engines are keyed by directory basename. Local paths like `/path/to/Arch-Router-1.5B-4bit` failed to match the engine registered as `Arch-Router-1.5B-4bit`.
- Adds fallback to basename lookup when the full path doesn't match.
- Enables metrics logging by default and bumps crate versions to 0.1.11.

## Test plan
- [x] Added `auto_router_model_resolved_by_basename` unit test
- [ ] Manual test: configure auto_router with a local model path, verify server starts successfully

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced auto_router model lookup with fallback resolution—models specified by full paths or Hugging Face repository IDs are now reliably resolved using basename lookup when needed

* **Chores**
  * Metrics logging is now enabled by default in configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->