### PR TITLE
feat: add name field to ModelConfig

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,27 @@
+# Higgs
+
+## Project Structure
+
+- `crates/higgs/` -- main binary crate (config, router, doctor, daemon, CLI)
+- `crates/higgs-engine/` -- inference engine
+- `crates/higgs-models/` -- model architectures
+
+## Development Rules
+
+### Doctor Validation
+
+When adding or changing config fields, always update `crates/higgs/src/doctor.rs` to validate the new field. The doctor should catch misconfiguration before the server starts. Run `cargo test -p higgs -- --test-threads=1` to verify.
+
+### Documentation
+
+When changing user-facing behavior (config fields, CLI flags, API surface), update:
+
+1. `README.md` -- config examples and reference tables
+2. `crates/higgs/src/daemon.rs` -- the `higgs init` config template
+3. Doc comments on public structs/fields if applicable
+
+### Testing
+
+- `cargo clippy -p higgs` -- must be clean (nursery lints enabled)
+- `cargo fmt -p higgs -- --check` -- must pass
+- `cargo test -p higgs -- --test-threads=1` -- all tests must pass (thread limit required due to shared port bindings)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "higgs"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "async-stream",
  "axum",
@@ -1192,7 +1192,7 @@ dependencies = [
 
 [[package]]
 name = "higgs-engine"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "higgs-models",
  "minijinja",
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "higgs-models"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "image",
  "mlx-rs",

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ port = 8000
 # --- Local models ---
 [[models]]
 path = "mlx-community/Llama-3.2-1B-Instruct-4bit"
+# name = "llama"     # optional friendly name (used as engine key and for auto_router lookup)
 # batch = false
 
 # --- Remote providers ---
@@ -131,9 +132,10 @@ provider = "higgs"   # "higgs" = local models only; set to a provider name to pr
 
 # --- Auto router (optional) ---
 # Classify requests with a local LLM to pick the best provider automatically.
+# The model field can reference a model by name or path.
 # [auto_router]
 # enabled = true
-# model = "mlx-community/Arch-Router-1.5B-4bit"
+# model = "llama"    # matches [[models]] name or path
 # timeout_ms = 2000
 
 # --- Metrics & dashboard ---

--- a/crates/higgs/src/config.rs
+++ b/crates/higgs/src/config.rs
@@ -1102,7 +1102,10 @@ mod tests {
         )
         .unwrap();
         let config = load_config_file(&path, None).unwrap();
-        assert_eq!(config.models[0].name.as_deref(), Some("coder"));
+        assert_eq!(
+            config.models.first().unwrap().name.as_deref(),
+            Some("coder")
+        );
     }
 
     #[test]
@@ -1118,6 +1121,6 @@ mod tests {
         )
         .unwrap();
         let config = load_config_file(&path, None).unwrap();
-        assert!(config.models[0].name.is_none());
+        assert!(config.models.first().unwrap().name.is_none());
     }
 }

--- a/crates/higgs/src/config.rs
+++ b/crates/higgs/src/config.rs
@@ -183,6 +183,8 @@ const fn default_max_body_size() -> usize {
 pub struct ModelConfig {
     pub path: String,
     #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
     pub batch: bool,
 }
 
@@ -371,6 +373,7 @@ pub fn build_simple_config(args: &ServeArgs) -> Result<HiggsConfig, String> {
         .iter()
         .map(|p| ModelConfig {
             path: p.clone(),
+            name: None,
             batch: args.batch,
         })
         .collect();
@@ -445,6 +448,7 @@ pub fn load_config_file(path: &Path, args: Option<&ServeArgs>) -> Result<HiggsCo
                 .iter()
                 .map(|p| ModelConfig {
                     path: p.clone(),
+                    name: None,
                     batch: serve_args.batch,
                 })
                 .collect();
@@ -474,12 +478,23 @@ fn validate_config(config: &HiggsConfig, simple_mode: bool) -> Result<(), String
         if model.path.trim().is_empty() {
             return Err("model path must not be empty or whitespace-only".to_owned());
         }
+        if let Some(ref name) = model.name {
+            if name.trim().is_empty() {
+                return Err("model name must not be empty or whitespace-only".to_owned());
+            }
+        }
     }
 
-    let mut seen = std::collections::HashSet::new();
+    let mut seen_paths = std::collections::HashSet::new();
+    let mut seen_names = std::collections::HashSet::new();
     for model in &config.models {
-        if !seen.insert(&model.path) {
+        if !seen_paths.insert(&model.path) {
             return Err(format!("duplicate model path: {}", model.path));
+        }
+        if let Some(ref name) = model.name {
+            if !seen_names.insert(name) {
+                return Err(format!("duplicate model name: {name}"));
+            }
         }
     }
 
@@ -509,17 +524,21 @@ fn validate_config(config: &HiggsConfig, simple_mode: bool) -> Result<(), String
 }
 
 /// If `auto_router` is enabled, ensure its model is present in `config.models`.
+///
+/// The `auto_router.model` field can reference a model by its `name` or `path`.
 fn ensure_auto_router_model(config: &mut HiggsConfig) {
     if !config.auto_router.enabled || config.auto_router.model.is_empty() {
         return;
     }
+    let auto_model = &config.auto_router.model;
     let already_listed = config
         .models
         .iter()
-        .any(|m| m.path == config.auto_router.model);
+        .any(|m| m.path == *auto_model || m.name.as_deref() == Some(auto_model));
     if !already_listed {
         config.models.push(ModelConfig {
             path: config.auto_router.model.clone(),
+            name: None,
             batch: false,
         });
     }
@@ -1003,5 +1022,102 @@ mod tests {
         let config = load_config_file(&path, Some(&args)).unwrap();
         assert_eq!(config.server.host, "127.0.0.1");
         assert_eq!(config.server.port, 9000);
+    }
+
+    #[test]
+    fn test_duplicate_model_names_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            r#"
+            [[models]]
+            path = "org/model-a"
+            name = "coder"
+
+            [[models]]
+            path = "org/model-b"
+            name = "coder"
+            "#,
+        )
+        .unwrap();
+        assert!(load_config_file(&path, None).is_err());
+    }
+
+    #[test]
+    fn test_empty_model_name_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            r#"
+            [[models]]
+            path = "org/model-a"
+            name = "  "
+            "#,
+        )
+        .unwrap();
+        assert!(load_config_file(&path, None).is_err());
+    }
+
+    #[test]
+    fn auto_router_matches_model_by_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            r#"
+            [[models]]
+            path = "/some/long/path/Arch-Router-1.5B-4bit"
+            name = "router"
+
+            [auto_router]
+            enabled = true
+            model = "router"
+            "#,
+        )
+        .unwrap();
+        let config = load_config_file(&path, None).unwrap();
+        // The auto_router model should match by name, not inject a duplicate
+        let count = config
+            .models
+            .iter()
+            .filter(|m| m.name.as_deref() == Some("router"))
+            .count();
+        assert_eq!(count, 1);
+        assert_eq!(config.models.len(), 1);
+    }
+
+    #[test]
+    fn test_model_name_deserialized() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            r#"
+            [[models]]
+            path = "org/model-a"
+            name = "coder"
+            "#,
+        )
+        .unwrap();
+        let config = load_config_file(&path, None).unwrap();
+        assert_eq!(config.models[0].name.as_deref(), Some("coder"));
+    }
+
+    #[test]
+    fn test_model_name_optional() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            r#"
+            [[models]]
+            path = "org/model-a"
+            "#,
+        )
+        .unwrap();
+        let config = load_config_file(&path, None).unwrap();
+        assert!(config.models[0].name.is_none());
     }
 }

--- a/crates/higgs/src/daemon.rs
+++ b/crates/higgs/src/daemon.rs
@@ -102,6 +102,7 @@ port = 8000
 
 # [[models]]
 # path = "mlx-community/Llama-3.2-1B-Instruct-4bit"
+# name = "llama"
 # batch = false
 
 # --- Remote providers ---

--- a/crates/higgs/src/doctor.rs
+++ b/crates/higgs/src/doctor.rs
@@ -61,11 +61,19 @@ fn check_config_valid(result: &mut DoctorResult) {
     pass("config file is valid", result);
 }
 
+fn model_label(model: &crate::config::ModelConfig) -> String {
+    model.name.as_ref().map_or_else(
+        || model.path.clone(),
+        |name| format!("\"{name}\" ({})", model.path),
+    )
+}
+
 fn check_models(config: &HiggsConfig, result: &mut DoctorResult) {
     for model in &config.models {
+        let label = model_label(model);
         match model_resolver::resolve(&model.path) {
-            Ok(_) => pass(&format!("model {} resolvable", model.path), result),
-            Err(err) => fail(&format!("model {} not found: {err}", model.path), result),
+            Ok(_) => pass(&format!("model {label} resolvable"), result),
+            Err(err) => fail(&format!("model {label} not found: {err}"), result),
         }
     }
 }
@@ -206,19 +214,15 @@ fn check_auto_router(config: &HiggsConfig, result: &mut DoctorResult) {
         .find(|m| m.path == *model_ref || m.name.as_deref() == Some(model_ref));
 
     if let Some(matched_model) = matched {
+        let label = model_label(matched_model);
         pass(
-            &format!("auto_router model \"{model_ref}\" found in models"),
+            &format!("auto_router model {label} found in models"),
             result,
         );
-        // Use the model's path for the download check
-        let resolve_path = &matched_model.path;
-        match model_resolver::resolve(resolve_path) {
-            Ok(_) => pass(
-                &format!("auto_router model \"{model_ref}\" downloaded"),
-                result,
-            ),
+        match model_resolver::resolve(&matched_model.path) {
+            Ok(_) => pass(&format!("auto_router model {label} downloaded"), result),
             Err(err) => fail(
-                &format!("auto_router model \"{model_ref}\" not downloaded: {err}"),
+                &format!("auto_router model {label} not downloaded: {err}"),
                 result,
             ),
         }

--- a/crates/higgs/src/doctor.rs
+++ b/crates/higgs/src/doctor.rs
@@ -71,20 +71,26 @@ fn check_models(config: &HiggsConfig, result: &mut DoctorResult) {
 }
 
 fn check_duplicate_models(config: &HiggsConfig, result: &mut DoctorResult) {
-    let mut seen = HashSet::new();
+    let mut seen_paths = HashSet::new();
+    let mut seen_names = HashSet::new();
     let mut duplicates = Vec::new();
     for model in &config.models {
-        if !seen.insert(&model.path) {
-            duplicates.push(model.path.clone());
+        if !seen_paths.insert(&model.path) {
+            duplicates.push(format!("path: {}", model.path));
+        }
+        if let Some(ref name) = model.name {
+            if !seen_names.insert(name) {
+                duplicates.push(format!("name: {name}"));
+            }
         }
     }
     if duplicates.is_empty() {
         if config.models.len() > 1 {
-            pass("no duplicate model paths", result);
+            pass("no duplicate model paths or names", result);
         }
     } else {
         for dup in &duplicates {
-            warn(&format!("duplicate model path: {dup}"), result);
+            warn(&format!("duplicate model {dup}"), result);
         }
     }
 }
@@ -187,34 +193,40 @@ fn check_auto_router(config: &HiggsConfig, result: &mut DoctorResult) {
         return;
     }
 
-    let model_name = &config.auto_router.model;
-    if model_name.is_empty() {
+    let model_ref = &config.auto_router.model;
+    if model_ref.is_empty() {
         fail("auto_router enabled but no model specified", result);
         return;
     }
 
-    let model_known = config.models.iter().any(|m| m.path == *model_name);
-    if model_known {
+    // Match by name or path
+    let matched = config
+        .models
+        .iter()
+        .find(|m| m.path == *model_ref || m.name.as_deref() == Some(model_ref));
+
+    if let Some(matched_model) = matched {
         pass(
-            &format!("auto_router model \"{model_name}\" found in models"),
+            &format!("auto_router model \"{model_ref}\" found in models"),
             result,
         );
+        // Use the model's path for the download check
+        let resolve_path = &matched_model.path;
+        match model_resolver::resolve(resolve_path) {
+            Ok(_) => pass(
+                &format!("auto_router model \"{model_ref}\" downloaded"),
+                result,
+            ),
+            Err(err) => fail(
+                &format!("auto_router model \"{model_ref}\" not downloaded: {err}"),
+                result,
+            ),
+        }
     } else {
         fail(
-            &format!("auto_router model \"{model_name}\" not found in models"),
+            &format!("auto_router model \"{model_ref}\" not found in models"),
             result,
         );
-    }
-
-    match model_resolver::resolve(model_name) {
-        Ok(_) => pass(
-            &format!("auto_router model \"{model_name}\" downloaded"),
-            result,
-        ),
-        Err(err) => fail(
-            &format!("auto_router model \"{model_name}\" not downloaded: {err}"),
-            result,
-        ),
     }
 
     let routes_with_descriptions = config
@@ -319,10 +331,12 @@ mod tests {
             models: vec![
                 ModelConfig {
                     path: "org/model-a".to_owned(),
+                    name: None,
                     batch: false,
                 },
                 ModelConfig {
                     path: "org/model-b".to_owned(),
+                    name: None,
                     batch: false,
                 },
             ],
@@ -340,10 +354,12 @@ mod tests {
             models: vec![
                 ModelConfig {
                     path: "org/model-a".to_owned(),
+                    name: None,
                     batch: false,
                 },
                 ModelConfig {
                     path: "org/model-a".to_owned(),
+                    name: None,
                     batch: false,
                 },
             ],
@@ -591,14 +607,15 @@ mod tests {
             },
             models: vec![ModelConfig {
                 path: "org/other-model".to_owned(),
+                name: None,
                 batch: false,
             }],
             ..HiggsConfig::default()
         };
         let mut result = empty_result();
         check_auto_router(&config, &mut result);
-        // Fails twice: not in [[models]] and not downloaded
-        assert_eq!(result.failures, 2);
+        // Fails once: not in [[models]] (download check skipped)
+        assert_eq!(result.failures, 1);
     }
 
     #[test]
@@ -612,6 +629,7 @@ mod tests {
             },
             models: vec![ModelConfig {
                 path: "org/router-model".to_owned(),
+                name: None,
                 batch: false,
             }],
             ..HiggsConfig::default()
@@ -635,6 +653,7 @@ mod tests {
             },
             models: vec![ModelConfig {
                 path: "org/router-model".to_owned(),
+                name: None,
                 batch: false,
             }],
             routes: vec![RouteConfig {

--- a/crates/higgs/src/main.rs
+++ b/crates/higgs/src/main.rs
@@ -217,7 +217,10 @@ fn load_engines(
         } else {
             Engine::load_simple(&resolved)?
         };
-        let name = engine.model_name().to_owned();
+        let name = model_cfg
+            .name
+            .clone()
+            .unwrap_or_else(|| engine.model_name().to_owned());
         tracing::info!(model_name = %name, "Model loaded");
 
         if engines.insert(name.clone(), Arc::new(engine)).is_some() {

--- a/crates/higgs/src/router.rs
+++ b/crates/higgs/src/router.rs
@@ -154,12 +154,9 @@ impl Router {
                 warn!("auto_router is enabled but no routes have descriptions");
             }
             let auto_model = &config.auto_router.model;
-            let engine = engines
-                .get(auto_model)
-                .cloned()
-                .ok_or_else(|| {
-                    format!("auto_router model '{auto_model}' not found among loaded models")
-                })?;
+            let engine = engines.get(auto_model).cloned().ok_or_else(|| {
+                format!("auto_router model '{auto_model}' not found among loaded models")
+            })?;
             Some(engine)
         } else {
             None
@@ -824,10 +821,7 @@ mod tests {
         engines.insert("router".to_owned(), Arc::new(engine));
 
         let router = Router::from_config(&config, engines);
-        assert!(
-            router.is_ok(),
-            "should resolve auto_router model by name"
-        );
+        assert!(router.is_ok(), "should resolve auto_router model by name");
     }
 
     #[tokio::test]

--- a/crates/higgs/src/router.rs
+++ b/crates/higgs/src/router.rs
@@ -153,17 +153,9 @@ impl Router {
             if auto_candidates.is_empty() {
                 warn!("auto_router is enabled but no routes have descriptions");
             }
-            // The engines map is keyed by resolved model name (directory basename),
-            // but the config may contain a full path or HF repo ID. Try both the
-            // raw config value and its basename.
             let auto_model = &config.auto_router.model;
-            let basename = std::path::Path::new(auto_model)
-                .file_name()
-                .and_then(|f| f.to_str())
-                .unwrap_or(auto_model);
             let engine = engines
                 .get(auto_model)
-                .or_else(|| engines.get(basename))
                 .cloned()
                 .ok_or_else(|| {
                     format!("auto_router model '{auto_model}' not found among loaded models")
@@ -815,25 +807,26 @@ mod tests {
     }
 
     #[test]
-    fn auto_router_model_resolved_by_basename() {
+    fn auto_router_model_resolved_by_name() {
         let config = config_from_toml(
             r#"
             [[models]]
             path = "/Users/someone/models/Arch-Router-1.5B-4bit"
+            name = "router"
 
             [auto_router]
             enabled = true
-            model = "/Users/someone/models/Arch-Router-1.5B-4bit"
+            model = "router"
             "#,
         );
-        let engine = crate::state::Engine::test_stub("Arch-Router-1.5B-4bit");
+        let engine = crate::state::Engine::test_stub("router");
         let mut engines = HashMap::new();
-        engines.insert("Arch-Router-1.5B-4bit".to_owned(), Arc::new(engine));
+        engines.insert("router".to_owned(), Arc::new(engine));
 
         let router = Router::from_config(&config, engines);
         assert!(
             router.is_ok(),
-            "should resolve auto_router model by basename"
+            "should resolve auto_router model by name"
         );
     }
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -4,3 +4,10 @@ pre-commit:
       glob: "**/*.rs"
       run: cargo fmt --all
       stage_fixed: true
+
+pre-push:
+  commands:
+    fmt-check:
+      run: cargo fmt --all -- --check
+    clippy:
+      run: RUSTFLAGS=-Dwarnings cargo clippy --all-targets --all-features


### PR DESCRIPTION
## Summary

- Adds optional `name` field to `ModelConfig` so models can be identified by friendly names (e.g. `"coder"` instead of `"mlx-community/Qwen3-Coder-Next-4bit"`)
- When set, `name` is used as the engine HashMap key, for auto_router model resolution, and in doctor checks
- Removes the basename fallback hack in router.rs, replacing it with proper name-based lookup

## Test plan

- [x] `cargo clippy -p higgs` -- clean
- [x] `cargo test -p higgs -- --test-threads=1` -- all 339 unit + 82 integration tests pass
- [ ] Manual: add `name` fields to `~/.config/higgs/config.toml`, run `higgs doctor`, then `higgs serve`

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional model names can be specified in config and used as engine keys.
  * Auto-router accepts model references by name or path and will resolve accordingly.

* **Improvements**
  * Validation rejects empty/whitespace names and enforces unique model names and paths.
  * Auto-router and model-list handling avoid duplicate model entries.

* **Documentation**
  * README and project docs updated to describe model name usage and auto-router behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->