### PR TITLE
feat: add --profile CLI flag, TUI routing tab, and config visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,23 @@ higgs attach      # attach TUI dashboard to running daemon
 higgs stop        # stop daemon
 ```
 
+### Profiles
+
+Named profiles let you maintain multiple configurations and run multiple instances simultaneously:
+
+```bash
+higgs init --profile dev              # create config.dev.toml
+higgs init --profile prod             # create config.prod.toml
+higgs serve --profile dev             # foreground with dev config
+higgs start --profile dev             # daemon with dev config (separate PID/log)
+higgs start --profile prod            # daemon with prod config (different port)
+higgs attach --profile dev            # attach TUI to dev instance
+higgs stop --profile dev              # stop only the dev instance
+higgs doctor --profile prod           # validate prod config
+```
+
+Each profile gets isolated runtime files (`higgs.<profile>.pid`, `higgs.<profile>.log`, `metrics.<profile>.jsonl`). Profiles must use different ports (configured in each profile's config file). `--profile` and `--config` are mutually exclusive.
+
 ## Features
 
 ### Local inference
@@ -217,6 +234,14 @@ eval "$(higgs shellenv)"
 | `higgs config set <key> <value>` | Write a config value |
 | `higgs config path` | Print the resolved config file path |
 | `higgs doctor` | Validate config, check model paths, probe providers |
+
+### Global flags
+
+| Flag | Description |
+|---|---|
+| `--config <FILE>` | Path to config file (conflicts with `--profile`) |
+| `--profile <NAME>` | Named profile, resolves to `config.<NAME>.toml` (conflicts with `--config`) |
+| `--verbose` | Enable debug logging |
 
 ## Supported Architectures
 

--- a/crates/higgs/src/config.rs
+++ b/crates/higgs/src/config.rs
@@ -1202,4 +1202,82 @@ mod tests {
         assert!(validate_profile_name("dev.prod").is_err());
         assert!(validate_profile_name("dev prod").is_err());
     }
+
+    #[test]
+    fn test_validate_profile_name_rejects_unicode() {
+        assert!(validate_profile_name("caf\u{00e9}").is_err());
+        assert!(validate_profile_name("\u{1f600}").is_err());
+    }
+
+    #[test]
+    fn test_validate_profile_name_rejects_control_chars() {
+        assert!(validate_profile_name("dev\0prod").is_err());
+        assert!(validate_profile_name("dev\nprod").is_err());
+        assert!(validate_profile_name("dev\tprod").is_err());
+    }
+
+    #[test]
+    fn test_validate_profile_name_rejects_shell_metacharacters() {
+        assert!(validate_profile_name("dev;rm -rf").is_err());
+        assert!(validate_profile_name("$(whoami)").is_err());
+        assert!(validate_profile_name("dev|prod").is_err());
+        assert!(validate_profile_name("dev&prod").is_err());
+    }
+
+    #[test]
+    fn test_profile_config_path_format() {
+        let path = profile_config_path("dev");
+        let file_name = path.file_name().unwrap().to_str().unwrap();
+        assert_eq!(file_name, "config.dev.toml");
+        assert!(path.parent().unwrap().ends_with(".config/higgs") || path.starts_with("/tmp"));
+    }
+
+    #[test]
+    fn test_profile_config_path_different_names() {
+        let dev = profile_config_path("dev");
+        let prod = profile_config_path("prod");
+        assert_ne!(dev, prod);
+        assert!(dev.to_str().unwrap().contains("config.dev.toml"));
+        assert!(prod.to_str().unwrap().contains("config.prod.toml"));
+    }
+
+    #[test]
+    fn test_profile_config_path_shares_parent_with_default() {
+        let profile_path = profile_config_path("test");
+        let default_path = default_config_path();
+        assert_eq!(profile_path.parent(), default_path.parent());
+    }
+
+    #[test]
+    fn test_default_metrics_log_path_for_profile_contains_profile_name() {
+        let path = default_metrics_log_path_for_profile("dev");
+        assert!(path.contains("metrics.dev.jsonl"), "path was: {path}");
+    }
+
+    #[test]
+    fn test_default_metrics_log_path_for_profile_different_names() {
+        let dev = default_metrics_log_path_for_profile("dev");
+        let prod = default_metrics_log_path_for_profile("prod");
+        assert_ne!(dev, prod);
+        assert!(dev.contains("metrics.dev.jsonl"));
+        assert!(prod.contains("metrics.prod.jsonl"));
+    }
+
+    #[test]
+    fn test_pid_path_default_vs_profile() {
+        let default = pid_path(None);
+        let profiled = pid_path(Some("dev"));
+        assert_ne!(default, profiled);
+        assert!(default.to_str().unwrap().contains("higgs.pid"));
+        assert!(profiled.to_str().unwrap().contains("higgs.dev.pid"));
+    }
+
+    #[test]
+    fn test_log_path_default_vs_profile() {
+        let default = log_path(None);
+        let profiled = log_path(Some("dev"));
+        assert_ne!(default, profiled);
+        assert!(default.to_str().unwrap().contains("higgs.log"));
+        assert!(profiled.to_str().unwrap().contains("higgs.dev.log"));
+    }
 }

--- a/crates/higgs/src/config.rs
+++ b/crates/higgs/src/config.rs
@@ -21,8 +21,18 @@ use serde::{Deserialize, Serialize};
 )]
 pub struct Cli {
     /// Path to config file (default: ~/.config/higgs/config.toml when auto-discovered).
-    #[arg(short, long, global = true, value_name = "FILE")]
+    #[arg(
+        short,
+        long,
+        global = true,
+        value_name = "FILE",
+        conflicts_with = "profile"
+    )]
     pub config: Option<PathBuf>,
+
+    /// Named config profile (resolves to ~/.config/higgs/config.<NAME>.toml).
+    #[arg(long, global = true, value_name = "NAME")]
+    pub profile: Option<String>,
 
     /// Enable debug logging.
     #[arg(short, long, global = true)]
@@ -363,7 +373,7 @@ const fn default_retention_minutes() -> u64 {
 
 /// Returns true if this is "simple mode" -- no config file, models come from CLI.
 pub const fn is_simple_mode(cli: &Cli, serve_args: &ServeArgs) -> bool {
-    cli.config.is_none() && !serve_args.models.is_empty()
+    cli.config.is_none() && cli.profile.is_none() && !serve_args.models.is_empty()
 }
 
 /// Build a `HiggsConfig` from CLI args only (simple mode, no config file).
@@ -561,14 +571,39 @@ pub fn default_config_path() -> PathBuf {
     config_dir().join("config.toml")
 }
 
-/// Returns the PID file path (~/.config/higgs/higgs.pid).
-pub fn pid_path() -> PathBuf {
-    config_dir().join("higgs.pid")
+/// Returns the config file path for a named profile (~/.config/higgs/config.<name>.toml).
+pub fn profile_config_path(name: &str) -> PathBuf {
+    config_dir().join(format!("config.{name}.toml"))
 }
 
-/// Returns the log file path (~/.config/higgs/higgs.log).
-pub fn log_path() -> PathBuf {
-    config_dir().join("higgs.log")
+/// Returns the PID file path, optionally scoped to a profile.
+pub fn pid_path(profile: Option<&str>) -> PathBuf {
+    profile.map_or_else(
+        || config_dir().join("higgs.pid"),
+        |name| config_dir().join(format!("higgs.{name}.pid")),
+    )
+}
+
+/// Returns the log file path, optionally scoped to a profile.
+pub fn log_path(profile: Option<&str>) -> PathBuf {
+    profile.map_or_else(
+        || config_dir().join("higgs.log"),
+        |name| config_dir().join(format!("higgs.{name}.log")),
+    )
+}
+
+/// Returns the default metrics log path, optionally scoped to a profile.
+pub fn default_metrics_log_path_for_profile(profile: &str) -> String {
+    directories::BaseDirs::new()
+        .map_or_else(
+            || PathBuf::from(format!("/tmp/higgs/logs/metrics.{profile}.jsonl")),
+            |d| {
+                d.home_dir()
+                    .join(format!(".config/higgs/logs/metrics.{profile}.jsonl"))
+            },
+        )
+        .to_string_lossy()
+        .to_string()
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/higgs/src/config.rs
+++ b/crates/higgs/src/config.rs
@@ -571,6 +571,25 @@ pub fn default_config_path() -> PathBuf {
     config_dir().join("config.toml")
 }
 
+/// Validates that a profile name is safe for use in file paths.
+pub fn validate_profile_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("profile name must not be empty".to_owned());
+    }
+    if name.contains('/') || name.contains('\\') || name.contains("..") {
+        return Err(format!("profile name '{name}' contains invalid characters"));
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err(format!(
+            "profile name '{name}' must contain only alphanumeric characters, hyphens, or underscores"
+        ));
+    }
+    Ok(())
+}
+
 /// Returns the config file path for a named profile (~/.config/higgs/config.<name>.toml).
 pub fn profile_config_path(name: &str) -> PathBuf {
     config_dir().join(format!("config.{name}.toml"))
@@ -1157,5 +1176,30 @@ mod tests {
         .unwrap();
         let config = load_config_file(&path, None).unwrap();
         assert!(config.models.first().unwrap().name.is_none());
+    }
+
+    #[test]
+    fn test_validate_profile_name_valid() {
+        assert!(validate_profile_name("dev").is_ok());
+        assert!(validate_profile_name("prod-us").is_ok());
+        assert!(validate_profile_name("test_1").is_ok());
+    }
+
+    #[test]
+    fn test_validate_profile_name_rejects_traversal() {
+        assert!(validate_profile_name("../etc").is_err());
+        assert!(validate_profile_name("foo/bar").is_err());
+        assert!(validate_profile_name("foo\\bar").is_err());
+    }
+
+    #[test]
+    fn test_validate_profile_name_rejects_empty() {
+        assert!(validate_profile_name("").is_err());
+    }
+
+    #[test]
+    fn test_validate_profile_name_rejects_special_chars() {
+        assert!(validate_profile_name("dev.prod").is_err());
+        assert!(validate_profile_name("dev prod").is_err());
     }
 }

--- a/crates/higgs/src/daemon.rs
+++ b/crates/higgs/src/daemon.rs
@@ -56,7 +56,6 @@ pub fn cmd_stop(profile: Option<&str>) {
             while pid_is_alive(pid) {
                 if std::time::Instant::now() >= deadline {
                     eprintln!("sent SIGTERM to {pid} but process still running after 5s");
-                    remove_pid_file(profile);
                     return;
                 }
                 std::thread::sleep(Duration::from_millis(50));
@@ -93,7 +92,13 @@ pub fn cmd_init(profile: Option<&str>) {
         std::process::exit(1);
     }
 
-    let default_config = r#"[server]
+    let metrics_path_example = profile.map_or_else(
+        || "~/.config/higgs/logs/metrics.jsonl".to_owned(),
+        |name| format!("~/.config/higgs/logs/metrics.{name}.jsonl"),
+    );
+
+    let default_config = format!(
+        r#"[server]
 host = "0.0.0.0"
 port = 8000
 # max_tokens = 32768
@@ -164,10 +169,11 @@ provider = "higgs"
 
 # [logging.metrics]
 # enabled = true
-# path = "~/.config/higgs/logs/metrics.jsonl"
+# path = "{metrics_path_example}"
 # max_size_mb = 50
 # max_files = 5
-"#;
+"#
+    );
 
     if let Err(e) = fs::write(&path, default_config) {
         eprintln!("failed to write {}: {e}", path.display());

--- a/crates/higgs/src/daemon.rs
+++ b/crates/higgs/src/daemon.rs
@@ -275,7 +275,11 @@ pub fn detach(config_path: &Path, verbose: bool, profile: Option<&str>) {
     };
 
     // Probe the server address from config to check readiness
-    let Ok(probe_config) = crate::config::load_config_file(config_path, None) else {
+    let probe_path = profile.map_or_else(
+        || config_path.to_path_buf(),
+        crate::config::profile_config_path,
+    );
+    let Ok(probe_config) = crate::config::load_config_file(&probe_path, None) else {
         eprintln!(
             "{label} started (pid {child_pid}), log: {}",
             log_path(profile).display()

--- a/crates/higgs/src/daemon.rs
+++ b/crates/higgs/src/daemon.rs
@@ -13,16 +13,16 @@ use crate::config::{self, HiggsConfig};
 use crate::metrics::MetricsStore;
 use crate::metrics_log::MetricsLogger;
 
-fn pid_path() -> std::path::PathBuf {
-    config::pid_path()
+fn pid_path(profile: Option<&str>) -> std::path::PathBuf {
+    config::pid_path(profile)
 }
 
-fn log_path() -> std::path::PathBuf {
-    config::log_path()
+fn log_path(profile: Option<&str>) -> std::path::PathBuf {
+    config::log_path(profile)
 }
 
-pub fn read_pid() -> Option<i32> {
-    fs::read_to_string(pid_path())
+pub fn read_pid(profile: Option<&str>) -> Option<i32> {
+    fs::read_to_string(pid_path(profile))
         .ok()
         .and_then(|s| s.trim().parse().ok())
 }
@@ -31,20 +31,21 @@ pub fn pid_is_alive(pid: i32) -> bool {
     kill(Pid::from_raw(pid), None).is_ok()
 }
 
-pub fn remove_pid_file() {
-    let _ = fs::remove_file(pid_path());
+pub fn remove_pid_file(profile: Option<&str>) {
+    let _ = fs::remove_file(pid_path(profile));
 }
 
-pub fn write_pid_file() {
+pub fn write_pid_file(profile: Option<&str>) {
     let pid = std::process::id();
-    if let Err(e) = fs::write(pid_path(), pid.to_string()) {
+    if let Err(e) = fs::write(pid_path(profile), pid.to_string()) {
         tracing::warn!("failed to write pid file: {e}");
     }
 }
 
 #[allow(clippy::print_stderr)]
-pub fn cmd_stop() {
-    match read_pid() {
+pub fn cmd_stop(profile: Option<&str>) {
+    let label = profile.map_or_else(|| "higgs".to_owned(), |p| format!("higgs [{p}]"));
+    match read_pid(profile) {
         Some(pid) if pid_is_alive(pid) => {
             if let Err(e) = kill(Pid::from_raw(pid), Signal::SIGTERM) {
                 eprintln!("failed to send SIGTERM to {pid}: {e}");
@@ -55,28 +56,32 @@ pub fn cmd_stop() {
             while pid_is_alive(pid) {
                 if std::time::Instant::now() >= deadline {
                     eprintln!("sent SIGTERM to {pid} but process still running after 5s");
-                    remove_pid_file();
+                    remove_pid_file(profile);
                     return;
                 }
                 std::thread::sleep(Duration::from_millis(50));
             }
-            remove_pid_file();
-            eprintln!("stopped higgs (pid {pid})");
+            remove_pid_file(profile);
+            eprintln!("stopped {label} (pid {pid})");
         }
         Some(_) => {
-            remove_pid_file();
-            eprintln!("higgs is not running (stale pid file removed)");
+            remove_pid_file(profile);
+            eprintln!("{label} is not running (stale pid file removed)");
         }
         None => {
-            eprintln!("higgs is not running (no pid file)");
+            eprintln!("{label} is not running (no pid file)");
         }
     }
 }
 
 #[allow(clippy::print_stderr)]
-pub fn cmd_init() {
+pub fn cmd_init(profile: Option<&str>) {
     let dir = config::config_dir();
-    let path = dir.join("config.toml");
+    let filename = profile.map_or_else(
+        || "config.toml".to_owned(),
+        |name| format!("config.{name}.toml"),
+    );
+    let path = dir.join(filename);
 
     if path.exists() {
         eprintln!("config already exists: {}", path.display());
@@ -188,14 +193,16 @@ pub fn cmd_shellenv(config: &HiggsConfig) {
     }
 }
 
-#[allow(clippy::print_stderr, unsafe_code)]
-pub fn detach(config_path: &Path, verbose: bool) {
-    if let Some(pid) = read_pid() {
+#[allow(clippy::print_stderr, clippy::too_many_lines, unsafe_code)]
+pub fn detach(config_path: &Path, verbose: bool, profile: Option<&str>) {
+    let label = profile.map_or_else(|| "higgs".to_owned(), |p| format!("higgs [{p}]"));
+
+    if let Some(pid) = read_pid(profile) {
         if pid_is_alive(pid) {
-            eprintln!("higgs is already running (pid {pid})");
+            eprintln!("{label} is already running (pid {pid})");
             std::process::exit(1);
         }
-        remove_pid_file();
+        remove_pid_file(profile);
     }
 
     let dir = config::config_dir();
@@ -204,7 +211,7 @@ pub fn detach(config_path: &Path, verbose: bool) {
         std::process::exit(1);
     }
 
-    let Ok(log) = fs::File::create(log_path()) else {
+    let Ok(log) = fs::File::create(log_path(profile)) else {
         eprintln!("failed to create log file");
         std::process::exit(1);
     };
@@ -224,7 +231,12 @@ pub fn detach(config_path: &Path, verbose: bool) {
     };
 
     let mut cmd = std::process::Command::new(exe);
-    cmd.arg("serve").arg("--config").arg(config_path);
+    cmd.arg("serve");
+    if let Some(name) = profile {
+        cmd.arg("--profile").arg(name);
+    } else {
+        cmd.arg("--config").arg(config_path);
+    }
     if verbose {
         cmd.arg("--verbose");
     }
@@ -252,7 +264,7 @@ pub fn detach(config_path: &Path, verbose: bool) {
         let _ = child.wait();
     });
 
-    if let Err(e) = fs::write(pid_path(), child_pid.to_string()) {
+    if let Err(e) = fs::write(pid_path(profile), child_pid.to_string()) {
         eprintln!("failed to write pid file: {e}");
         std::process::exit(1);
     }
@@ -265,8 +277,8 @@ pub fn detach(config_path: &Path, verbose: bool) {
     // Probe the server address from config to check readiness
     let Ok(probe_config) = crate::config::load_config_file(config_path, None) else {
         eprintln!(
-            "higgs started (pid {child_pid}), log: {}",
-            log_path().display()
+            "{label} started (pid {child_pid}), log: {}",
+            log_path(profile).display()
         );
         return;
     };
@@ -281,21 +293,24 @@ pub fn detach(config_path: &Path, verbose: bool) {
     let deadline = std::time::Instant::now() + Duration::from_secs(5);
     loop {
         if !pid_is_alive(child_pid_i32) {
-            remove_pid_file();
-            eprintln!("higgs failed to start, check {}", log_path().display());
+            remove_pid_file(profile);
+            eprintln!(
+                "{label} failed to start, check {}",
+                log_path(profile).display()
+            );
             std::process::exit(1);
         }
         if TcpStream::connect(&probe_addr).is_ok() {
             eprintln!(
-                "higgs started (pid {child_pid}), log: {}",
-                log_path().display()
+                "{label} started (pid {child_pid}), log: {}",
+                log_path(profile).display()
             );
             return;
         }
         if std::time::Instant::now() >= deadline {
             eprintln!(
-                "higgs started (pid {child_pid}) but not yet accepting connections, log: {}",
-                log_path().display()
+                "{label} started (pid {child_pid}) but not yet accepting connections, log: {}",
+                log_path(profile).display()
             );
             return;
         }
@@ -304,7 +319,7 @@ pub fn detach(config_path: &Path, verbose: bool) {
 }
 
 #[allow(clippy::print_stderr)]
-pub fn run_attached(config: &HiggsConfig) {
+pub fn run_attached(config: &HiggsConfig, profile: Option<&str>) {
     if !config.logging.metrics.enabled {
         eprintln!("cannot attach: [logging.metrics] enabled = true required in config");
         std::process::exit(1);
@@ -333,7 +348,9 @@ pub fn run_attached(config: &HiggsConfig) {
         }
     });
 
-    match crate::tui::run(Arc::clone(&metrics), true) {
+    let tui_config = crate::tui::TuiConfig::from_higgs_config(config, profile);
+
+    match crate::tui::run(Arc::clone(&metrics), true, Some(tui_config)) {
         Ok(_) => {}
         Err(e) => {
             eprintln!("TUI error: {e}");
@@ -433,21 +450,35 @@ mod tests {
     #[test]
     fn pid_path_suffix() {
         with_temp_config_dir(|dir| {
-            assert_eq!(pid_path(), dir.join("higgs.pid"));
+            assert_eq!(pid_path(None), dir.join("higgs.pid"));
+        });
+    }
+
+    #[test]
+    fn pid_path_profile_suffix() {
+        with_temp_config_dir(|dir| {
+            assert_eq!(pid_path(Some("dev")), dir.join("higgs.dev.pid"));
         });
     }
 
     #[test]
     fn log_path_suffix() {
         with_temp_config_dir(|dir| {
-            assert_eq!(log_path(), dir.join("higgs.log"));
+            assert_eq!(log_path(None), dir.join("higgs.log"));
+        });
+    }
+
+    #[test]
+    fn log_path_profile_suffix() {
+        with_temp_config_dir(|dir| {
+            assert_eq!(log_path(Some("dev")), dir.join("higgs.dev.log"));
         });
     }
 
     #[test]
     fn read_pid_none_when_no_file() {
         with_temp_config_dir(|_| {
-            assert!(read_pid().is_none());
+            assert!(read_pid(None).is_none());
         });
     }
 
@@ -455,7 +486,7 @@ mod tests {
     fn read_pid_returns_valid_pid() {
         with_temp_config_dir(|dir| {
             std::fs::write(dir.join("higgs.pid"), "12345").unwrap();
-            assert_eq!(read_pid(), Some(12345));
+            assert_eq!(read_pid(None), Some(12345));
         });
     }
 
@@ -463,7 +494,7 @@ mod tests {
     fn read_pid_none_for_non_numeric() {
         with_temp_config_dir(|dir| {
             std::fs::write(dir.join("higgs.pid"), "not-a-number").unwrap();
-            assert!(read_pid().is_none());
+            assert!(read_pid(None).is_none());
         });
     }
 
@@ -471,8 +502,8 @@ mod tests {
     fn write_and_read_pid_file() {
         with_temp_config_dir(|dir| {
             std::fs::create_dir_all(dir).unwrap();
-            write_pid_file();
-            let pid = read_pid().unwrap();
+            write_pid_file(None);
+            let pid = read_pid(None).unwrap();
             assert_eq!(pid, i32::try_from(std::process::id()).unwrap());
         });
     }
@@ -483,7 +514,7 @@ mod tests {
             let path = dir.join("higgs.pid");
             std::fs::write(&path, "12345").unwrap();
             assert!(path.exists());
-            remove_pid_file();
+            remove_pid_file(None);
             assert!(!path.exists());
         });
     }
@@ -491,7 +522,7 @@ mod tests {
     #[test]
     fn remove_pid_file_noop_when_missing() {
         with_temp_config_dir(|_| {
-            remove_pid_file();
+            remove_pid_file(None);
         });
     }
 
@@ -552,7 +583,7 @@ mod tests {
     fn cmd_init_creates_config_file() {
         with_temp_config_dir(|dir| {
             std::fs::create_dir_all(dir).unwrap();
-            cmd_init();
+            cmd_init(None);
             assert!(dir.join("config.toml").exists());
         });
     }
@@ -563,8 +594,18 @@ mod tests {
             std::fs::create_dir_all(dir).unwrap();
             let path = dir.join("config.toml");
             std::fs::write(&path, "existing content").unwrap();
-            cmd_init();
+            cmd_init(None);
             assert_eq!(std::fs::read_to_string(&path).unwrap(), "existing content");
+        });
+    }
+
+    #[test]
+    fn cmd_init_profile_creates_named_config() {
+        with_temp_config_dir(|dir| {
+            std::fs::create_dir_all(dir).unwrap();
+            cmd_init(Some("dev"));
+            assert!(dir.join("config.dev.toml").exists());
+            assert!(!dir.join("config.toml").exists());
         });
     }
 }

--- a/crates/higgs/src/main.rs
+++ b/crates/higgs/src/main.rs
@@ -7,7 +7,7 @@ use clap::Parser;
 
 use higgs::{
     build_router,
-    config::{self, Cli, Commands, ConfigAction, HiggsConfig, ServeArgs},
+    config::{self, Cli, Commands, ConfigAction, HiggsConfig, MetricsLogConfig, ServeArgs},
     model_download, model_resolver,
     router::Router,
     state::{AppState, Engine},
@@ -18,24 +18,26 @@ use higgs::{
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
+    let profile = cli.profile.as_deref();
+
     match cli.command {
         Commands::Serve(ref args) => cmd_serve(&cli, args).await,
         Commands::Start(ref _args) => {
             let config_path = resolve_config_path(&cli)?;
-            higgs::daemon::detach(&config_path, cli.verbose);
+            higgs::daemon::detach(&config_path, cli.verbose, profile);
             Ok(())
         }
         Commands::Stop => {
-            higgs::daemon::cmd_stop();
+            higgs::daemon::cmd_stop(profile);
             Ok(())
         }
         Commands::Attach => {
             let config = load_config_for_command(&cli)?;
-            higgs::daemon::run_attached(&config);
+            higgs::daemon::run_attached(&config, profile);
             Ok(())
         }
         Commands::Init => {
-            higgs::daemon::cmd_init();
+            higgs::daemon::cmd_init(profile);
             Ok(())
         }
         Commands::Shellenv => {
@@ -51,6 +53,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             init_tracing(cli.verbose);
             let config = if let Some(ref path) = cli.config {
                 config::load_config_file(path, Some(args))?
+            } else if let Some(ref name) = cli.profile {
+                let path = config::profile_config_path(name);
+                config::load_config_file(&path, Some(args))?
             } else {
                 let default = config::default_config_path();
                 if default.exists() {
@@ -70,11 +75,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 }
 
-/// Resolve a config file path from CLI args or the default location.
+/// Resolve a config file path from CLI args, profile, or the default location.
 #[allow(clippy::print_stderr)]
 fn resolve_config_path(cli: &Cli) -> Result<std::path::PathBuf, Box<dyn std::error::Error>> {
     if let Some(ref path) = cli.config {
         return Ok(path.clone());
+    }
+    if let Some(ref name) = cli.profile {
+        let path = config::profile_config_path(name);
+        if path.exists() {
+            return Ok(path);
+        }
+        return Err(format!(
+            "profile config not found at {}\nhint: use 'higgs init --profile {name}' to create one",
+            path.display()
+        )
+        .into());
     }
     let default = config::default_config_path();
     if default.exists() {
@@ -97,13 +113,17 @@ fn load_config_for_command(cli: &Cli) -> Result<HiggsConfig, Box<dyn std::error:
 async fn cmd_serve(cli: &Cli, args: &ServeArgs) -> Result<(), Box<dyn std::error::Error>> {
     init_tracing(cli.verbose);
 
+    let profile = cli.profile.as_deref();
     let simple_mode = config::is_simple_mode(cli, args);
 
     // Load config: simple mode (--model) or config file mode (--config)
-    let higgs_config = if simple_mode {
+    let mut higgs_config = if simple_mode {
         config::build_simple_config(args)?
     } else if let Some(ref path) = cli.config {
         config::load_config_file(path, Some(args))?
+    } else if let Some(ref name) = cli.profile {
+        let path = config::profile_config_path(name);
+        config::load_config_file(&path, Some(args))?
     } else if args.models.is_empty() {
         let default_path = config::default_config_path();
         if default_path.exists() {
@@ -116,6 +136,15 @@ async fn cmd_serve(cli: &Cli, args: &ServeArgs) -> Result<(), Box<dyn std::error
     } else {
         config::build_simple_config(args)?
     };
+
+    // Rewrite metrics path for profile isolation if still at default
+    if let Some(name) = profile {
+        let default_path = config::default_metrics_log_path_for_profile(name);
+        let generic_default = MetricsLogConfig::default().path;
+        if higgs_config.logging.metrics.path == generic_default {
+            higgs_config.logging.metrics.path = default_path;
+        }
+    }
 
     // Load all local models and build router
     let engines = load_engines(&higgs_config)?;
@@ -157,7 +186,7 @@ async fn cmd_serve(cli: &Cli, args: &ServeArgs) -> Result<(), Box<dyn std::error
     let listener = tokio::net::TcpListener::bind(&bind_addr).await?;
 
     // Write PID file after bind succeeds so it's never stale on bind errors
-    higgs::daemon::write_pid_file();
+    higgs::daemon::write_pid_file(profile);
 
     axum::serve(
         listener,
@@ -166,7 +195,7 @@ async fn cmd_serve(cli: &Cli, args: &ServeArgs) -> Result<(), Box<dyn std::error
     .with_graceful_shutdown(higgs::daemon::await_shutdown_signal())
     .await?;
 
-    higgs::daemon::remove_pid_file();
+    higgs::daemon::remove_pid_file(profile);
     Ok(())
 }
 
@@ -235,10 +264,13 @@ fn load_engines(
 }
 
 fn cmd_config(cli: &Cli, action: &ConfigAction) {
-    let config_path = cli
-        .config
-        .clone()
-        .unwrap_or_else(config::default_config_path);
+    let config_path = cli.config.clone().unwrap_or_else(|| {
+        cli.profile
+            .as_ref()
+            .map_or_else(config::default_config_path, |name| {
+                config::profile_config_path(name)
+            })
+    });
     match action {
         ConfigAction::Get { key } => {
             higgs::cli_config::config_get(&config_path, key);

--- a/crates/higgs/src/main.rs
+++ b/crates/higgs/src/main.rs
@@ -124,8 +124,8 @@ async fn cmd_serve(cli: &Cli, args: &ServeArgs) -> Result<(), Box<dyn std::error
         config::build_simple_config(args)?
     } else if let Some(ref path) = cli.config {
         config::load_config_file(path, Some(args))?
-    } else if let Some(ref name) = cli.profile {
-        let path = config::profile_config_path(name);
+    } else if cli.profile.is_some() {
+        let path = resolve_config_path(cli)?;
         config::load_config_file(&path, Some(args))?
     } else if args.models.is_empty() {
         let default_path = config::default_config_path();

--- a/crates/higgs/src/main.rs
+++ b/crates/higgs/src/main.rs
@@ -18,6 +18,9 @@ use higgs::{
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
+    if let Some(ref name) = cli.profile {
+        config::validate_profile_name(name)?;
+    }
     let profile = cli.profile.as_deref();
 
     match cli.command {
@@ -53,8 +56,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             init_tracing(cli.verbose);
             let config = if let Some(ref path) = cli.config {
                 config::load_config_file(path, Some(args))?
-            } else if let Some(ref name) = cli.profile {
-                let path = config::profile_config_path(name);
+            } else if cli.profile.is_some() {
+                let path = resolve_config_path(&cli)?;
                 config::load_config_file(&path, Some(args))?
             } else {
                 let default = config::default_config_path();

--- a/crates/higgs/src/tui/mod.rs
+++ b/crates/higgs/src/tui/mod.rs
@@ -553,4 +553,181 @@ mod tests {
         let app = make_attached_app();
         assert!(app.attached);
     }
+
+    // -- TuiConfig::from_higgs_config tests -----------------------------------
+
+    use crate::config::{
+        AutoRouterConfig, DefaultRoute, HiggsConfig, ModelConfig, ProviderConfig, RouteConfig,
+    };
+    use std::collections::HashMap;
+
+    fn minimal_config() -> HiggsConfig {
+        HiggsConfig {
+            models: vec![ModelConfig {
+                path: "mlx-community/Llama-3.2-1B-Instruct-4bit".to_owned(),
+                name: None,
+                batch: false,
+            }],
+            ..HiggsConfig::default()
+        }
+    }
+
+    #[test]
+    fn from_config_extracts_model_name_from_path() {
+        let config = minimal_config();
+        let tui = TuiConfig::from_higgs_config(&config, None);
+        assert_eq!(tui.model_names, vec!["Llama-3.2-1B-Instruct-4bit"]);
+    }
+
+    #[test]
+    fn from_config_uses_explicit_model_name() {
+        let mut config = minimal_config();
+        config.models[0].name = Some("llama".to_owned());
+        let tui = TuiConfig::from_higgs_config(&config, None);
+        assert_eq!(tui.model_names, vec!["llama"]);
+    }
+
+    #[test]
+    fn from_config_injects_higgs_provider_when_models_exist() {
+        let config = minimal_config();
+        let tui = TuiConfig::from_higgs_config(&config, None);
+        assert!(tui.provider_names.contains(&"higgs".to_owned()));
+    }
+
+    #[test]
+    fn from_config_no_higgs_provider_without_models() {
+        let config = HiggsConfig::default();
+        let tui = TuiConfig::from_higgs_config(&config, None);
+        assert!(!tui.provider_names.contains(&"higgs".to_owned()));
+    }
+
+    #[test]
+    fn from_config_includes_remote_providers() {
+        let mut config = minimal_config();
+        config.providers.insert(
+            "anthropic".to_owned(),
+            ProviderConfig {
+                url: "https://api.anthropic.com".to_owned(),
+                format: crate::config::ApiFormat::Anthropic,
+                api_key: None,
+                strip_auth: false,
+                stub_count_tokens: false,
+            },
+        );
+        let tui = TuiConfig::from_higgs_config(&config, None);
+        assert!(tui.provider_names.contains(&"anthropic".to_owned()));
+        assert!(tui.provider_names.contains(&"higgs".to_owned()));
+    }
+
+    #[test]
+    fn from_config_providers_are_sorted() {
+        let mut config = minimal_config();
+        let mut providers = HashMap::new();
+        providers.insert(
+            "openai".to_owned(),
+            ProviderConfig {
+                url: "https://api.openai.com".to_owned(),
+                format: crate::config::ApiFormat::OpenAi,
+                api_key: None,
+                strip_auth: false,
+                stub_count_tokens: false,
+            },
+        );
+        providers.insert(
+            "anthropic".to_owned(),
+            ProviderConfig {
+                url: "https://api.anthropic.com".to_owned(),
+                format: crate::config::ApiFormat::Anthropic,
+                api_key: None,
+                strip_auth: false,
+                stub_count_tokens: false,
+            },
+        );
+        config.providers = providers;
+        let tui = TuiConfig::from_higgs_config(&config, None);
+        let expected = vec!["anthropic", "higgs", "openai"];
+        assert_eq!(tui.provider_names, expected);
+    }
+
+    #[test]
+    fn from_config_maps_routes() {
+        let mut config = minimal_config();
+        config.routes = vec![RouteConfig {
+            pattern: Some("claude-.*".to_owned()),
+            provider: "anthropic".to_owned(),
+            model: Some("claude-sonnet-4-6".to_owned()),
+            name: Some("Claude".to_owned()),
+            description: Some("Anthropic models".to_owned()),
+        }];
+        let tui = TuiConfig::from_higgs_config(&config, None);
+        assert_eq!(tui.routes.len(), 1);
+        let r = &tui.routes[0];
+        assert_eq!(r.pattern.as_deref(), Some("claude-.*"));
+        assert_eq!(r.provider, "anthropic");
+        assert_eq!(r.model_rewrite.as_deref(), Some("claude-sonnet-4-6"));
+        assert_eq!(r.name.as_deref(), Some("Claude"));
+        assert_eq!(r.description.as_deref(), Some("Anthropic models"));
+    }
+
+    #[test]
+    fn from_config_copies_default_provider() {
+        let mut config = minimal_config();
+        config.default = DefaultRoute {
+            provider: "openai".to_owned(),
+        };
+        let tui = TuiConfig::from_higgs_config(&config, None);
+        assert_eq!(tui.default_provider, "openai");
+    }
+
+    #[test]
+    fn from_config_copies_auto_router() {
+        let mut config = minimal_config();
+        config.auto_router = AutoRouterConfig {
+            enabled: true,
+            force: true,
+            model: "my-router".to_owned(),
+            timeout_ms: 5000,
+        };
+        let tui = TuiConfig::from_higgs_config(&config, None);
+        assert!(tui.auto_router.enabled);
+        assert!(tui.auto_router.force);
+        assert_eq!(tui.auto_router.model, "my-router");
+        assert_eq!(tui.auto_router.timeout_ms, 5000);
+    }
+
+    #[test]
+    fn from_config_passes_profile() {
+        let config = minimal_config();
+        let tui = TuiConfig::from_higgs_config(&config, Some("dev"));
+        assert_eq!(tui.profile.as_deref(), Some("dev"));
+    }
+
+    #[test]
+    fn from_config_none_profile() {
+        let config = minimal_config();
+        let tui = TuiConfig::from_higgs_config(&config, None);
+        assert!(tui.profile.is_none());
+    }
+
+    #[test]
+    fn from_config_no_duplicate_higgs_when_already_a_provider() {
+        let mut config = minimal_config();
+        config.providers.insert(
+            "higgs".to_owned(),
+            ProviderConfig {
+                url: "http://localhost:8000".to_owned(),
+                format: crate::config::ApiFormat::OpenAi,
+                api_key: None,
+                strip_auth: false,
+                stub_count_tokens: false,
+            },
+        );
+        let tui = TuiConfig::from_higgs_config(&config, None);
+        let higgs_count = tui
+            .provider_names
+            .iter()
+            .filter(|n| n.as_str() == "higgs")
+            .count();
+        assert_eq!(higgs_count, 1);
+    }
 }

--- a/crates/higgs/src/tui/mod.rs
+++ b/crates/higgs/src/tui/mod.rs
@@ -8,7 +8,85 @@ use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph, Tabs};
 
+use crate::config::HiggsConfig;
 use crate::metrics::MetricsStore;
+
+// ---------------------------------------------------------------------------
+// TuiConfig -- config data passed to the TUI for display
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct TuiConfig {
+    pub profile: Option<String>,
+    pub model_names: Vec<String>,
+    pub provider_names: Vec<String>,
+    pub routes: Vec<TuiRoute>,
+    pub default_provider: String,
+    pub auto_router: TuiAutoRouter,
+}
+
+#[derive(Debug, Clone)]
+pub struct TuiRoute {
+    pub pattern: Option<String>,
+    pub provider: String,
+    pub model_rewrite: Option<String>,
+    pub name: Option<String>,
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TuiAutoRouter {
+    pub enabled: bool,
+    pub force: bool,
+    pub model: String,
+    pub timeout_ms: u64,
+}
+
+impl TuiConfig {
+    pub fn from_higgs_config(config: &HiggsConfig, profile: Option<&str>) -> Self {
+        let model_names: Vec<String> = config
+            .models
+            .iter()
+            .map(|m| {
+                m.name
+                    .clone()
+                    .unwrap_or_else(|| m.path.rsplit('/').next().unwrap_or(&m.path).to_owned())
+            })
+            .collect();
+
+        let mut provider_names: Vec<String> = config.providers.keys().cloned().collect();
+        if !config.models.is_empty() && !provider_names.contains(&"higgs".to_owned()) {
+            provider_names.push("higgs".to_owned());
+        }
+        provider_names.sort();
+
+        let routes: Vec<TuiRoute> = config
+            .routes
+            .iter()
+            .map(|r| TuiRoute {
+                pattern: r.pattern.clone(),
+                provider: r.provider.clone(),
+                model_rewrite: r.model.clone(),
+                name: r.name.clone(),
+                description: r.description.clone(),
+            })
+            .collect();
+
+        Self {
+            profile: profile.map(String::from),
+            model_names,
+            provider_names,
+            routes,
+            default_provider: config.default.provider.clone(),
+            auto_router: TuiAutoRouter {
+                enabled: config.auto_router.enabled,
+                force: config.auto_router.force,
+                model: config.auto_router.model.clone(),
+                timeout_ms: config.auto_router.timeout_ms,
+            },
+        }
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Tab {
@@ -16,11 +94,18 @@ pub enum Tab {
     Models,
     Providers,
     Errors,
+    Routing,
 }
 
 impl Tab {
     fn titles() -> Vec<&'static str> {
-        vec!["Overview [1]", "Models [2]", "Providers [3]", "Errors [4]"]
+        vec![
+            "Overview [1]",
+            "Models [2]",
+            "Providers [3]",
+            "Errors [4]",
+            "Routing [5]",
+        ]
     }
 
     const fn index(self) -> usize {
@@ -29,6 +114,7 @@ impl Tab {
             Self::Models => 1,
             Self::Providers => 2,
             Self::Errors => 3,
+            Self::Routing => 4,
         }
     }
 }
@@ -45,16 +131,22 @@ pub struct App {
     pub scroll_offset: usize,
     pub exit_mode: Option<ExitMode>,
     pub attached: bool,
+    pub config: Option<TuiConfig>,
 }
 
 impl App {
-    pub const fn new(metrics: Arc<MetricsStore>, attached: bool) -> Self {
+    pub const fn new(
+        metrics: Arc<MetricsStore>,
+        attached: bool,
+        config: Option<TuiConfig>,
+    ) -> Self {
         Self {
             metrics,
             active_tab: Tab::Overview,
             scroll_offset: 0,
             exit_mode: None,
             attached,
+            config,
         }
     }
 
@@ -84,21 +176,27 @@ impl App {
                 self.active_tab = Tab::Errors;
                 self.scroll_offset = 0;
             }
+            KeyCode::Char('5') => {
+                self.active_tab = Tab::Routing;
+                self.scroll_offset = 0;
+            }
             KeyCode::Tab | KeyCode::Right | KeyCode::Char('l') => {
                 self.active_tab = match self.active_tab {
                     Tab::Overview => Tab::Models,
                     Tab::Models => Tab::Providers,
                     Tab::Providers => Tab::Errors,
-                    Tab::Errors => Tab::Overview,
+                    Tab::Errors => Tab::Routing,
+                    Tab::Routing => Tab::Overview,
                 };
                 self.scroll_offset = 0;
             }
             KeyCode::Left | KeyCode::Char('h') => {
                 self.active_tab = match self.active_tab {
-                    Tab::Overview => Tab::Errors,
+                    Tab::Overview => Tab::Routing,
                     Tab::Models => Tab::Overview,
                     Tab::Providers => Tab::Models,
                     Tab::Errors => Tab::Providers,
+                    Tab::Routing => Tab::Errors,
                 };
                 self.scroll_offset = 0;
             }
@@ -135,10 +233,17 @@ impl App {
 
     #[allow(clippy::indexing_slicing)]
     pub fn draw(&self, frame: &mut Frame) {
+        let profile_tag = self
+            .config
+            .as_ref()
+            .and_then(|c| c.profile.as_ref())
+            .map(|p| format!(" [{p}]"))
+            .unwrap_or_default();
+
         let title = if self.attached {
-            " higgs (attached) "
+            format!(" higgs{profile_tag} (attached) ")
         } else {
-            " higgs "
+            format!(" higgs{profile_tag} ")
         };
 
         let hint = if self.attached {
@@ -173,13 +278,30 @@ impl App {
                 views::overview::draw(frame, content_area, &self.metrics, self.scroll_offset);
             }
             Tab::Models => {
-                views::models::draw(frame, content_area, &self.metrics, self.scroll_offset);
+                let names = self.config.as_ref().map(|c| c.model_names.as_slice());
+                views::models::draw(
+                    frame,
+                    content_area,
+                    &self.metrics,
+                    self.scroll_offset,
+                    names,
+                );
             }
             Tab::Providers => {
-                views::providers::draw(frame, content_area, &self.metrics, self.scroll_offset);
+                let names = self.config.as_ref().map(|c| c.provider_names.as_slice());
+                views::providers::draw(
+                    frame,
+                    content_area,
+                    &self.metrics,
+                    self.scroll_offset,
+                    names,
+                );
             }
             Tab::Errors => {
                 views::errors::draw(frame, content_area, &self.metrics, self.scroll_offset);
+            }
+            Tab::Routing => {
+                views::routing::draw(frame, content_area, self.config.as_ref());
             }
         }
 
@@ -191,7 +313,11 @@ impl App {
     }
 }
 
-pub fn run(metrics: Arc<MetricsStore>, attached: bool) -> io::Result<ExitMode> {
+pub fn run(
+    metrics: Arc<MetricsStore>,
+    attached: bool,
+    config: Option<TuiConfig>,
+) -> io::Result<ExitMode> {
     let mut terminal = ratatui::init();
 
     let default_hook = std::panic::take_hook();
@@ -200,7 +326,7 @@ pub fn run(metrics: Arc<MetricsStore>, attached: bool) -> io::Result<ExitMode> {
         default_hook(info);
     }));
 
-    let mut app = App::new(metrics, attached);
+    let mut app = App::new(metrics, attached, config);
 
     let result = (|| -> io::Result<ExitMode> {
         loop {
@@ -234,11 +360,19 @@ mod tests {
     use super::*;
 
     fn make_app() -> App {
-        App::new(Arc::new(MetricsStore::new(Duration::from_secs(60))), false)
+        App::new(
+            Arc::new(MetricsStore::new(Duration::from_secs(60))),
+            false,
+            None,
+        )
     }
 
     fn make_attached_app() -> App {
-        App::new(Arc::new(MetricsStore::new(Duration::from_secs(60))), true)
+        App::new(
+            Arc::new(MetricsStore::new(Duration::from_secs(60))),
+            true,
+            None,
+        )
     }
 
     fn key(code: KeyCode) -> event::KeyEvent {
@@ -294,6 +428,7 @@ mod tests {
             ('2', Tab::Models),
             ('3', Tab::Providers),
             ('4', Tab::Errors),
+            ('5', Tab::Routing),
             ('1', Tab::Overview),
         ] {
             app.handle_key(key(KeyCode::Char(ch)));
@@ -318,7 +453,13 @@ mod tests {
     fn tab_cycles_through_tabs() {
         assert_tab_cycle(
             KeyCode::Tab,
-            &[Tab::Models, Tab::Providers, Tab::Errors, Tab::Overview],
+            &[
+                Tab::Models,
+                Tab::Providers,
+                Tab::Errors,
+                Tab::Routing,
+                Tab::Overview,
+            ],
         );
     }
 
@@ -348,7 +489,13 @@ mod tests {
     fn right_arrow_cycles_forward() {
         assert_tab_cycle(
             KeyCode::Right,
-            &[Tab::Models, Tab::Providers, Tab::Errors, Tab::Overview],
+            &[
+                Tab::Models,
+                Tab::Providers,
+                Tab::Errors,
+                Tab::Routing,
+                Tab::Overview,
+            ],
         );
     }
 
@@ -356,7 +503,13 @@ mod tests {
     fn left_arrow_cycles_backward() {
         assert_tab_cycle(
             KeyCode::Left,
-            &[Tab::Errors, Tab::Providers, Tab::Models, Tab::Overview],
+            &[
+                Tab::Routing,
+                Tab::Errors,
+                Tab::Providers,
+                Tab::Models,
+                Tab::Overview,
+            ],
         );
     }
 

--- a/crates/higgs/src/tui/views/mod.rs
+++ b/crates/higgs/src/tui/views/mod.rs
@@ -5,6 +5,7 @@ pub mod errors;
 pub mod models;
 pub mod overview;
 pub mod providers;
+pub mod routing;
 
 /// Formats a token count for display: raw below 1K, "1.0K" style up to ~1M,
 /// "1.5M" style above.

--- a/crates/higgs/src/tui/views/models.rs
+++ b/crates/higgs/src/tui/views/models.rs
@@ -8,7 +8,13 @@ use crate::metrics::{MetricsStore, RequestRecord, RoutingMethod};
 
 /// Builds model-summary rows from a snapshot. Shared by the Models tab and the
 /// overview Token Usage panel.
-pub fn model_table(snap: &[RequestRecord], title: String, skip: usize) -> (Table<'static>, usize) {
+#[allow(clippy::too_many_lines)]
+pub fn model_table(
+    snap: &[RequestRecord],
+    title: String,
+    skip: usize,
+    configured_models: Option<&[String]>,
+) -> (Table<'static>, usize) {
     let groups = MetricsStore::group_by(snap, |r| r.model.clone());
 
     let header = Row::new(vec![
@@ -17,14 +23,36 @@ pub fn model_table(snap: &[RequestRecord], title: String, skip: usize) -> (Table
     .style(Style::default().add_modifier(Modifier::BOLD));
 
     let mut model_names: Vec<String> = groups.keys().cloned().collect();
+    // Merge in configured names not already present in metrics
+    if let Some(configured) = configured_models {
+        for name in configured {
+            if !model_names.contains(name) {
+                model_names.push(name.clone());
+            }
+        }
+    }
     model_names.sort();
     let total = model_names.len();
 
     let rows: Vec<Row> = model_names
         .iter()
         .skip(skip)
-        .filter_map(|model| {
-            let records = groups.get(model)?;
+        .map(|model| {
+            let Some(records) = groups.get(model) else {
+                // Zero-traffic configured model
+                let dim = Style::default().fg(Color::DarkGray);
+                return Row::new(vec![
+                    Cell::from("---").style(dim),
+                    Cell::from(model.clone()).style(dim),
+                    Cell::from("-").style(dim),
+                    Cell::from("-").style(dim),
+                    Cell::from("-").style(dim),
+                    Cell::from("-").style(dim),
+                    Cell::from("-").style(dim),
+                    Cell::from("-").style(dim),
+                    Cell::from("-").style(dim),
+                ]);
+            };
             let count = u64::try_from(records.len()).unwrap_or(0);
             let input: u64 = records.iter().map(|r| r.input_tokens).sum();
             let output: u64 = records.iter().map(|r| r.output_tokens).sum();
@@ -65,7 +93,7 @@ pub fn model_table(snap: &[RequestRecord], title: String, skip: usize) -> (Table
                 Style::default().fg(Color::DarkGray)
             };
 
-            Some(Row::new(vec![
+            Row::new(vec![
                 Cell::from(indicator).style(indicator_style),
                 Cell::from(model.clone()).style(Style::default().fg(Color::White)),
                 Cell::from(format_tokens(count)),
@@ -76,7 +104,7 @@ pub fn model_table(snap: &[RequestRecord], title: String, skip: usize) -> (Table
                 Cell::from(format_duration(p50)),
                 Cell::from(format_duration(p95)),
                 Cell::from(format_tokens(errors)).style(error_style),
-            ]))
+            ])
         })
         .collect();
 
@@ -100,9 +128,15 @@ pub fn model_table(snap: &[RequestRecord], title: String, skip: usize) -> (Table
     (table, total)
 }
 
-pub fn draw(frame: &mut Frame, area: Rect, metrics: &Arc<MetricsStore>, scroll: usize) {
+pub fn draw(
+    frame: &mut Frame,
+    area: Rect,
+    metrics: &Arc<MetricsStore>,
+    scroll: usize,
+    configured_models: Option<&[String]>,
+) {
     let snap = metrics.snapshot();
-    let (table, total) = model_table(&snap, " Models ".to_owned(), scroll);
+    let (table, total) = model_table(&snap, " Models ".to_owned(), scroll, configured_models);
     frame.render_widget(table, area);
     super::render_scrollbar(frame, area, total, scroll);
 }
@@ -140,7 +174,7 @@ mod tests {
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
         terminal
             .draw(|f| {
-                draw(f, f.area(), &metrics, 0);
+                draw(f, f.area(), &metrics, 0, None);
             })
             .unwrap();
     }
@@ -153,7 +187,7 @@ mod tests {
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
         terminal
             .draw(|f| {
-                draw(f, f.area(), &metrics, 0);
+                draw(f, f.area(), &metrics, 0, None);
             })
             .unwrap();
         let buffer = terminal.backend().buffer().clone();
@@ -177,7 +211,15 @@ mod tests {
         let mut other = sample_record();
         other.model = "gpt-4".to_owned();
         records.push(other);
-        let (_, total) = model_table(&records, " Test ".to_owned(), 0);
+        let (_, total) = model_table(&records, " Test ".to_owned(), 0, None);
+        assert_eq!(total, 2);
+    }
+
+    #[test]
+    fn model_table_includes_configured_with_zero_traffic() {
+        let records = vec![sample_record()];
+        let configured = vec!["claude-opus-4-6".to_owned(), "unused-model".to_owned()];
+        let (_, total) = model_table(&records, " Test ".to_owned(), 0, Some(&configured));
         assert_eq!(total, 2);
     }
 }

--- a/crates/higgs/src/tui/views/overview.rs
+++ b/crates/higgs/src/tui/views/overview.rs
@@ -220,7 +220,7 @@ fn draw_stats_row(frame: &mut Frame, area: Rect, snap: &[crate::metrics::Request
 }
 
 fn draw_token_usage(frame: &mut Frame, area: Rect, snap: &[crate::metrics::RequestRecord]) {
-    let (table, _) = super::models::model_table(snap, " Token Usage ".to_owned(), 0);
+    let (table, _) = super::models::model_table(snap, " Token Usage ".to_owned(), 0, None);
     frame.render_widget(table, area);
 }
 

--- a/crates/higgs/src/tui/views/providers.rs
+++ b/crates/higgs/src/tui/views/providers.rs
@@ -6,7 +6,13 @@ use ratatui::widgets::{Block, Borders, Cell, Row, Table};
 use super::{format_duration, format_tokens};
 use crate::metrics::MetricsStore;
 
-pub fn draw(frame: &mut Frame, area: Rect, metrics: &Arc<MetricsStore>, scroll: usize) {
+pub fn draw(
+    frame: &mut Frame,
+    area: Rect,
+    metrics: &Arc<MetricsStore>,
+    scroll: usize,
+    configured_providers: Option<&[String]>,
+) {
     let snap = metrics.snapshot();
     let groups = MetricsStore::group_by(&snap, |r| r.provider.clone());
 
@@ -15,7 +21,15 @@ pub fn draw(frame: &mut Frame, area: Rect, metrics: &Arc<MetricsStore>, scroll: 
     ])
     .style(Style::default().add_modifier(Modifier::BOLD));
 
-    let mut names: Vec<&String> = groups.keys().collect();
+    let mut names: Vec<String> = groups.keys().cloned().collect();
+    // Merge in configured provider names not already present in metrics
+    if let Some(configured) = configured_providers {
+        for name in configured {
+            if !names.contains(name) {
+                names.push(name.clone());
+            }
+        }
+    }
     names.sort();
 
     let total = names.len();
@@ -23,8 +37,21 @@ pub fn draw(frame: &mut Frame, area: Rect, metrics: &Arc<MetricsStore>, scroll: 
     let rows: Vec<Row> = names
         .iter()
         .skip(scroll)
-        .filter_map(|name| {
-            let records = groups.get(*name)?;
+        .map(|name| {
+            let Some(records) = groups.get(name) else {
+                // Zero-traffic configured provider
+                let dim = Style::default().fg(Color::DarkGray);
+                return Row::new(vec![
+                    Cell::from(name.as_str()).style(dim),
+                    Cell::from("-").style(dim),
+                    Cell::from("-").style(dim),
+                    Cell::from("-").style(dim),
+                    Cell::from("-").style(dim),
+                    Cell::from("-").style(dim),
+                    Cell::from("-").style(dim),
+                    Cell::from("-").style(dim),
+                ]);
+            };
             let count = u64::try_from(records.len()).unwrap_or(0);
             let input: u64 = records.iter().map(|r| r.input_tokens).sum();
             let output: u64 = records.iter().map(|r| r.output_tokens).sum();
@@ -38,7 +65,7 @@ pub fn draw(frame: &mut Frame, area: Rect, metrics: &Arc<MetricsStore>, scroll: 
             } else {
                 Style::default().fg(Color::DarkGray)
             };
-            Some(Row::new(vec![
+            Row::new(vec![
                 Cell::from(name.as_str()).style(Style::default().fg(Color::White)),
                 Cell::from(format_tokens(count)),
                 Cell::from(format_tokens(input)).style(Style::default().fg(Color::Cyan)),
@@ -48,7 +75,7 @@ pub fn draw(frame: &mut Frame, area: Rect, metrics: &Arc<MetricsStore>, scroll: 
                 Cell::from(format_duration(p50)),
                 Cell::from(format_duration(p95)),
                 Cell::from(format_tokens(errors)).style(error_style),
-            ]))
+            ])
         })
         .collect();
 
@@ -105,7 +132,7 @@ mod tests {
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
         terminal
             .draw(|f| {
-                draw(f, f.area(), &metrics, 0);
+                draw(f, f.area(), &metrics, 0, None);
             })
             .unwrap();
     }
@@ -118,7 +145,7 @@ mod tests {
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
         terminal
             .draw(|f| {
-                draw(f, f.area(), &metrics, 0);
+                draw(f, f.area(), &metrics, 0, None);
             })
             .unwrap();
         let buffer = terminal.backend().buffer().clone();
@@ -130,6 +157,29 @@ mod tests {
         assert!(
             content.contains("anthropic"),
             "buffer should contain provider name"
+        );
+    }
+
+    #[test]
+    fn draw_shows_configured_zero_traffic_providers() {
+        let metrics = Arc::new(MetricsStore::new(Duration::from_secs(3600)));
+        let configured = vec!["openai".to_owned(), "ollama".to_owned()];
+        let backend = ratatui::backend::TestBackend::new(120, 40);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                draw(f, f.area(), &metrics, 0, Some(&configured));
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        let content: String = buffer
+            .content()
+            .iter()
+            .map(|c| c.symbol().chars().next().unwrap_or(' '))
+            .collect();
+        assert!(
+            content.contains("openai"),
+            "buffer should contain configured provider"
         );
     }
 }

--- a/crates/higgs/src/tui/views/routing.rs
+++ b/crates/higgs/src/tui/views/routing.rs
@@ -1,0 +1,280 @@
+use ratatui::prelude::*;
+use ratatui::widgets::{Block, Borders, Cell, List, ListItem, Paragraph, Row, Table};
+
+use crate::tui::TuiConfig;
+
+pub fn draw(frame: &mut Frame, area: Rect, config: Option<&TuiConfig>) {
+    if let Some(c) = config {
+        draw_with_config(frame, area, c);
+    } else {
+        let msg = Paragraph::new("No configuration available")
+            .alignment(Alignment::Center)
+            .block(Block::default().borders(Borders::ALL).title(" Routing "));
+        frame.render_widget(msg, area);
+    }
+}
+
+#[allow(clippy::indexing_slicing)]
+fn draw_with_config(frame: &mut Frame, area: Rect, config: &TuiConfig) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(4),
+            Constraint::Min(8),
+            Constraint::Length(8),
+        ])
+        .split(area);
+
+    // Layout::split with 3 constraints always returns 3 elements
+    draw_auto_router(frame, chunks[0], config);
+    draw_routes_table(frame, chunks[1], config);
+    draw_bottom_panels(frame, chunks[2], config);
+}
+
+fn draw_auto_router(frame: &mut Frame, area: Rect, config: &TuiConfig) {
+    let ar = &config.auto_router;
+    let (status_text, status_style) = if ar.enabled {
+        if ar.force {
+            ("ENABLED (force)", Style::default().fg(Color::Yellow))
+        } else {
+            ("ENABLED", Style::default().fg(Color::Green))
+        }
+    } else {
+        ("DISABLED", Style::default().fg(Color::DarkGray))
+    };
+
+    let lines = vec![
+        Line::from(vec![
+            Span::raw("  Status: "),
+            Span::styled(status_text, status_style),
+        ]),
+        Line::from(vec![
+            Span::raw("  Model: "),
+            Span::styled(&ar.model, Style::default().fg(Color::White)),
+            Span::raw("  Timeout: "),
+            Span::styled(
+                format!("{}ms", ar.timeout_ms),
+                Style::default().fg(Color::White),
+            ),
+        ]),
+    ];
+
+    let widget = Paragraph::new(lines).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(" Auto Router "),
+    );
+    frame.render_widget(widget, area);
+}
+
+#[allow(clippy::indexing_slicing)]
+fn draw_routes_table(frame: &mut Frame, area: Rect, config: &TuiConfig) {
+    let header = Row::new(vec!["#", "Pattern", "Provider", "Rewrite", "Name"])
+        .style(Style::default().add_modifier(Modifier::BOLD));
+
+    let mut rows: Vec<Row> = config
+        .routes
+        .iter()
+        .enumerate()
+        .map(|(i, route)| {
+            let priority = format!("{}", i + 1);
+            let pattern = route.pattern.as_deref().unwrap_or("-");
+            let rewrite = route.model_rewrite.as_deref().unwrap_or("-");
+            let name = route.name.as_deref().unwrap_or("-");
+
+            let provider_style = if route.provider == "higgs" {
+                Style::default().fg(Color::Magenta)
+            } else {
+                Style::default().fg(Color::White)
+            };
+
+            Row::new(vec![
+                Cell::from(priority),
+                Cell::from(pattern.to_owned()).style(Style::default().fg(Color::Cyan)),
+                Cell::from(route.provider.clone()).style(provider_style),
+                Cell::from(rewrite.to_owned()),
+                Cell::from(name.to_owned()),
+            ])
+        })
+        .collect();
+
+    // Default route as last row
+    let default_style = Style::default().fg(Color::DarkGray);
+    let default_provider_style = if config.default_provider == "higgs" {
+        Style::default().fg(Color::Magenta)
+    } else {
+        Style::default().fg(Color::White)
+    };
+    rows.push(Row::new(vec![
+        Cell::from("*").style(default_style),
+        Cell::from("(default)").style(default_style),
+        Cell::from(config.default_provider.clone()).style(default_provider_style),
+        Cell::from("-").style(default_style),
+        Cell::from("-").style(default_style),
+    ]));
+
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Length(3),
+            Constraint::Min(15),
+            Constraint::Length(15),
+            Constraint::Length(15),
+            Constraint::Length(15),
+        ],
+    )
+    .header(header)
+    .block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(" Routes (first match wins) "),
+    );
+
+    frame.render_widget(table, area);
+}
+
+#[allow(clippy::indexing_slicing)]
+fn draw_bottom_panels(frame: &mut Frame, area: Rect, config: &TuiConfig) {
+    let cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(area);
+
+    // Local models list
+    let model_items: Vec<ListItem> = if config.model_names.is_empty() {
+        vec![ListItem::new(Span::styled(
+            "  (none)",
+            Style::default().fg(Color::DarkGray),
+        ))]
+    } else {
+        config
+            .model_names
+            .iter()
+            .map(|name| {
+                ListItem::new(Span::styled(
+                    format!("  {name}"),
+                    Style::default().fg(Color::White),
+                ))
+            })
+            .collect()
+    };
+    let models_list = List::new(model_items).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(" Local Models "),
+    );
+    // Layout::split with 2 constraints always returns 2 elements
+    frame.render_widget(models_list, cols[0]);
+
+    // Providers list
+    let provider_items: Vec<ListItem> = if config.provider_names.is_empty() {
+        vec![ListItem::new(Span::styled(
+            "  (none)",
+            Style::default().fg(Color::DarkGray),
+        ))]
+    } else {
+        config
+            .provider_names
+            .iter()
+            .map(|name| {
+                let style = if name == "higgs" {
+                    Style::default().fg(Color::Magenta)
+                } else {
+                    Style::default().fg(Color::White)
+                };
+                ListItem::new(Span::styled(format!("  {name}"), style))
+            })
+            .collect()
+    };
+    let providers_list = List::new(provider_items)
+        .block(Block::default().borders(Borders::ALL).title(" Providers "));
+    frame.render_widget(providers_list, cols[1]);
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::tui::{TuiAutoRouter, TuiConfig, TuiRoute};
+
+    fn sample_config() -> TuiConfig {
+        TuiConfig {
+            profile: None,
+            model_names: vec!["Llama-3.2-1B".to_owned()],
+            provider_names: vec!["anthropic".to_owned(), "higgs".to_owned()],
+            routes: vec![TuiRoute {
+                pattern: Some("claude-.*".to_owned()),
+                provider: "anthropic".to_owned(),
+                model_rewrite: None,
+                name: None,
+                description: None,
+            }],
+            default_provider: "higgs".to_owned(),
+            auto_router: TuiAutoRouter {
+                enabled: false,
+                force: false,
+                model: "katanemo/Arch-Router-1.5B".to_owned(),
+                timeout_ms: 2000,
+            },
+        }
+    }
+
+    #[test]
+    fn draw_no_config_no_panic() {
+        let backend = ratatui::backend::TestBackend::new(120, 40);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                draw(f, f.area(), None);
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        let content: String = buffer
+            .content()
+            .iter()
+            .map(|c| c.symbol().chars().next().unwrap_or(' '))
+            .collect();
+        assert!(content.contains("No configuration available"));
+    }
+
+    #[test]
+    fn draw_with_config_no_panic() {
+        let config = sample_config();
+        let backend = ratatui::backend::TestBackend::new(120, 40);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                draw(f, f.area(), Some(&config));
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        let content: String = buffer
+            .content()
+            .iter()
+            .map(|c| c.symbol().chars().next().unwrap_or(' '))
+            .collect();
+        assert!(content.contains("Auto Router"));
+        assert!(content.contains("Routes"));
+        assert!(content.contains("anthropic"));
+    }
+
+    #[test]
+    fn draw_auto_router_enabled() {
+        let mut config = sample_config();
+        config.auto_router.enabled = true;
+        let backend = ratatui::backend::TestBackend::new(120, 40);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                draw(f, f.area(), Some(&config));
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        let content: String = buffer
+            .content()
+            .iter()
+            .map(|c| c.symbol().chars().next().unwrap_or(' '))
+            .collect();
+        assert!(content.contains("ENABLED"));
+    }
+}


### PR DESCRIPTION
## Summary

- Add `--profile <NAME>` global CLI flag that resolves to `config.<NAME>.toml` with per-profile PID, log, and metrics file isolation, enabling multiple simultaneous instances
- Add a **Routing** tab (key `5`) to the TUI dashboard showing auto-router status, route table with priority ordering, local models list, and providers list
- Show configured models and providers with zero traffic as dimmed rows in the **Models** and **Providers** tabs, making unused/misconfigured entries visible

## Test plan

- [x] `cargo clippy -p higgs` -- clean
- [x] `cargo fmt -p higgs -- --check` -- pass
- [x] `cargo test -p higgs -- --test-threads=1` -- 82 passed, 0 failed
- [ ] Manual: `higgs init --profile dev` creates `config.dev.toml`
- [ ] Manual: `higgs serve --profile dev` loads correct config, writes `higgs.dev.pid`
- [ ] Manual: `higgs start --profile dev` + `higgs start` runs two instances on different ports
- [ ] Manual: `higgs attach --profile dev` attaches to dev instance
- [ ] Manual: `higgs stop --profile dev` stops only the dev instance
- [ ] Manual: Models/Providers tabs show zero-traffic configured entries in gray
- [ ] Manual: Routing tab shows correct config visualization

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Profiles: named profiles with isolated PID, log, and metrics paths; profile-scoped config loading and profile tag in the UI.
  * TUI: added Routing tab and full routing view.
  * TUI tables: configured models and providers now appear even when they have zero traffic.

* **Documentation**
  * Profiles guide with usage, modes, port isolation, and mutual-exclusion notes.
  * Global flags docs for --config, --profile, and --verbose.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->