### PR TITLE
fix: improve Anthropic API compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,6 +533,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,6 +605,27 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "ctrlc"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73736a89c4aff73035ba2ed2e565061954da00d4970fc9ac25dcc85a2a20d790"
+dependencies = [
+ "dispatch2",
+ "nix 0.30.1",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "darling"
@@ -722,6 +770,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "directories"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -761,6 +819,18 @@ dependencies = [
  "option-ext",
  "redox_users 0.5.2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
@@ -1002,6 +1072,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1161,6 +1241,7 @@ dependencies = [
  "chrono",
  "clap",
  "crossterm",
+ "ctrlc",
  "directories",
  "figment",
  "futures",
@@ -1170,8 +1251,9 @@ dependencies = [
  "http",
  "http-body-util",
  "hyper",
+ "json5",
  "mlx-rs",
- "nix",
+ "nix 0.29.0",
  "ratatui",
  "regex",
  "reqwest",
@@ -1625,6 +1707,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1929,6 +2022,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "no-std-compat"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2014,6 +2119,21 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"
@@ -2173,6 +2293,49 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -2749,6 +2912,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -3357,6 +3531,18 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uncased"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ governor = "0.8"
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+json5 = "0.4"
 
 # Tokenization + Templates
 tokenizers = { version = "0.22", features = ["http"] }
@@ -114,6 +115,7 @@ futures = "0.3"
 
 # Daemon + TUI
 nix = { version = "0.29", features = ["signal", "process"] }
+ctrlc = "3"
 ratatui = "0.29"
 crossterm = "0.28"
 

--- a/crates/higgs/Cargo.toml
+++ b/crates/higgs/Cargo.toml
@@ -21,6 +21,7 @@ tower-http.workspace = true
 governor.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+json5.workspace = true
 clap.workspace = true
 figment.workspace = true
 directories.workspace = true
@@ -38,6 +39,7 @@ http.workspace = true
 futures.workspace = true
 toml_edit.workspace = true
 nix.workspace = true
+ctrlc.workspace = true
 ratatui.workspace = true
 crossterm.workspace = true
 

--- a/crates/higgs/src/anthropic_adapter.rs
+++ b/crates/higgs/src/anthropic_adapter.rs
@@ -1,4 +1,4 @@
-use crate::types::anthropic::{AnthropicContent, AnthropicMessage};
+use crate::types::anthropic::{AnthropicContent, AnthropicMessage, SystemPrompt};
 
 /// Map an `OpenAI` `finish_reason` to an Anthropic `stop_reason`.
 pub fn openai_finish_to_anthropic_stop(finish_reason: &str) -> String {
@@ -13,14 +13,14 @@ pub fn openai_finish_to_anthropic_stop(finish_reason: &str) -> String {
 /// Convert Anthropic messages to the engine's `ChatMessage` format.
 pub fn anthropic_messages_to_engine(
     messages: &[AnthropicMessage],
-    system: Option<&str>,
+    system: Option<&SystemPrompt>,
 ) -> Vec<higgs_engine::chat_template::ChatMessage> {
     let mut result = Vec::new();
 
     if let Some(sys) = system {
         result.push(higgs_engine::chat_template::ChatMessage {
             role: "system".to_owned(),
-            content: sys.to_owned(),
+            content: sys.to_text(),
             tool_calls: None,
         });
     }
@@ -33,7 +33,15 @@ pub fn anthropic_messages_to_engine(
                 .filter_map(|b| match b {
                     crate::types::anthropic::ContentBlock::Text { text } => Some(text.as_str()),
                     crate::types::anthropic::ContentBlock::ToolUse { .. }
-                    | crate::types::anthropic::ContentBlock::ToolResult { .. } => None,
+                    | crate::types::anthropic::ContentBlock::ToolResult { .. }
+                    | crate::types::anthropic::ContentBlock::Thinking { .. }
+                    | crate::types::anthropic::ContentBlock::RedactedThinking { .. }
+                    | crate::types::anthropic::ContentBlock::Image { .. }
+                    | crate::types::anthropic::ContentBlock::Document { .. }
+                    | crate::types::anthropic::ContentBlock::ServerToolUse { .. }
+                    | crate::types::anthropic::ContentBlock::WebSearchToolResult { .. }
+                    | crate::types::anthropic::ContentBlock::CodeExecutionToolResult { .. }
+                    | crate::types::anthropic::ContentBlock::Other => None,
                 })
                 .collect::<Vec<_>>()
                 .join(""),
@@ -88,8 +96,9 @@ mod tests {
     #[test]
     fn test_anthropic_messages_to_engine_with_system() {
         let messages = vec![text_message("user", "Hello")];
+        let system = SystemPrompt::Text("Be helpful".to_owned());
 
-        let result = anthropic_messages_to_engine(&messages, Some("Be helpful"));
+        let result = anthropic_messages_to_engine(&messages, Some(&system));
         assert_eq!(result.len(), 2);
         assert_eq!(result.first().map(|m| m.role.as_str()), Some("system"));
         assert_eq!(
@@ -142,7 +151,7 @@ mod tests {
                 },
                 ContentBlock::ToolResult {
                     tool_use_id: "tu_1".to_owned(),
-                    content: "72 degrees".to_owned(),
+                    content: AnthropicContent::Text("72 degrees".to_owned()),
                 },
             ],
         )];
@@ -174,8 +183,9 @@ mod tests {
     #[test]
     fn test_system_as_empty_string() {
         let messages = vec![text_message("user", "Hello")];
+        let system = SystemPrompt::Text(String::new());
 
-        let result = anthropic_messages_to_engine(&messages, Some(""));
+        let result = anthropic_messages_to_engine(&messages, Some(&system));
         assert_eq!(result.len(), 2);
         assert_eq!(result.first().map(|m| m.role.as_str()), Some("system"));
         assert_eq!(result.first().map(|m| m.content.as_str()), Some(""));
@@ -193,7 +203,7 @@ mod tests {
                 },
                 ContentBlock::ToolResult {
                     tool_use_id: "tu_1".to_owned(),
-                    content: "72 degrees".to_owned(),
+                    content: AnthropicContent::Text("72 degrees".to_owned()),
                 },
             ],
         )];

--- a/crates/higgs/src/auto_router.rs
+++ b/crates/higgs/src/auto_router.rs
@@ -8,7 +8,8 @@ use crate::state::Engine;
 
 #[allow(clippy::expect_used)]
 static ROUTE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"\{"route"\s*:\s*"([^"]+)"\}"#).expect("hardcoded regex is valid")
+    Regex::new(r#"\{["']\s*route["']\s*:\s*["']([^"']+)["']\s*\}"#)
+        .expect("hardcoded regex is valid")
 });
 
 const TASK_INSTRUCTION: &str = "\
@@ -67,8 +68,14 @@ fn build_prompt(routes: &[RouteCandidate], messages: &[serde_json::Value]) -> St
 }
 
 fn parse_route_name(text: &str, valid_names: &[&str]) -> Option<String> {
-    // Try full JSON parse first
-    if let Ok(v) = serde_json::from_str::<serde_json::Value>(text.trim()) {
+    let trimmed = text.trim();
+
+    // Try strict JSON first, then lenient JSON5 (handles single quotes,
+    // trailing commas, unquoted keys, etc.)
+    let parsed = serde_json::from_str::<serde_json::Value>(trimmed)
+        .or_else(|_| json5::from_str::<serde_json::Value>(trimmed));
+
+    if let Ok(v) = parsed {
         if let Some(name) = v.get("route").and_then(|r| r.as_str()) {
             if name != "other" && valid_names.contains(&name) {
                 return Some(name.to_owned());
@@ -196,6 +203,15 @@ mod tests {
         let names = vec!["code_gen", "summarize"];
         let text = "Based on the analysis, the best route is:\n{\"route\": \"summarize\"}";
         assert_eq!(parse_route_name(text, &names), Some("summarize".to_owned()));
+    }
+
+    #[test]
+    fn parse_single_quoted_json() {
+        let names = vec!["small", "coder"];
+        assert_eq!(
+            parse_route_name("{'route': 'small'}", &names),
+            Some("small".to_owned())
+        );
     }
 
     #[test]

--- a/crates/higgs/src/daemon.rs
+++ b/crates/higgs/src/daemon.rs
@@ -261,7 +261,11 @@ pub fn cmd_exec(config: &HiggsConfig, command: &[String]) -> ! {
     .unwrap_or_else(|e| eprintln!("warning: failed to set signal handler: {e}"));
 
     let status = match child.wait() {
-        Ok(s) => s.code().unwrap_or(1),
+        Ok(s) => s.code().unwrap_or_else(|| {
+            // Child killed by signal -- use the Unix convention of 128 + signal.
+            use std::os::unix::process::ExitStatusExt;
+            s.signal().map_or(1, |sig| 128 + sig)
+        }),
         Err(e) => {
             eprintln!("failed to wait for '{program}': {e}");
             1

--- a/crates/higgs/src/daemon.rs
+++ b/crates/higgs/src/daemon.rs
@@ -254,7 +254,7 @@ pub fn cmd_exec(config: &HiggsConfig, command: &[String]) -> ! {
     };
     let child_pid = nix::unistd::Pid::from_raw(child_pid_raw);
 
-    // Forward SIGINT/SIGTERM to child, then wait for it to exit.
+    // Forward Ctrl+C (SIGINT) to child as SIGTERM, then wait for it to exit.
     ctrlc::set_handler(move || {
         let _ = nix::sys::signal::kill(child_pid, nix::sys::signal::Signal::SIGTERM);
     })

--- a/crates/higgs/src/daemon.rs
+++ b/crates/higgs/src/daemon.rs
@@ -211,9 +211,9 @@ pub fn cmd_shellenv(config: &HiggsConfig) {
     }
 }
 
-/// Execute a command with `ANTHROPIC_BASE_URL` and `OPENAI_BASE_URL` pointing at the Higgs server.
+/// Spawn a command with `ANTHROPIC_BASE_URL` and `OPENAI_BASE_URL` pointing at the Higgs server.
 ///
-/// Replaces the current process via `exec`. Never returns on success.
+/// Forwards signals to the child and exits with its status. Never returns.
 #[allow(clippy::print_stderr)]
 pub fn cmd_exec(config: &HiggsConfig, command: &[String]) -> ! {
     let Some((program, args)) = command.split_first() else {
@@ -242,12 +242,17 @@ pub fn cmd_exec(config: &HiggsConfig, command: &[String]) -> ! {
     {
         Ok(c) => c,
         Err(e) => {
-            eprintln!("failed to exec '{program}': {e}");
+            eprintln!("failed to spawn '{program}': {e}");
             std::process::exit(1);
         }
     };
 
-    let child_pid = nix::unistd::Pid::from_raw(i32::try_from(child.id()).unwrap_or(0));
+    let Ok(child_pid_raw) = i32::try_from(child.id()) else {
+        eprintln!("child pid {} exceeds i32 range", child.id());
+        let _ = child.kill();
+        std::process::exit(1);
+    };
+    let child_pid = nix::unistd::Pid::from_raw(child_pid_raw);
 
     // Forward SIGINT/SIGTERM to child, then wait for it to exit.
     ctrlc::set_handler(move || {

--- a/crates/higgs/src/daemon.rs
+++ b/crates/higgs/src/daemon.rs
@@ -258,7 +258,7 @@ pub fn cmd_exec(config: &HiggsConfig, command: &[String]) -> ! {
     ctrlc::set_handler(move || {
         let _ = nix::sys::signal::kill(child_pid, nix::sys::signal::Signal::SIGTERM);
     })
-    .ok();
+    .unwrap_or_else(|e| eprintln!("warning: failed to set signal handler: {e}"));
 
     let status = match child.wait() {
         Ok(s) => s.code().unwrap_or(1),

--- a/crates/higgs/src/daemon.rs
+++ b/crates/higgs/src/daemon.rs
@@ -1,6 +1,5 @@
 use std::fs;
 use std::net::TcpStream;
-use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -155,7 +154,7 @@ provider = "higgs"
 
 # [auto_router]
 # enabled = true
-# model = "mlx-community/Arch-Router-1.5B-4bit"
+# model = "router"             # matches a [[models]] name
 # timeout_ms = 2000
 
 # --- Usage ---
@@ -235,14 +234,35 @@ pub fn cmd_exec(config: &HiggsConfig, command: &[String]) -> ! {
     }
 
     let base_url = format!("http://{addr}");
-    let err = std::process::Command::new(program)
+    let mut child = match std::process::Command::new(program)
         .args(args)
         .env("ANTHROPIC_BASE_URL", &base_url)
         .env("OPENAI_BASE_URL", &base_url)
-        .exec();
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("failed to exec '{program}': {e}");
+            std::process::exit(1);
+        }
+    };
 
-    eprintln!("failed to exec '{program}': {err}");
-    std::process::exit(1);
+    let child_pid = nix::unistd::Pid::from_raw(i32::try_from(child.id()).unwrap_or(0));
+
+    // Forward SIGINT/SIGTERM to child, then wait for it to exit.
+    ctrlc::set_handler(move || {
+        let _ = nix::sys::signal::kill(child_pid, nix::sys::signal::Signal::SIGTERM);
+    })
+    .ok();
+
+    let status = match child.wait() {
+        Ok(s) => s.code().unwrap_or(1),
+        Err(e) => {
+            eprintln!("failed to wait for '{program}': {e}");
+            1
+        }
+    };
+    std::process::exit(status);
 }
 
 #[allow(clippy::print_stderr, clippy::too_many_lines, unsafe_code)]

--- a/crates/higgs/src/routes/anthropic.rs
+++ b/crates/higgs/src/routes/anthropic.rs
@@ -36,7 +36,7 @@ pub async fn create_message(
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<axum::response::Response, ServerError> {
-    let req: CreateMessageRequest = serde_json::from_slice(&body)
+    let mut req: CreateMessageRequest = serde_json::from_slice(&body)
         .map_err(|e| ServerError::BadRequest(format!("Invalid request body: {e}")))?;
 
     if req.messages.is_empty() {
@@ -61,9 +61,10 @@ pub async fn create_message(
     match resolved {
         ResolvedRoute::Higgs {
             engine,
+            model_name,
             routing_method,
-            ..
         } => {
+            req.model = model_name;
             let start = Instant::now();
             if req.stream == Some(true) {
                 let stream =
@@ -101,7 +102,7 @@ pub async fn create_message(
             ..
         } => {
             let start = Instant::now();
-            let model_name = req.model.clone();
+            let metrics_model = model_rewrite.as_deref().unwrap_or(&req.model).to_owned();
             let is_streaming = req.stream == Some(true);
             let result = match provider_format {
                 ApiFormat::Anthropic => {
@@ -180,7 +181,7 @@ pub async fn create_message(
                     id: 0,
                     timestamp: Instant::now(),
                     wallclock: chrono::Utc::now(),
-                    model: model_name,
+                    model: metrics_model,
                     provider: provider_name,
                     routing_method: routing_method.into(),
                     status,
@@ -208,7 +209,7 @@ async fn create_message_non_streaming(
     };
     let stop_sequences = req.stop_sequences.unwrap_or_default();
 
-    let engine_messages = anthropic_messages_to_engine(&req.messages, req.system.as_deref());
+    let engine_messages = anthropic_messages_to_engine(&req.messages, req.system.as_ref());
     let tools = req.tools.as_deref();
 
     let prompt_tokens = engine
@@ -267,7 +268,7 @@ fn create_message_stream(
     };
     let stop_sequences = req.stop_sequences.unwrap_or_default();
 
-    let engine_messages = anthropic_messages_to_engine(&req.messages, req.system.as_deref());
+    let engine_messages = anthropic_messages_to_engine(&req.messages, req.system.as_ref());
     let tools = req.tools.as_deref();
 
     let prompt_tokens = engine
@@ -445,8 +446,7 @@ pub async fn count_tokens(
 
     match resolved {
         ResolvedRoute::Higgs { engine, .. } => {
-            let engine_messages =
-                anthropic_messages_to_engine(&req.messages, req.system.as_deref());
+            let engine_messages = anthropic_messages_to_engine(&req.messages, req.system.as_ref());
             let tools = req.tools.as_deref();
 
             let tokens = engine

--- a/crates/higgs/src/routes/chat.rs
+++ b/crates/higgs/src/routes/chat.rs
@@ -35,7 +35,7 @@ pub async fn chat_completions(
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<axum::response::Response, ServerError> {
-    let req: ChatCompletionRequest = serde_json::from_slice(&body)
+    let mut req: ChatCompletionRequest = serde_json::from_slice(&body)
         .map_err(|e| ServerError::BadRequest(format!("Invalid request body: {e}")))?;
 
     if req.messages.is_empty() {
@@ -57,14 +57,13 @@ pub async fn chat_completions(
         .await
         .map_err(ServerError::ModelNotFound)?;
 
-    let request_model = req.model.clone();
-
     match resolved {
         ResolvedRoute::Higgs {
             engine,
+            model_name,
             routing_method,
-            ..
         } => {
+            req.model = model_name;
             if req.stream == Some(true) {
                 let stream = chat_completions_stream(
                     Arc::clone(&state),
@@ -107,6 +106,7 @@ pub async fn chat_completions(
             routing_method,
             ..
         } => {
+            let metrics_model = model_rewrite.as_deref().unwrap_or(&req.model).to_owned();
             let is_streaming = req.stream == Some(true);
             match provider_format {
                 ApiFormat::OpenAi => {
@@ -131,7 +131,7 @@ pub async fn chat_completions(
                             id: 0,
                             timestamp: Instant::now(),
                             wallclock: chrono::Utc::now(),
-                            model: request_model,
+                            model: metrics_model.clone(),
                             provider: provider_name.clone(),
                             routing_method: routing_method.into(),
                             status: result.as_ref().map_or(502, |resp| resp.status().as_u16()),
@@ -173,7 +173,7 @@ pub async fn chat_completions(
                                 id: 0,
                                 timestamp: Instant::now(),
                                 wallclock: chrono::Utc::now(),
-                                model: request_model,
+                                model: metrics_model.clone(),
                                 provider: provider_name.clone(),
                                 routing_method: routing_method.into(),
                                 status: upstream_status,
@@ -209,7 +209,7 @@ pub async fn chat_completions(
                                 id: 0,
                                 timestamp: Instant::now(),
                                 wallclock: chrono::Utc::now(),
-                                model: request_model,
+                                model: metrics_model.clone(),
                                 provider: provider_name.clone(),
                                 routing_method: routing_method.into(),
                                 status: upstream_status,

--- a/crates/higgs/src/routes/completions.rs
+++ b/crates/higgs/src/routes/completions.rs
@@ -119,13 +119,14 @@ pub async fn completions(
                 api_key.as_deref(),
             )
             .await;
+            let metrics_model = model_rewrite.as_deref().unwrap_or(&req.model).to_owned();
             if let Some(ref metrics) = state.metrics {
                 let status = response.as_ref().map_or(502, |resp| resp.status().as_u16());
                 metrics.record(RequestRecord {
                     id: 0,
                     timestamp: Instant::now(),
                     wallclock: chrono::Utc::now(),
-                    model: req.model,
+                    model: metrics_model,
                     provider: provider_name,
                     routing_method: routing_method.into(),
                     status,

--- a/crates/higgs/src/routes/embeddings.rs
+++ b/crates/higgs/src/routes/embeddings.rs
@@ -141,13 +141,14 @@ pub async fn embeddings(
                 api_key.as_deref(),
             )
             .await;
+            let metrics_model = model_rewrite.as_deref().unwrap_or(&req.model).to_owned();
             if let Some(ref metrics) = state.metrics {
                 let status = response.as_ref().map_or(502, |resp| resp.status().as_u16());
                 metrics.record(RequestRecord {
                     id: 0,
                     timestamp: Instant::now(),
                     wallclock: chrono::Utc::now(),
-                    model: req.model,
+                    model: metrics_model,
                     provider: provider_name,
                     routing_method: routing_method.into(),
                     status,

--- a/crates/higgs/src/translate.rs
+++ b/crates/higgs/src/translate.rs
@@ -1241,4 +1241,101 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_slice(&result).unwrap();
         assert_eq!(parsed["system"], "Be helpful.\nBe concise.");
     }
+
+    #[test]
+    fn extract_tool_results_string_content() {
+        let blocks = vec![serde_json::json!({
+            "type": "tool_result",
+            "tool_use_id": "tu_1",
+            "content": "hello world"
+        })];
+        let results = extract_tool_results(&blocks);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0], ("tu_1".to_owned(), "hello world".to_owned()));
+    }
+
+    #[test]
+    fn extract_tool_results_array_content() {
+        let blocks = vec![serde_json::json!({
+            "type": "tool_result",
+            "tool_use_id": "tu_2",
+            "content": [
+                {"type": "text", "text": "first"},
+                {"type": "text", "text": "second"}
+            ]
+        })];
+        let results = extract_tool_results(&blocks);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].1, "first\n\nsecond");
+    }
+
+    #[test]
+    fn extract_tool_results_missing_content() {
+        let blocks = vec![serde_json::json!({
+            "type": "tool_result",
+            "tool_use_id": "tu_3"
+        })];
+        let results = extract_tool_results(&blocks);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].1, "");
+    }
+
+    #[test]
+    fn extract_tool_results_mixed_blocks() {
+        let blocks = vec![
+            serde_json::json!({"type": "text", "text": "thinking..."}),
+            serde_json::json!({
+                "type": "tool_result",
+                "tool_use_id": "tu_4",
+                "content": "result A"
+            }),
+            serde_json::json!({
+                "type": "tool_use",
+                "id": "tu_5",
+                "name": "foo",
+                "input": {}
+            }),
+            serde_json::json!({
+                "type": "tool_result",
+                "tool_use_id": "tu_6",
+                "content": "result B"
+            }),
+        ];
+        let results = extract_tool_results(&blocks);
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].0, "tu_4");
+        assert_eq!(results[1].0, "tu_6");
+    }
+
+    #[test]
+    fn extract_tool_results_empty_array_content() {
+        let blocks = vec![serde_json::json!({
+            "type": "tool_result",
+            "tool_use_id": "tu_7",
+            "content": []
+        })];
+        let results = extract_tool_results(&blocks);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].1, "");
+    }
+
+    #[test]
+    fn anthropic_to_openai_system_as_array() {
+        let body = serde_json::json!({
+            "model": "claude-sonnet-4-6",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "system": [
+                {"type": "text", "text": "You are helpful."},
+                {"type": "text", "text": "Be concise."}
+            ],
+            "max_tokens": 100
+        });
+        let result = anthropic_to_openai_request(body.to_string().as_bytes()).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&result).unwrap();
+
+        let messages = parsed["messages"].as_array().unwrap();
+        assert_eq!(messages[0]["role"], "system");
+        assert_eq!(messages[0]["content"], "You are helpful.\n\nBe concise.");
+        assert_eq!(messages[1]["role"], "user");
+    }
 }

--- a/crates/higgs/src/translate.rs
+++ b/crates/higgs/src/translate.rs
@@ -209,12 +209,24 @@ pub fn anthropic_to_openai_request(body: &[u8]) -> Result<Bytes, ServerError> {
 
     let mut openai_messages = Vec::new();
 
-    // system field -> system message
-    if let Some(system) = anthropic.get("system").and_then(|s| s.as_str()) {
-        if !system.is_empty() {
+    // system field -> system message (string or array of text blocks)
+    if let Some(system_val) = anthropic.get("system") {
+        let system_text = match system_val {
+            serde_json::Value::String(s) => s.clone(),
+            serde_json::Value::Array(blocks) => blocks
+                .iter()
+                .filter_map(|b| b.get("text").and_then(|t| t.as_str()))
+                .collect::<Vec<_>>()
+                .join("\n\n"),
+            serde_json::Value::Null
+            | serde_json::Value::Bool(_)
+            | serde_json::Value::Number(_)
+            | serde_json::Value::Object(_) => String::new(),
+        };
+        if !system_text.is_empty() {
             openai_messages.push(serde_json::json!({
                 "role": "system",
-                "content": system,
+                "content": system_text,
             }));
         }
     }
@@ -979,11 +991,15 @@ fn extract_tool_results(blocks: &[serde_json::Value]) -> Vec<(String, String)> {
         .filter(|b| b.get("type").and_then(|t| t.as_str()) == Some("tool_result"))
         .filter_map(|b| {
             let id = b.get("tool_use_id").and_then(|v| v.as_str())?.to_owned();
-            let content = b
-                .get("content")
-                .and_then(|c| c.as_str())
-                .unwrap_or("")
-                .to_owned();
+            let content = match b.get("content") {
+                Some(serde_json::Value::String(s)) => s.clone(),
+                Some(serde_json::Value::Array(arr)) => arr
+                    .iter()
+                    .filter_map(|block| block.get("text").and_then(|t| t.as_str()))
+                    .collect::<Vec<_>>()
+                    .join("\n\n"),
+                _ => String::new(),
+            };
             Some((id, content))
         })
         .collect()

--- a/crates/higgs/src/types/anthropic.rs
+++ b/crates/higgs/src/types/anthropic.rs
@@ -66,8 +66,8 @@ pub enum AnthropicContent {
 
 /// A content block in the Anthropic format.
 ///
-/// Remaining block types (e.g. `document`, `server_tool_use`) are captured
-/// as `Other` and silently skipped during text extraction.
+/// Unknown future block types are captured as `Other`
+/// and silently skipped during text extraction.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum ContentBlock {

--- a/crates/higgs/src/types/anthropic.rs
+++ b/crates/higgs/src/types/anthropic.rs
@@ -1,5 +1,32 @@
 use serde::{Deserialize, Serialize};
 
+/// The Anthropic API `system` field: either a plain string or an array of
+/// text blocks (with optional `cache_control` / `citations` we ignore).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum SystemPrompt {
+    Text(String),
+    Blocks(Vec<SystemBlock>),
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SystemBlock {
+    pub text: String,
+}
+
+impl SystemPrompt {
+    pub fn to_text(&self) -> String {
+        match self {
+            Self::Text(s) => s.clone(),
+            Self::Blocks(blocks) => blocks
+                .iter()
+                .map(|b| b.text.as_str())
+                .collect::<Vec<_>>()
+                .join("\n\n"),
+        }
+    }
+}
+
 /// POST /v1/messages request body (Anthropic Messages API).
 #[derive(Debug, Clone, Deserialize)]
 pub struct CreateMessageRequest {
@@ -15,7 +42,7 @@ pub struct CreateMessageRequest {
     #[serde(default)]
     pub stream: Option<bool>,
     #[serde(default)]
-    pub system: Option<String>,
+    pub system: Option<SystemPrompt>,
     #[serde(default)]
     pub stop_sequences: Option<Vec<String>>,
     #[serde(default)]
@@ -38,6 +65,9 @@ pub enum AnthropicContent {
 }
 
 /// A content block in the Anthropic format.
+///
+/// Remaining block types (e.g. `document`, `server_tool_use`) are captured
+/// as `Other` and silently skipped during text extraction.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum ContentBlock {
@@ -52,8 +82,60 @@ pub enum ContentBlock {
     #[serde(rename = "tool_result")]
     ToolResult {
         tool_use_id: String,
-        content: String,
+        content: AnthropicContent,
     },
+    #[serde(rename = "thinking")]
+    Thinking { thinking: String, signature: String },
+    #[serde(rename = "redacted_thinking")]
+    RedactedThinking { data: String },
+    #[serde(rename = "image")]
+    Image { source: serde_json::Value },
+    #[serde(rename = "document")]
+    Document { source: serde_json::Value },
+    #[serde(rename = "server_tool_use")]
+    ServerToolUse {
+        id: String,
+        name: String,
+        input: serde_json::Value,
+    },
+    #[serde(rename = "web_search_tool_result")]
+    WebSearchToolResult {
+        tool_use_id: String,
+        content: serde_json::Value,
+    },
+    #[serde(rename = "code_execution_tool_result")]
+    CodeExecutionToolResult {
+        tool_use_id: String,
+        content: serde_json::Value,
+    },
+    #[serde(other)]
+    Other,
+}
+
+impl AnthropicContent {
+    /// Flatten to a single string, joining text blocks with newlines.
+    pub fn to_text(&self) -> String {
+        match self {
+            Self::Text(s) => s.clone(),
+            Self::Blocks(blocks) => blocks
+                .iter()
+                .filter_map(|b| match b {
+                    ContentBlock::Text { text } => Some(text.as_str()),
+                    ContentBlock::ToolUse { .. }
+                    | ContentBlock::ToolResult { .. }
+                    | ContentBlock::Thinking { .. }
+                    | ContentBlock::RedactedThinking { .. }
+                    | ContentBlock::Image { .. }
+                    | ContentBlock::Document { .. }
+                    | ContentBlock::ServerToolUse { .. }
+                    | ContentBlock::WebSearchToolResult { .. }
+                    | ContentBlock::CodeExecutionToolResult { .. }
+                    | ContentBlock::Other => None,
+                })
+                .collect::<Vec<_>>()
+                .join("\n\n"),
+        }
+    }
 }
 
 /// POST /v1/messages response (non-streaming).
@@ -91,7 +173,7 @@ pub struct CountTokensRequest {
     pub model: String,
     pub messages: Vec<AnthropicMessage>,
     #[serde(default)]
-    pub system: Option<String>,
+    pub system: Option<SystemPrompt>,
     #[serde(default)]
     pub tools: Option<Vec<serde_json::Value>>,
 }
@@ -289,7 +371,7 @@ mod tests {
             "system": "You are helpful."
         }"#;
         let req: CountTokensRequest = serde_json::from_str(json).unwrap();
-        assert_eq!(req.system, Some("You are helpful.".to_owned()));
+        assert_eq!(req.system.unwrap().to_text(), "You are helpful.");
     }
 
     #[test]
@@ -316,9 +398,16 @@ mod tests {
         );
         let blocks = expect_blocks(&msg);
         assert_eq!(blocks.len(), 1);
-        assert!(
-            matches!(&blocks[0], ContentBlock::ToolResult { tool_use_id, content } if tool_use_id == "tu_1" && content == "72 degrees")
-        );
+        if let ContentBlock::ToolResult {
+            tool_use_id,
+            content,
+        } = &blocks[0]
+        {
+            assert_eq!(tool_use_id, "tu_1");
+            assert_eq!(content.to_text(), "72 degrees");
+        } else {
+            panic!("expected ToolResult block");
+        }
     }
 
     #[test]
@@ -411,7 +500,7 @@ mod tests {
         let msg: AnthropicMessage = serde_json::from_str(&json).unwrap();
         let blocks = expect_blocks(&msg);
         if let ContentBlock::ToolResult { content, .. } = &blocks[0] {
-            assert_eq!(content.len(), 10_000);
+            assert_eq!(content.to_text().len(), 10_000);
         } else {
             panic!("expected ToolResult block");
         }
@@ -436,7 +525,10 @@ mod tests {
             "system": "You are a helpful assistant."
         }"#;
         let req: CountTokensRequest = serde_json::from_str(json).unwrap();
-        assert_eq!(req.system, Some("You are a helpful assistant.".to_owned()));
+        assert_eq!(
+            req.system.unwrap().to_text(),
+            "You are a helpful assistant."
+        );
     }
 
     #[test]
@@ -522,5 +614,149 @@ mod tests {
         assert!(req.tools.is_some());
         let tools = req.tools.unwrap();
         assert_eq!(tools.len(), 1);
+    }
+
+    #[test]
+    fn test_system_as_string() {
+        let req = anthropic_request_with(r#""system": "Be concise.""#);
+        assert_eq!(req.system.unwrap().to_text(), "Be concise.");
+    }
+
+    #[test]
+    fn test_system_as_array_of_blocks() {
+        let json = r#"{
+            "model": "test",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 100,
+            "system": [
+                {"type": "text", "text": "You are a helpful assistant."},
+                {"type": "text", "text": "Be concise.", "cache_control": {"type": "ephemeral"}}
+            ]
+        }"#;
+        let req: CreateMessageRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            req.system.unwrap().to_text(),
+            "You are a helpful assistant.\n\nBe concise."
+        );
+    }
+
+    #[test]
+    fn test_tool_result_content_as_array_of_blocks() {
+        let msg = parse_message(
+            r#"{"role": "user", "content": [{"type": "tool_result", "tool_use_id": "tu_1", "content": [{"type": "text", "text": "first"}, {"type": "text", "text": "second"}]}]}"#,
+        );
+        let blocks = expect_blocks(&msg);
+        if let ContentBlock::ToolResult { content, .. } = &blocks[0] {
+            assert_eq!(content.to_text(), "first\n\nsecond");
+        } else {
+            panic!("expected ToolResult block");
+        }
+    }
+
+    #[test]
+    fn test_thinking_block() {
+        let msg = parse_message(
+            r#"{"role": "assistant", "content": [{"type": "thinking", "thinking": "Let me think...", "signature": "sig123"}]}"#,
+        );
+        let blocks = expect_blocks(&msg);
+        assert!(matches!(
+            &blocks[0],
+            ContentBlock::Thinking { thinking, signature }
+                if thinking == "Let me think..." && signature == "sig123"
+        ));
+    }
+
+    #[test]
+    fn test_redacted_thinking_block() {
+        let msg = parse_message(
+            r#"{"role": "assistant", "content": [{"type": "redacted_thinking", "data": "abc123"}]}"#,
+        );
+        let blocks = expect_blocks(&msg);
+        assert!(matches!(
+            &blocks[0],
+            ContentBlock::RedactedThinking { data } if data == "abc123"
+        ));
+    }
+
+    #[test]
+    fn test_image_block() {
+        let msg = parse_message(
+            r#"{"role": "user", "content": [{"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "iVBOR..."}}]}"#,
+        );
+        let blocks = expect_blocks(&msg);
+        assert!(matches!(&blocks[0], ContentBlock::Image { source } if source["type"] == "base64"));
+    }
+
+    #[test]
+    fn test_document_block() {
+        let msg = parse_message(
+            r#"{"role": "user", "content": [{"type": "document", "source": {"type": "base64", "media_type": "application/pdf", "data": "JVBER..."}}]}"#,
+        );
+        let blocks = expect_blocks(&msg);
+        assert!(
+            matches!(&blocks[0], ContentBlock::Document { source } if source["media_type"] == "application/pdf")
+        );
+    }
+
+    #[test]
+    fn test_server_tool_use_block() {
+        let msg = parse_message(
+            r#"{"role": "assistant", "content": [{"type": "server_tool_use", "id": "stu_1", "name": "web_search", "input": {"query": "rust lang"}}]}"#,
+        );
+        let blocks = expect_blocks(&msg);
+        assert!(matches!(
+            &blocks[0],
+            ContentBlock::ServerToolUse { id, name, .. }
+                if id == "stu_1" && name == "web_search"
+        ));
+    }
+
+    #[test]
+    fn test_web_search_tool_result_block() {
+        let msg = parse_message(
+            r#"{"role": "user", "content": [{"type": "web_search_tool_result", "tool_use_id": "stu_1", "content": [{"type": "web_search_result", "url": "https://example.com", "title": "Example", "encrypted_content": "abc"}]}]}"#,
+        );
+        let blocks = expect_blocks(&msg);
+        assert!(matches!(
+            &blocks[0],
+            ContentBlock::WebSearchToolResult { tool_use_id, .. }
+                if tool_use_id == "stu_1"
+        ));
+    }
+
+    #[test]
+    fn test_code_execution_tool_result_block() {
+        let msg = parse_message(
+            r#"{"role": "user", "content": [{"type": "code_execution_tool_result", "tool_use_id": "stu_2", "content": [{"type": "code_execution_output", "output": "hello world"}]}]}"#,
+        );
+        let blocks = expect_blocks(&msg);
+        assert!(matches!(
+            &blocks[0],
+            ContentBlock::CodeExecutionToolResult { tool_use_id, .. }
+                if tool_use_id == "stu_2"
+        ));
+    }
+
+    #[test]
+    fn test_thinking_block_excluded_from_to_text() {
+        let content = AnthropicContent::Blocks(vec![
+            ContentBlock::Thinking {
+                thinking: "internal thought".to_owned(),
+                signature: "sig".to_owned(),
+            },
+            ContentBlock::Text {
+                text: "visible".to_owned(),
+            },
+        ]);
+        assert_eq!(content.to_text(), "visible");
+    }
+
+    #[test]
+    fn test_unknown_block_type_becomes_other() {
+        let msg = parse_message(
+            r#"{"role": "user", "content": [{"type": "some_future_type", "data": "whatever"}]}"#,
+        );
+        let blocks = expect_blocks(&msg);
+        assert!(matches!(&blocks[0], ContentBlock::Other));
     }
 }

--- a/crates/higgs/tests/integration/cli_exec.rs
+++ b/crates/higgs/tests/integration/cli_exec.rs
@@ -2,6 +2,8 @@
 
 #![allow(clippy::panic, clippy::unwrap_used, clippy::tests_outside_test_module)]
 
+use std::io::Write;
+use std::net::TcpListener;
 use std::process::Command;
 
 fn higgs_bin() -> std::path::PathBuf {
@@ -19,9 +21,18 @@ fn higgs_bin() -> std::path::PathBuf {
 
 #[test]
 fn exec_exits_with_error_when_server_not_running() {
+    // Bind a random port then drop the listener so nothing is listening on it.
+    let port = TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port();
+
+    let dir = write_test_config(port);
+
     let output = Command::new(higgs_bin())
         .args(["exec", "--", "echo", "hello"])
-        .env("HIGGS_CONFIG_DIR", "/tmp/higgs-test-nonexistent")
+        .env("HIGGS_CONFIG_DIR", dir.path())
         .output()
         .unwrap();
 
@@ -43,5 +54,119 @@ fn exec_requires_command_argument() {
     assert!(
         stderr.contains("required") || stderr.contains("Usage"),
         "expected clap error in stderr, got: {stderr}"
+    );
+}
+
+/// Write a minimal valid config.toml pointing at the given port.
+/// Includes a dummy provider so config validation passes (otherwise
+/// `load_config_for_command` errors and `unwrap_or_default` silently
+/// falls back to defaults, making the test flaky).
+fn write_test_config(port: u16) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.toml");
+    let mut f = std::fs::File::create(&config_path).unwrap();
+    write!(
+        f,
+        "[server]\nhost = \"127.0.0.1\"\nport = {port}\n\n\
+         [provider.dummy]\nurl = \"http://127.0.0.1:1\"\n"
+    )
+    .unwrap();
+    dir
+}
+
+/// Bind a random port and write a config pointing at it.
+/// Returns (TcpListener, temp dir) -- keep the listener alive so `higgs exec`
+/// sees a "running" server.
+fn fake_server_env() -> (TcpListener, tempfile::TempDir) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let dir = write_test_config(port);
+    (listener, dir)
+}
+
+#[test]
+fn exec_forwards_child_exit_code() {
+    let (_listener, dir) = fake_server_env();
+
+    let output = Command::new(higgs_bin())
+        .args(["exec", "--", "sh", "-c", "exit 42"])
+        .env("HIGGS_CONFIG_DIR", dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(42),
+        "expected exit code 42, got {:?}",
+        output.status.code()
+    );
+}
+
+#[test]
+fn exec_forwards_zero_exit_code() {
+    let (_listener, dir) = fake_server_env();
+
+    let output = Command::new(higgs_bin())
+        .args(["exec", "--", "true"])
+        .env("HIGGS_CONFIG_DIR", dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "expected exit code 0, got {:?}",
+        output.status.code()
+    );
+}
+
+#[test]
+fn exec_reports_spawn_failure() {
+    let (_listener, dir) = fake_server_env();
+
+    let output = Command::new(higgs_bin())
+        .args(["exec", "--", "/nonexistent/binary"])
+        .env("HIGGS_CONFIG_DIR", dir.path())
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("failed to spawn"),
+        "expected 'failed to spawn' in stderr, got: {stderr}"
+    );
+}
+
+#[test]
+fn exec_sigint_terminates_child() {
+    use std::time::{Duration, Instant};
+
+    let (_listener, dir) = fake_server_env();
+
+    let mut child = Command::new(higgs_bin())
+        .args(["exec", "--", "sleep", "60"])
+        .env("HIGGS_CONFIG_DIR", dir.path())
+        .spawn()
+        .unwrap();
+
+    // Give the child process time to start
+    std::thread::sleep(Duration::from_millis(500));
+
+    let pid = nix::unistd::Pid::from_raw(i32::try_from(child.id()).unwrap());
+    nix::sys::signal::kill(pid, nix::sys::signal::Signal::SIGINT).unwrap();
+
+    let start = Instant::now();
+    let status = child.wait().unwrap();
+    let elapsed = start.elapsed();
+
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "child should terminate within 5s after SIGINT, took {elapsed:?}"
+    );
+    // The child exits from signal, so it won't have a success code
+    assert!(
+        !status.success(),
+        "expected non-zero exit after SIGINT, got: {status}"
     );
 }

--- a/crates/higgs/tests/integration/cli_exec.rs
+++ b/crates/higgs/tests/integration/cli_exec.rs
@@ -164,9 +164,11 @@ fn exec_sigint_terminates_child() {
         elapsed < Duration::from_secs(5),
         "child should terminate within 5s after SIGINT, took {elapsed:?}"
     );
-    // The child exits from signal, so it won't have a success code
-    assert!(
-        !status.success(),
-        "expected non-zero exit after SIGINT, got: {status}"
+    // SIGINT handler forwards SIGTERM (signal 15) to child, so exit code
+    // should be 128 + 15 = 143 per Unix convention.
+    assert_eq!(
+        status.code(),
+        Some(143),
+        "expected exit code 143 (128 + SIGTERM), got: {status}"
     );
 }

--- a/crates/higgs/tests/integration/cli_exec.rs
+++ b/crates/higgs/tests/integration/cli_exec.rs
@@ -75,7 +75,7 @@ fn write_test_config(port: u16) -> tempfile::TempDir {
 }
 
 /// Bind a random port and write a config pointing at it.
-/// Returns (TcpListener, temp dir) -- keep the listener alive so `higgs exec`
+/// Returns (`TcpListener`, temp dir) -- keep the listener alive so `higgs exec`
 /// sees a "running" server.
 fn fake_server_env() -> (TcpListener, tempfile::TempDir) {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();

--- a/crates/higgs/tests/integration/request_validation.rs
+++ b/crates/higgs/tests/integration/request_validation.rs
@@ -247,7 +247,7 @@ fn anthropic_request_with_system_prompt() {
         "system": "You are a pirate."
     }"#;
     let req: CreateMessageRequest = serde_json::from_str(json).unwrap();
-    assert_eq!(req.system, Some("You are a pirate.".to_owned()));
+    assert_eq!(req.system.unwrap().to_text(), "You are a pirate.");
 }
 
 #[test]
@@ -282,7 +282,16 @@ fn anthropic_content_blocks() {
             assert_eq!(blocks.len(), 2);
             match &blocks[0] {
                 ContentBlock::Text { text } => assert_eq!(text, "first"),
-                ContentBlock::ToolUse { .. } | ContentBlock::ToolResult { .. } => {
+                ContentBlock::ToolUse { .. }
+                | ContentBlock::ToolResult { .. }
+                | ContentBlock::Thinking { .. }
+                | ContentBlock::RedactedThinking { .. }
+                | ContentBlock::Image { .. }
+                | ContentBlock::Document { .. }
+                | ContentBlock::ServerToolUse { .. }
+                | ContentBlock::WebSearchToolResult { .. }
+                | ContentBlock::CodeExecutionToolResult { .. }
+                | ContentBlock::Other => {
                     panic!("expected Text block")
                 }
             }
@@ -310,7 +319,16 @@ fn anthropic_tool_use_block() {
                 assert_eq!(name, "get_weather");
                 assert_eq!(input["city"], "SF");
             }
-            ContentBlock::Text { .. } | ContentBlock::ToolResult { .. } => {
+            ContentBlock::Text { .. }
+            | ContentBlock::ToolResult { .. }
+            | ContentBlock::Thinking { .. }
+            | ContentBlock::RedactedThinking { .. }
+            | ContentBlock::Image { .. }
+            | ContentBlock::Document { .. }
+            | ContentBlock::ServerToolUse { .. }
+            | ContentBlock::WebSearchToolResult { .. }
+            | ContentBlock::CodeExecutionToolResult { .. }
+            | ContentBlock::Other => {
                 panic!("expected ToolUse block")
             }
         },
@@ -336,9 +354,18 @@ fn anthropic_tool_result_block() {
                 content,
             } => {
                 assert_eq!(tool_use_id, "toolu_123");
-                assert_eq!(content, "72 degrees");
+                assert_eq!(content.to_text(), "72 degrees");
             }
-            ContentBlock::Text { .. } | ContentBlock::ToolUse { .. } => {
+            ContentBlock::Text { .. }
+            | ContentBlock::ToolUse { .. }
+            | ContentBlock::Thinking { .. }
+            | ContentBlock::RedactedThinking { .. }
+            | ContentBlock::Image { .. }
+            | ContentBlock::Document { .. }
+            | ContentBlock::ServerToolUse { .. }
+            | ContentBlock::WebSearchToolResult { .. }
+            | ContentBlock::CodeExecutionToolResult { .. }
+            | ContentBlock::Other => {
                 panic!("expected ToolResult block")
             }
         },
@@ -354,7 +381,7 @@ fn anthropic_count_tokens_request() {
         "system": "be helpful"
     }"#;
     let req: CountTokensRequest = serde_json::from_str(json).unwrap();
-    assert_eq!(req.system, Some("be helpful".to_owned()));
+    assert_eq!(req.system.unwrap().to_text(), "be helpful");
     assert_eq!(req.messages.len(), 1);
 }
 
@@ -409,7 +436,8 @@ fn anthropic_messages_to_engine_with_system() {
     use higgs::anthropic_adapter::anthropic_messages_to_engine;
 
     let messages = make_single_user_message();
-    let result = anthropic_messages_to_engine(&messages, Some("be helpful"));
+    let system = higgs::types::anthropic::SystemPrompt::Text("be helpful".to_owned());
+    let result = anthropic_messages_to_engine(&messages, Some(&system));
     assert_eq!(result.len(), 2);
     assert_eq!(result[0].role, "system");
     assert_eq!(result[0].content, "be helpful");


### PR DESCRIPTION
## Summary

- Accept `system` field as string or array of content blocks, matching the Anthropic Messages API spec (fixes `higgs exec -- claude -p` returning 400)
- Handle `tool_result.content` as string or array of content blocks
- Add all Anthropic content block types: thinking, redacted_thinking, image, document, server_tool_use, web_search_tool_result, code_execution_tool_result, plus an `Other` catch-all
- Use json5 to parse single-quoted JSON from auto-router models
- Record resolved model name in metrics when auto-router overrides the request model
- Switch `higgs exec` from exec() to spawn() with SIGTERM forwarding so Ctrl+C works

## Test plan

- [x] `cargo clippy -p higgs` clean
- [x] `cargo fmt -p higgs -- --check` passes
- [x] `cargo test -p higgs -- --test-threads=1` all pass
- [ ] Smoke test: `higgs stop; higgs start && higgs exec -- claude -p "hey"` completes without 400 errors
- [ ] Verify Ctrl+C terminates `higgs exec` child process
- [ ] Verify auto-router correctly parses single-quoted JSON route selections

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Anthropic inputs now accept richer system prompts (text or block arrays) and many new content block types; route parsing accepts JSON5 and single-quoted JSON-like input.
  * Metrics/reporting reflect resolved model names after rewrites.

* **Bug Fixes**
  * Daemon execution now spawns child processes, forwards termination signals, and correctly propagates child exit codes including SIGINT.

* **Tests**
  * Expanded integration/unit tests covering new Anthropic formats, route parsing, and exec behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->