### PR TITLE
fix: strip thinking tags, fix force routing, add proxy usage metrics

### DIFF
--- a/crates/higgs/src/proxy.rs
+++ b/crates/higgs/src/proxy.rs
@@ -102,6 +102,50 @@ pub fn stub_count_tokens_response() -> Response {
         .into_response()
 }
 
+/// Send a request to an upstream provider and return status + body bytes.
+///
+/// Unlike [`send_to_provider`], this does not error on 4xx/5xx status codes,
+/// making it suitable for passthrough where error responses should be forwarded.
+/// Unlike [`proxy_request`], this reads the full body so the caller can inspect
+/// it (e.g., to extract usage for metrics).
+pub async fn send_and_read(
+    client: &reqwest::Client,
+    provider_url: &str,
+    path: &str,
+    body: Bytes,
+    original_headers: &HeaderMap,
+    strip_auth: bool,
+    api_key: Option<&str>,
+) -> Result<(StatusCode, Bytes), ServerError> {
+    let url = format!("{}{path}", provider_url.trim_end_matches('/'));
+    let headers = build_forwarding_headers(original_headers, strip_auth, api_key, body.len());
+
+    tracing::debug!(url = %url, body_bytes = body.len(), "sending to provider (read)");
+
+    let upstream = client
+        .post(&url)
+        .headers(headers)
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| {
+            tracing::error!(url = %url, error = %e, "provider request failed");
+            ServerError::ProxyError(format!("provider unreachable: {e}"))
+        })?;
+
+    let status = StatusCode::from_u16(upstream.status().as_u16())
+        .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+
+    tracing::info!(status = %status, url = %url, "provider responded");
+
+    let resp_bytes = upstream
+        .bytes()
+        .await
+        .map_err(|e| ServerError::ProxyError(format!("Failed to read response: {e}")))?;
+
+    Ok((status, resp_bytes))
+}
+
 /// Send a request to an upstream provider and return the raw response.
 ///
 /// Unlike [`proxy_request`], this returns the reqwest response directly so the
@@ -185,6 +229,32 @@ pub async fn proxy_request(
     *response.status_mut() = status;
     *response.headers_mut() = response_headers;
     Ok(response)
+}
+
+/// Extract `(input_tokens, output_tokens)` from a proxy response body.
+///
+/// Handles both Anthropic (`usage.input_tokens` / `usage.output_tokens`)
+/// and `OpenAI` (`usage.prompt_tokens` / `usage.completion_tokens`) formats.
+pub fn extract_usage(body: &[u8]) -> (u64, u64) {
+    let Ok(json) = serde_json::from_slice::<serde_json::Value>(body) else {
+        return (0, 0);
+    };
+    let Some(usage) = json.get("usage") else {
+        return (0, 0);
+    };
+
+    let input = usage
+        .get("input_tokens")
+        .or_else(|| usage.get("prompt_tokens"))
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+    let output = usage
+        .get("output_tokens")
+        .or_else(|| usage.get("completion_tokens"))
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+
+    (input, output)
 }
 
 #[cfg(test)]

--- a/crates/higgs/src/router.rs
+++ b/crates/higgs/src/router.rs
@@ -189,10 +189,16 @@ impl Router {
             if let Some(resolved) = self.try_auto_route(messages).await {
                 return Ok(resolved);
             }
-            if model == "auto" {
-                return self.resolve_target(&self.default_target, model, RoutingMethod::Default);
+            // Auto-routing returned nothing -- skip pattern matching.
+            // Direct engine lookup still applies (the model may be a local engine name).
+            if let Some(engine) = self.local_engines.get(model) {
+                return Ok(ResolvedRoute::Higgs {
+                    engine: Arc::clone(engine),
+                    model_name: model.to_owned(),
+                    routing_method: RoutingMethod::Direct,
+                });
             }
-            // force mode: auto-routing returned nothing, fall through to normal resolution
+            return self.resolve_target(&self.default_target, model, RoutingMethod::Default);
         }
 
         // Pattern matching (first match wins)
@@ -883,9 +889,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn force_mode_falls_through_without_engine() {
-        // force=true, no auto-router engine loaded, named model should
-        // fall through to normal resolution (pattern/direct/default).
+    async fn force_mode_skips_pattern_matching() {
+        // force=true, no auto-router engine loaded -- should skip pattern
+        // matching and fall through to default, not pattern.
         let config = config_from_toml(
             r#"
             [provider.anthropic]
@@ -913,7 +919,7 @@ mod tests {
                 ..
             } => {
                 assert_eq!(provider_name, "anthropic");
-                assert_eq!(routing_method, RoutingMethod::Pattern);
+                assert_eq!(routing_method, RoutingMethod::Default);
             }
             ResolvedRoute::Higgs { .. } => panic!("expected Remote route"),
         }

--- a/crates/higgs/src/routes/anthropic.rs
+++ b/crates/higgs/src/routes/anthropic.rs
@@ -104,6 +104,8 @@ pub async fn create_message(
             let start = Instant::now();
             let metrics_model = model_rewrite.as_deref().unwrap_or(&req.model).to_owned();
             let is_streaming = req.stream == Some(true);
+            let mut usage = (0u64, 0u64);
+
             let result = match provider_format {
                 ApiFormat::Anthropic => {
                     let proxy_body = if let Some(ref rewrite) = model_rewrite {
@@ -111,16 +113,36 @@ pub async fn create_message(
                     } else {
                         body
                     };
-                    crate::proxy::proxy_request(
-                        &state.http_client,
-                        &provider_url,
-                        "/v1/messages",
-                        proxy_body,
-                        &headers,
-                        strip_auth,
-                        api_key.as_deref(),
-                    )
-                    .await
+                    if is_streaming {
+                        crate::proxy::proxy_request(
+                            &state.http_client,
+                            &provider_url,
+                            "/v1/messages",
+                            proxy_body,
+                            &headers,
+                            strip_auth,
+                            api_key.as_deref(),
+                        )
+                        .await
+                    } else {
+                        let (status, resp_bytes) = crate::proxy::send_and_read(
+                            &state.http_client,
+                            &provider_url,
+                            "/v1/messages",
+                            proxy_body,
+                            &headers,
+                            strip_auth,
+                            api_key.as_deref(),
+                        )
+                        .await?;
+                        usage = crate::proxy::extract_usage(&resp_bytes);
+                        Ok((
+                            status,
+                            [(axum::http::header::CONTENT_TYPE, "application/json")],
+                            resp_bytes,
+                        )
+                            .into_response())
+                    }
                 }
                 ApiFormat::OpenAi => {
                     let translated = crate::translate::anthropic_to_openai_request(&body)?;
@@ -163,6 +185,7 @@ pub async fn create_message(
                         let resp_bytes = upstream.bytes().await.map_err(|e| {
                             ServerError::ProxyError(format!("Failed to read response: {e}"))
                         })?;
+                        usage = crate::proxy::extract_usage(&resp_bytes);
                         let translated_resp = crate::translate::openai_response_to_anthropic(
                             &resp_bytes,
                             &req.model,
@@ -186,8 +209,8 @@ pub async fn create_message(
                     routing_method: routing_method.into(),
                     status,
                     duration: start.elapsed(),
-                    input_tokens: 0,
-                    output_tokens: 0,
+                    input_tokens: usage.0,
+                    output_tokens: usage.1,
                     error_body: None,
                 });
             }
@@ -235,13 +258,20 @@ async fn create_message_non_streaming(
     let stop_reason = openai_finish_to_anthropic_stop(&output.finish_reason);
     let msg_id = format!("msg_{}", uuid::Uuid::new_v4().simple());
 
+    let reasoning_result = higgs_engine::reasoning_parser::parse_reasoning(&output.text);
+    let visible_text = if reasoning_result.reasoning.is_some() {
+        reasoning_result.text
+    } else {
+        output.text
+    };
+
     Ok(CreateMessageResponse {
         id: msg_id,
         message_type: "message",
         role: "assistant",
         content: vec![ContentBlockResponse {
             block_type: "text",
-            text: output.text,
+            text: visible_text,
         }],
         model: req.model,
         stop_reason: Some(stop_reason),
@@ -356,15 +386,18 @@ fn create_message_stream(
         // 3. content_block_delta events (one per token)
         let mut final_stop_reason = None;
         let mut total_output_tokens: u32 = 0;
+        let mut reasoning_tracker = higgs_engine::reasoning_parser::StreamingReasoningTracker::new();
 
         while let Some(output) = rx.recv().await {
-            if !output.new_text.is_empty() {
+            let (visible, _reasoning) = reasoning_tracker.process(&output.new_text);
+
+            if !visible.is_empty() {
                 let delta_event = ContentBlockDeltaEvent {
                     event_type: "content_block_delta",
                     index: 0,
                     delta: TextDelta {
                         delta_type: "text_delta",
-                        text: output.new_text,
+                        text: visible,
                     },
                 };
                 match serde_json::to_string(&delta_event) {
@@ -375,6 +408,23 @@ fn create_message_stream(
             total_output_tokens = output.completion_tokens;
             if let Some(reason) = output.finish_reason {
                 final_stop_reason = Some(openai_finish_to_anthropic_stop(&reason));
+            }
+        }
+
+        // Flush any remaining visible text buffered by the reasoning tracker
+        let (flush_visible, _flush_reasoning) = reasoning_tracker.flush();
+        if !flush_visible.is_empty() {
+            let delta_event = ContentBlockDeltaEvent {
+                event_type: "content_block_delta",
+                index: 0,
+                delta: TextDelta {
+                    delta_type: "text_delta",
+                    text: flush_visible,
+                },
+            };
+            match serde_json::to_string(&delta_event) {
+                Ok(json) => yield Ok(Event::default().event("content_block_delta").data(json)),
+                Err(e) => tracing::error!(error = %e, "Failed to serialize SSE chunk"),
             }
         }
 

--- a/crates/higgs/src/routes/chat.rs
+++ b/crates/higgs/src/routes/chat.rs
@@ -204,6 +204,7 @@ pub async fn chat_completions(
                         let resp_bytes = upstream.bytes().await.map_err(|e| {
                             ServerError::ProxyError(format!("Failed to read response: {e}"))
                         })?;
+                        let usage = crate::proxy::extract_usage(&resp_bytes);
                         if let Some(ref metrics) = state.metrics {
                             metrics.record(RequestRecord {
                                 id: 0,
@@ -214,15 +215,14 @@ pub async fn chat_completions(
                                 routing_method: routing_method.into(),
                                 status: upstream_status,
                                 duration: start.elapsed(),
-                                input_tokens: 0,
-                                output_tokens: 0,
+                                input_tokens: usage.0,
+                                output_tokens: usage.1,
                                 error_body: None,
                             });
                         }
                         let status_code = axum::http::StatusCode::from_u16(upstream_status)
                             .unwrap_or(axum::http::StatusCode::BAD_GATEWAY);
                         if upstream_status >= 400 {
-                            // Pass through error responses without translation
                             Ok((
                                 status_code,
                                 [(axum::http::header::CONTENT_TYPE, "application/json")],


### PR DESCRIPTION
## Summary

- **Strip thinking tags from Anthropic route**: Local models (e.g. Qwen) emit `<think>...</think>` tags in output. The OpenAI chat route already strips these via `reasoning_parser`, but the Anthropic route passed them through verbatim. Now both streaming and non-streaming Anthropic responses filter thinking content.

- **Fix auto_router force mode**: When `force = true`, pattern-matching routes were still evaluated as fallback. Now force mode skips pattern matching entirely, falling through only to direct engine lookup and the default provider.

- **Extract token usage from proxy responses**: Non-streaming proxy responses now extract `input_tokens`/`output_tokens` (Anthropic) or `prompt_tokens`/`completion_tokens` (OpenAI) from the response body for metrics. Adds `send_and_read` helper for passthrough that preserves status codes while allowing body inspection. Streaming proxy responses still report 0 tokens (would require stream interception).

## Test plan

- [x] `cargo clippy -p higgs` clean
- [x] `cargo fmt -p higgs -- --check` clean
- [x] `cargo test -p higgs -- --test-threads=1` all 397 unit + 88 integration tests pass
- [ ] Manual: verify thinking tags stripped from local model Anthropic responses
- [ ] Manual: verify metrics show non-zero token counts for proxied providers
- [ ] Manual: verify force mode only shows AUT/DFL routing, no PTN


Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-request usage tracking and metrics for Anthropic responses.
  * Enhanced routing to check for local engine matches by model name.

* **Bug Fixes**
  * Fixed usage metrics to reflect actual token counts instead of hardcoded zeros.
  * Improved reasoning text extraction and visibility in non-streaming responses.
  * Enhanced streaming and non-streaming response handling separation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->