### PR TITLE
fix: restore pattern matching fallback in force routing mode

### DIFF
--- a/crates/higgs/src/router.rs
+++ b/crates/higgs/src/router.rs
@@ -189,16 +189,10 @@ impl Router {
             if let Some(resolved) = self.try_auto_route(messages).await {
                 return Ok(resolved);
             }
-            // Auto-routing returned nothing -- skip pattern matching.
-            // Direct engine lookup still applies (the model may be a local engine name).
-            if let Some(engine) = self.local_engines.get(model) {
-                return Ok(ResolvedRoute::Higgs {
-                    engine: Arc::clone(engine),
-                    model_name: model.to_owned(),
-                    routing_method: RoutingMethod::Direct,
-                });
+            if model == "auto" {
+                return self.resolve_target(&self.default_target, model, RoutingMethod::Default);
             }
-            return self.resolve_target(&self.default_target, model, RoutingMethod::Default);
+            // force mode: auto-routing returned nothing, fall through to normal resolution
         }
 
         // Pattern matching (first match wins)
@@ -889,9 +883,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn force_mode_skips_pattern_matching() {
-        // force=true, no auto-router engine loaded -- should skip pattern
-        // matching and fall through to default, not pattern.
+    async fn force_mode_falls_through_without_engine() {
+        // force=true, no auto-router engine loaded, named model should
+        // fall through to normal resolution (pattern/direct/default).
         let config = config_from_toml(
             r#"
             [provider.anthropic]
@@ -919,7 +913,7 @@ mod tests {
                 ..
             } => {
                 assert_eq!(provider_name, "anthropic");
-                assert_eq!(routing_method, RoutingMethod::Default);
+                assert_eq!(routing_method, RoutingMethod::Pattern);
             }
             ResolvedRoute::Higgs { .. } => panic!("expected Remote route"),
         }


### PR DESCRIPTION
## Summary

- Reverts the force routing change from PR #55 that suppressed pattern matching when `auto_router.force = true`
- Force mode means "try auto-routing first for ALL requests," not "suppress pattern matching"
- When auto-routing has no answer, pattern routes should still apply as fallback
- The previous change broke model resolution for names that rely on pattern routes (e.g., `claude-opus-4-6` matching `pattern = "opus"`)

## Test plan

- [x] All 35 router unit tests pass, including `force_mode_falls_through_without_engine`
- [x] `cargo clippy -p higgs` clean
- [x] `cargo fmt -p higgs -- --check` clean
- [ ] Manual: verify `claude-opus-4-6` resolves correctly with force mode enabled


Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed routing resolution behavior when auto-routing is enabled with force mode. The router now correctly falls through to pattern matching and direct routing evaluation instead of defaulting immediately, resulting in more accurate route selection in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->