### PR TITLE
feat: add `higgs run -- <command>` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "higgs"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "async-stream",
  "axum",
@@ -1192,7 +1192,7 @@ dependencies = [
 
 [[package]]
 name = "higgs-engine"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "higgs-models",
  "minijinja",
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "higgs-models"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "image",
  "mlx-rs",

--- a/crates/higgs/src/config.rs
+++ b/crates/higgs/src/config.rs
@@ -56,6 +56,12 @@ pub enum Commands {
     Init,
     /// Print shell environment variables (for eval).
     Shellenv,
+    /// Set shell environment and exec a command.
+    Run {
+        /// Command and arguments to execute.
+        #[arg(trailing_var_arg = true, required = true)]
+        command: Vec<String>,
+    },
     /// Read or modify configuration values.
     Config {
         #[command(subcommand)]

--- a/crates/higgs/src/daemon.rs
+++ b/crates/higgs/src/daemon.rs
@@ -188,14 +188,22 @@ provider = "higgs"
     eprintln!("created {}", path.display());
 }
 
-#[allow(clippy::print_stdout)]
-pub fn cmd_shellenv(config: &HiggsConfig) {
-    let host = match config.server.host.as_str() {
+/// Map wildcard bind addresses to localhost for client connections.
+fn resolve_host(host: &str) -> &str {
+    match host {
         "0.0.0.0" => "127.0.0.1",
         "::" => "::1",
         other => other,
-    };
-    let addr = format!("{host}:{}", config.server.port);
+    }
+}
+
+#[allow(clippy::print_stdout)]
+pub fn cmd_shellenv(config: &HiggsConfig) {
+    let addr = format!(
+        "{}:{}",
+        resolve_host(&config.server.host),
+        config.server.port
+    );
 
     if TcpStream::connect(&addr).is_ok() {
         let base_url = format!("http://{addr}");
@@ -204,6 +212,9 @@ pub fn cmd_shellenv(config: &HiggsConfig) {
     }
 }
 
+/// Execute a command with `ANTHROPIC_BASE_URL` and `OPENAI_BASE_URL` pointing at the Higgs server.
+///
+/// Replaces the current process via `exec`. Never returns on success.
 #[allow(clippy::print_stderr)]
 pub fn cmd_run(config: &HiggsConfig, command: &[String]) -> ! {
     let Some((program, args)) = command.split_first() else {
@@ -211,12 +222,11 @@ pub fn cmd_run(config: &HiggsConfig, command: &[String]) -> ! {
         std::process::exit(1);
     };
 
-    let host = match config.server.host.as_str() {
-        "0.0.0.0" => "127.0.0.1",
-        "::" => "::1",
-        other => other,
-    };
-    let addr = format!("{host}:{}", config.server.port);
+    let addr = format!(
+        "{}:{}",
+        resolve_host(&config.server.host),
+        config.server.port
+    );
 
     if TcpStream::connect(&addr).is_err() {
         eprintln!("higgs is not running on {addr}");
@@ -328,12 +338,11 @@ pub fn detach(config_path: &Path, verbose: bool, profile: Option<&str>) {
         );
         return;
     };
-    let probe_host = match probe_config.server.host.as_str() {
-        "0.0.0.0" => "127.0.0.1",
-        "::" => "::1",
-        other => other,
-    };
-    let probe_addr = format!("{probe_host}:{}", probe_config.server.port);
+    let probe_addr = format!(
+        "{}:{}",
+        resolve_host(&probe_config.server.host),
+        probe_config.server.port
+    );
 
     // Poll until the daemon is accepting connections or the process dies
     let deadline = std::time::Instant::now() + Duration::from_secs(5);
@@ -653,5 +662,21 @@ mod tests {
             assert!(dir.join("config.dev.toml").exists());
             assert!(!dir.join("config.toml").exists());
         });
+    }
+
+    #[test]
+    fn resolve_host_maps_ipv4_wildcard() {
+        assert_eq!(resolve_host("0.0.0.0"), "127.0.0.1");
+    }
+
+    #[test]
+    fn resolve_host_maps_ipv6_wildcard() {
+        assert_eq!(resolve_host("::"), "::1");
+    }
+
+    #[test]
+    fn resolve_host_passes_through_other() {
+        assert_eq!(resolve_host("10.0.0.1"), "10.0.0.1");
+        assert_eq!(resolve_host("127.0.0.1"), "127.0.0.1");
     }
 }

--- a/crates/higgs/src/daemon.rs
+++ b/crates/higgs/src/daemon.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::net::TcpStream;
+use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -157,6 +158,10 @@ provider = "higgs"
 # model = "mlx-community/Arch-Router-1.5B-4bit"
 # timeout_ms = 2000
 
+# --- Usage ---
+# eval "$(higgs shellenv)"  -- set env vars in current shell
+# higgs run -- claude        -- run a command with env vars set
+
 # --- Retention ---
 # How long to keep metrics in memory for the TUI dashboard.
 
@@ -197,6 +202,37 @@ pub fn cmd_shellenv(config: &HiggsConfig) {
         println!("export ANTHROPIC_BASE_URL={base_url}");
         println!("export OPENAI_BASE_URL={base_url}");
     }
+}
+
+#[allow(clippy::print_stderr)]
+pub fn cmd_run(config: &HiggsConfig, command: &[String]) -> ! {
+    let Some((program, args)) = command.split_first() else {
+        eprintln!("no command specified");
+        std::process::exit(1);
+    };
+
+    let host = match config.server.host.as_str() {
+        "0.0.0.0" => "127.0.0.1",
+        "::" => "::1",
+        other => other,
+    };
+    let addr = format!("{host}:{}", config.server.port);
+
+    if TcpStream::connect(&addr).is_err() {
+        eprintln!("higgs is not running on {addr}");
+        eprintln!("hint: start with 'higgs start' or 'higgs serve'");
+        std::process::exit(1);
+    }
+
+    let base_url = format!("http://{addr}");
+    let err = std::process::Command::new(program)
+        .args(args)
+        .env("ANTHROPIC_BASE_URL", &base_url)
+        .env("OPENAI_BASE_URL", &base_url)
+        .exec();
+
+    eprintln!("failed to exec '{program}': {err}");
+    std::process::exit(1);
 }
 
 #[allow(clippy::print_stderr, clippy::too_many_lines, unsafe_code)]

--- a/crates/higgs/src/main.rs
+++ b/crates/higgs/src/main.rs
@@ -48,6 +48,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             higgs::daemon::cmd_shellenv(&config);
             Ok(())
         }
+        Commands::Run { ref command } => {
+            let config = load_config_for_command(&cli).unwrap_or_default();
+            higgs::daemon::cmd_run(&config, command);
+        }
         Commands::Config { ref action } => {
             cmd_config(&cli, action);
             Ok(())

--- a/crates/higgs/tests/integration/cli_run.rs
+++ b/crates/higgs/tests/integration/cli_run.rs
@@ -1,0 +1,47 @@
+//! CLI integration tests for `higgs run`.
+
+#![allow(clippy::panic, clippy::unwrap_used, clippy::tests_outside_test_module)]
+
+use std::process::Command;
+
+fn higgs_bin() -> std::path::PathBuf {
+    // cargo sets this during `cargo test`
+    let mut path = std::env::current_exe()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    path.push("higgs");
+    path
+}
+
+#[test]
+fn run_exits_with_error_when_server_not_running() {
+    let output = Command::new(higgs_bin())
+        .args(["run", "--", "echo", "hello"])
+        .env("HIGGS_CONFIG_DIR", "/tmp/higgs-test-nonexistent")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("not running"),
+        "expected 'not running' in stderr, got: {stderr}"
+    );
+}
+
+#[test]
+fn run_requires_command_argument() {
+    let output = Command::new(higgs_bin()).args(["run"]).output().unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    // clap should report missing required argument
+    assert!(
+        stderr.contains("required") || stderr.contains("Usage"),
+        "expected clap error in stderr, got: {stderr}"
+    );
+}

--- a/crates/higgs/tests/integration/mod.rs
+++ b/crates/higgs/tests/integration/mod.rs
@@ -1,3 +1,4 @@
+mod cli_run;
 mod error_contract;
 mod proxy_e2e;
 mod request_validation;

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,10 @@
   "include-v-in-tag": true,
   "plugins": [
     {
+      "type": "cargo-workspace",
+      "merge": false
+    },
+    {
       "type": "linked-versions",
       "groupName": "workspace",
       "components": ["higgs-models", "higgs-engine", "higgs"]


### PR DESCRIPTION
## Summary

- Adds `higgs run -- <command>` that sets `ANTHROPIC_BASE_URL` and `OPENAI_BASE_URL` then execs the command, replacing the `eval "$(higgs shellenv)"` workflow
- Verifies the server is reachable before exec, failing fast with a hint if higgs is not running
- Uses Unix `exec` to replace the process (zero overhead, signals work naturally)

## Test plan

- [x] `cargo clippy -p higgs` -- clean
- [x] `cargo fmt -p higgs -- --check` -- pass
- [x] `cargo test -p higgs -- --test-threads=1` -- all 339 tests pass
- [ ] Manual: `higgs start && higgs run -- env | grep BASE_URL` shows both vars set
- [ ] Manual: `higgs stop && higgs run -- env` prints error and exits 1

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `run` command that executes programs with the Higgs environment automatically configured, setting up the necessary API endpoint variables for seamless integration with your workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->