### PR TITLE
feat: add `higgs exec -- <command>` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "higgs"
-version = "0.1.15"
+version = "0.1.13"
 dependencies = [
  "async-stream",
  "axum",
@@ -1192,7 +1192,7 @@ dependencies = [
 
 [[package]]
 name = "higgs-engine"
-version = "0.1.15"
+version = "0.1.13"
 dependencies = [
  "higgs-models",
  "minijinja",
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "higgs-models"
-version = "0.1.15"
+version = "0.1.13"
 dependencies = [
  "image",
  "mlx-rs",

--- a/README.md
+++ b/README.md
@@ -223,11 +223,11 @@ eval "$(higgs shellenv)"
 Or run a single command with the env vars set:
 
 ```bash
-higgs run -- claude
-higgs run -- aider --model openai/gpt-4o
+higgs exec -- claude
+higgs exec -- aider --model openai/gpt-4o
 ```
 
-`higgs run` verifies the server is reachable, sets `ANTHROPIC_BASE_URL` and `OPENAI_BASE_URL`, then execs the command.
+`higgs exec` verifies the server is reachable, sets `ANTHROPIC_BASE_URL` and `OPENAI_BASE_URL`, then execs the command.
 
 ## CLI Commands
 
@@ -239,7 +239,7 @@ higgs run -- aider --model openai/gpt-4o
 | `higgs attach` | Attach TUI dashboard to a running daemon |
 | `higgs init` | Create default config at `~/.config/higgs/config.toml` |
 | `higgs shellenv` | Print `export` lines for `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` |
-| `higgs run -- <cmd>` | Set env vars and exec a command (replaces `eval "$(higgs shellenv)"`) |
+| `higgs exec -- <cmd>` | Set env vars and exec a command (replaces `eval "$(higgs shellenv)"`) |
 | `higgs config get <key>` | Read a config value (dot-separated key) |
 | `higgs config set <key> <value>` | Write a config value |
 | `higgs config path` | Print the resolved config file path |

--- a/README.md
+++ b/README.md
@@ -220,6 +220,15 @@ eval "$(higgs shellenv)"
 # Exports ANTHROPIC_BASE_URL and OPENAI_BASE_URL when the server is reachable
 ```
 
+Or run a single command with the env vars set:
+
+```bash
+higgs run -- claude
+higgs run -- aider --model openai/gpt-4o
+```
+
+`higgs run` verifies the server is reachable, sets `ANTHROPIC_BASE_URL` and `OPENAI_BASE_URL`, then execs the command.
+
 ## CLI Commands
 
 | Command | Description |
@@ -230,6 +239,7 @@ eval "$(higgs shellenv)"
 | `higgs attach` | Attach TUI dashboard to a running daemon |
 | `higgs init` | Create default config at `~/.config/higgs/config.toml` |
 | `higgs shellenv` | Print `export` lines for `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` |
+| `higgs run -- <cmd>` | Set env vars and exec a command (replaces `eval "$(higgs shellenv)"`) |
 | `higgs config get <key>` | Read a config value (dot-separated key) |
 | `higgs config set <key> <value>` | Write a config value |
 | `higgs config path` | Print the resolved config file path |

--- a/crates/higgs/src/config.rs
+++ b/crates/higgs/src/config.rs
@@ -57,7 +57,7 @@ pub enum Commands {
     /// Print shell environment variables (for eval).
     Shellenv,
     /// Set shell environment and exec a command.
-    Run {
+    Exec {
         /// Command and arguments to execute.
         #[arg(trailing_var_arg = true, required = true)]
         command: Vec<String>,

--- a/crates/higgs/src/daemon.rs
+++ b/crates/higgs/src/daemon.rs
@@ -212,9 +212,6 @@ pub fn cmd_shellenv(config: &HiggsConfig) {
     }
 }
 
-/// Execute a command with `ANTHROPIC_BASE_URL` and `OPENAI_BASE_URL` pointing at the Higgs server.
-///
-/// Replaces the current process via `exec`. Never returns on success.
 #[allow(clippy::print_stderr)]
 pub fn cmd_run(config: &HiggsConfig, command: &[String]) -> ! {
     let Some((program, args)) = command.split_first() else {
@@ -222,11 +219,12 @@ pub fn cmd_run(config: &HiggsConfig, command: &[String]) -> ! {
         std::process::exit(1);
     };
 
-    let addr = format!(
-        "{}:{}",
-        resolve_host(&config.server.host),
-        config.server.port
-    );
+    let host = match config.server.host.as_str() {
+        "0.0.0.0" => "127.0.0.1",
+        "::" => "::1",
+        other => other,
+    };
+    let addr = format!("{host}:{}", config.server.port);
 
     if TcpStream::connect(&addr).is_err() {
         eprintln!("higgs is not running on {addr}");

--- a/crates/higgs/src/daemon.rs
+++ b/crates/higgs/src/daemon.rs
@@ -212,6 +212,9 @@ pub fn cmd_shellenv(config: &HiggsConfig) {
     }
 }
 
+/// Execute a command with `ANTHROPIC_BASE_URL` and `OPENAI_BASE_URL` pointing at the Higgs server.
+///
+/// Replaces the current process via `exec`. Never returns on success.
 #[allow(clippy::print_stderr)]
 pub fn cmd_run(config: &HiggsConfig, command: &[String]) -> ! {
     let Some((program, args)) = command.split_first() else {
@@ -219,12 +222,11 @@ pub fn cmd_run(config: &HiggsConfig, command: &[String]) -> ! {
         std::process::exit(1);
     };
 
-    let host = match config.server.host.as_str() {
-        "0.0.0.0" => "127.0.0.1",
-        "::" => "::1",
-        other => other,
-    };
-    let addr = format!("{host}:{}", config.server.port);
+    let addr = format!(
+        "{}:{}",
+        resolve_host(&config.server.host),
+        config.server.port
+    );
 
     if TcpStream::connect(&addr).is_err() {
         eprintln!("higgs is not running on {addr}");

--- a/crates/higgs/src/daemon.rs
+++ b/crates/higgs/src/daemon.rs
@@ -160,7 +160,7 @@ provider = "higgs"
 
 # --- Usage ---
 # eval "$(higgs shellenv)"  -- set env vars in current shell
-# higgs run -- claude        -- run a command with env vars set
+# higgs exec -- claude       -- exec a command with env vars set
 
 # --- Retention ---
 # How long to keep metrics in memory for the TUI dashboard.
@@ -216,7 +216,7 @@ pub fn cmd_shellenv(config: &HiggsConfig) {
 ///
 /// Replaces the current process via `exec`. Never returns on success.
 #[allow(clippy::print_stderr)]
-pub fn cmd_run(config: &HiggsConfig, command: &[String]) -> ! {
+pub fn cmd_exec(config: &HiggsConfig, command: &[String]) -> ! {
     let Some((program, args)) = command.split_first() else {
         eprintln!("no command specified");
         std::process::exit(1);

--- a/crates/higgs/src/main.rs
+++ b/crates/higgs/src/main.rs
@@ -48,9 +48,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             higgs::daemon::cmd_shellenv(&config);
             Ok(())
         }
-        Commands::Run { ref command } => {
+        Commands::Exec { ref command } => {
             let config = load_config_for_command(&cli).unwrap_or_default();
-            higgs::daemon::cmd_run(&config, command);
+            higgs::daemon::cmd_exec(&config, command);
         }
         Commands::Config { ref action } => {
             cmd_config(&cli, action);

--- a/crates/higgs/tests/integration/cli_exec.rs
+++ b/crates/higgs/tests/integration/cli_exec.rs
@@ -1,4 +1,4 @@
-//! CLI integration tests for `higgs run`.
+//! CLI integration tests for `higgs exec`.
 
 #![allow(clippy::panic, clippy::unwrap_used, clippy::tests_outside_test_module)]
 
@@ -18,9 +18,9 @@ fn higgs_bin() -> std::path::PathBuf {
 }
 
 #[test]
-fn run_exits_with_error_when_server_not_running() {
+fn exec_exits_with_error_when_server_not_running() {
     let output = Command::new(higgs_bin())
-        .args(["run", "--", "echo", "hello"])
+        .args(["exec", "--", "echo", "hello"])
         .env("HIGGS_CONFIG_DIR", "/tmp/higgs-test-nonexistent")
         .output()
         .unwrap();
@@ -34,8 +34,8 @@ fn run_exits_with_error_when_server_not_running() {
 }
 
 #[test]
-fn run_requires_command_argument() {
-    let output = Command::new(higgs_bin()).args(["run"]).output().unwrap();
+fn exec_requires_command_argument() {
+    let output = Command::new(higgs_bin()).args(["exec"]).output().unwrap();
 
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);

--- a/crates/higgs/tests/integration/mod.rs
+++ b/crates/higgs/tests/integration/mod.rs
@@ -1,4 +1,4 @@
-mod cli_run;
+mod cli_exec;
 mod error_contract;
 mod proxy_e2e;
 mod request_validation;


### PR DESCRIPTION
## Summary

- Adds `higgs exec -- <command>` which sets `ANTHROPIC_BASE_URL` and `OPENAI_BASE_URL` then execs the given command, replacing the current process
- Verifies the Higgs server is reachable before exec, with a helpful error if it isn't
- Extracts a shared `resolve_host` helper to map wildcard bind addresses (`0.0.0.0`, `::`) to localhost, used by both `shellenv` and `exec`

## Test plan

- [x] Unit tests for `resolve_host` mapping
- [x] Integration tests: `exec` exits with error when server not running, `exec` requires command argument
- [ ] Manual: `higgs start && higgs exec -- echo hello` prints "hello" with env vars set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `higgs exec` command that verifies server connectivity, sets up environment variables, and executes provided commands in a single convenient step, replacing the previous eval-based approach.

* **Documentation**
  * Updated shell integration documentation with usage examples for various tools and workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->