### PR TITLE
fix: normalize auto_router.model to a name like routes do

### DIFF
--- a/crates/higgs/src/config.rs
+++ b/crates/higgs/src/config.rs
@@ -539,25 +539,50 @@ fn validate_config(config: &HiggsConfig, simple_mode: bool) -> Result<(), String
     Ok(())
 }
 
-/// If `auto_router` is enabled, ensure its model is present in `config.models`.
+/// If `auto_router` is enabled, ensure its model is present in `config.models`
+/// and that `auto_router.model` is normalized to a model name (not a path).
 ///
-/// The `auto_router.model` field can reference a model by its `name` or `path`.
+/// This mirrors how `routes[].model` works: always a name reference into the
+/// engines map, never a raw filesystem path.
 fn ensure_auto_router_model(config: &mut HiggsConfig) {
     if !config.auto_router.enabled || config.auto_router.model.is_empty() {
         return;
     }
-    let auto_model = &config.auto_router.model;
-    let already_listed = config
+    let auto_ref = &config.auto_router.model;
+
+    // Already references a model by name -- nothing to do.
+    if config
         .models
         .iter()
-        .any(|m| m.path == *auto_model || m.name.as_deref() == Some(auto_model));
-    if !already_listed {
-        config.models.push(ModelConfig {
-            path: config.auto_router.model.clone(),
-            name: None,
-            batch: false,
-        });
+        .any(|m| m.name.as_deref() == Some(auto_ref))
+    {
+        return;
     }
+
+    // References a model by path -- normalize to its name.
+    if let Some(model) = config.models.iter_mut().find(|m| m.path == *auto_ref) {
+        let name = model.name.get_or_insert_with(|| path_basename(&model.path));
+        config.auto_router.model = name.clone();
+        return;
+    }
+
+    // Not listed at all -- inject a model entry with a derived name.
+    let path = config.auto_router.model.clone();
+    let name = path_basename(&path);
+    config.models.push(ModelConfig {
+        path,
+        name: Some(name.clone()),
+        batch: false,
+    });
+    config.auto_router.model = name;
+}
+
+fn path_basename(path: &str) -> String {
+    std::path::Path::new(path)
+        .file_name()
+        .and_then(|f| f.to_str())
+        .unwrap_or(path)
+        .to_owned()
 }
 
 /// Returns the default config directory path (~/.config/higgs/).

--- a/crates/higgs/src/router.rs
+++ b/crates/higgs/src/router.rs
@@ -824,6 +824,52 @@ mod tests {
         assert!(router.is_ok(), "should resolve auto_router model by name");
     }
 
+    #[test]
+    fn auto_router_model_resolved_by_path() {
+        let config = config_from_toml(
+            r#"
+            [[models]]
+            path = "/Users/someone/models/Arch-Router-1.5B-4bit"
+            name = "router"
+
+            [auto_router]
+            enabled = true
+            model = "/Users/someone/models/Arch-Router-1.5B-4bit"
+            "#,
+        );
+        let engine = crate::state::Engine::test_stub("router");
+        let mut engines = HashMap::new();
+        engines.insert("router".to_owned(), Arc::new(engine));
+
+        let router = Router::from_config(&config, engines);
+        assert!(router.is_ok(), "should resolve auto_router model by path");
+    }
+
+    #[test]
+    fn auto_router_model_resolved_by_path_without_name() {
+        // ensure_auto_router_model injects the model entry with name=None,
+        // so the engine key is derived from engine.model_name() (the basename).
+        let config = config_from_toml(
+            r#"
+            [[models]]
+            path = "/Users/someone/models/Arch-Router-1.5B-4bit"
+
+            [auto_router]
+            enabled = true
+            model = "/Users/someone/models/Arch-Router-1.5B-4bit"
+            "#,
+        );
+        let engine = crate::state::Engine::test_stub("Arch-Router-1.5B-4bit");
+        let mut engines = HashMap::new();
+        engines.insert("Arch-Router-1.5B-4bit".to_owned(), Arc::new(engine));
+
+        let router = Router::from_config(&config, engines);
+        assert!(
+            router.is_ok(),
+            "should resolve auto_router model by path when model has no name"
+        );
+    }
+
     #[tokio::test]
     async fn auto_model_with_remote_default_rejects_without_rewrite() {
         // model="auto" falling through to a remote default with no model_rewrite


### PR DESCRIPTION
## Summary

- `ensure_auto_router_model` now normalizes `auto_router.model` from a filesystem path to a model name, matching how `routes[].model` works
- When the value is a path matching an existing `[[models]]` entry, resolves to that model's name (deriving one from the basename if needed)
- When it matches nothing, injects a `[[models]]` entry with a derived name
- Adds tests for path-based and nameless model resolution

## Test plan

- [x] `cargo test -p higgs -- --test-threads=1` -- 84 passed
- [x] `cargo clippy -p higgs` -- clean
- [x] `cargo fmt -p higgs -- --check` -- clean

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Auto_router model configuration now consistently normalizes to use model names instead of filesystem paths, ensuring predictable configuration behavior.

* **Tests**
  * Added comprehensive test coverage for model resolution in auto_router configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->