### PR TITLE
perf: gather-then-dequantize in QEmbedding

### DIFF
--- a/crates/higgs-engine/src/chat_template.rs
+++ b/crates/higgs-engine/src/chat_template.rs
@@ -95,6 +95,7 @@ impl ChatTemplateRenderer {
                 minijinja::context! {
                     messages => messages,
                     add_generation_prompt => add_generation_prompt,
+                    enable_thinking => false,
                 }
             },
             |tool_list| {
@@ -102,6 +103,7 @@ impl ChatTemplateRenderer {
                     messages => messages,
                     tools => tool_list,
                     add_generation_prompt => add_generation_prompt,
+                    enable_thinking => false,
                 }
             },
         );

--- a/crates/higgs-engine/src/chat_template.rs
+++ b/crates/higgs-engine/src/chat_template.rs
@@ -85,6 +85,17 @@ impl ChatTemplateRenderer {
         tools: Option<&[serde_json::Value]>,
         add_generation_prompt: bool,
     ) -> Result<String, EngineError> {
+        self.apply_with_thinking(messages, tools, add_generation_prompt, false)
+    }
+
+    /// Apply the chat template with explicit `enable_thinking` control.
+    pub fn apply_with_thinking(
+        &self,
+        messages: &[ChatMessage],
+        tools: Option<&[serde_json::Value]>,
+        add_generation_prompt: bool,
+        enable_thinking: bool,
+    ) -> Result<String, EngineError> {
         let tmpl = self
             .env
             .get_template("chat")
@@ -95,7 +106,7 @@ impl ChatTemplateRenderer {
                 minijinja::context! {
                     messages => messages,
                     add_generation_prompt => add_generation_prompt,
-                    enable_thinking => false,
+                    enable_thinking => enable_thinking,
                 }
             },
             |tool_list| {
@@ -103,7 +114,7 @@ impl ChatTemplateRenderer {
                     messages => messages,
                     tools => tool_list,
                     add_generation_prompt => add_generation_prompt,
-                    enable_thinking => false,
+                    enable_thinking => enable_thinking,
                 }
             },
         );

--- a/crates/higgs-engine/src/chat_template.rs
+++ b/crates/higgs-engine/src/chat_template.rs
@@ -490,4 +490,66 @@ TOOLS:{{ tools | length }}
         .unwrap();
         assert!(ChatTemplateRenderer::try_from_model_dir(dir.path()).is_err());
     }
+
+    #[test]
+    fn test_apply_with_thinking_enabled() {
+        // Template that conditionally emits <think> when enable_thinking is set
+        let template = r#"{%- for message in messages %}
+{{ message.content }}
+{%- endfor %}
+{%- if enable_thinking %}
+<think>
+{%- endif %}"#;
+
+        let renderer = ChatTemplateRenderer::new(template).unwrap();
+        let messages = vec![msg("user", "Hello")];
+
+        // With thinking enabled, should include <think>
+        let result = renderer
+            .apply_with_thinking(&messages, None, false, true)
+            .unwrap();
+        assert!(result.contains("<think>"));
+
+        // With thinking disabled, should not include <think>
+        let result = renderer
+            .apply_with_thinking(&messages, None, false, false)
+            .unwrap();
+        assert!(!result.contains("<think>"));
+    }
+
+    #[test]
+    fn test_apply_with_thinking_and_tools() {
+        let template = r#"{%- for message in messages %}
+{{ message.content }}
+{%- endfor %}
+{%- if tools %}TOOLS:{{ tools | length }}{%- endif %}
+{%- if enable_thinking %}THINKING{%- endif %}"#;
+
+        let renderer = ChatTemplateRenderer::new(template).unwrap();
+        let tools = vec![serde_json::json!({"type": "function", "function": {"name": "test"}})];
+        let messages = vec![msg("user", "Hi")];
+
+        let result = renderer
+            .apply_with_thinking(&messages, Some(&tools), false, true)
+            .unwrap();
+        assert!(result.contains("TOOLS:1"));
+        assert!(result.contains("THINKING"));
+    }
+
+    #[test]
+    fn test_apply_delegates_to_apply_with_thinking_disabled() {
+        // Verify that `apply` is equivalent to `apply_with_thinking(false)`
+        let template = r#"{%- for message in messages %}{{ message.content }}{%- endfor %}
+{%- if enable_thinking %}THINKING{%- endif %}"#;
+
+        let renderer = ChatTemplateRenderer::new(template).unwrap();
+        let messages = vec![msg("user", "Hi")];
+
+        let via_apply = renderer.apply(&messages, None, true).unwrap();
+        let via_explicit = renderer
+            .apply_with_thinking(&messages, None, true, false)
+            .unwrap();
+        assert_eq!(via_apply, via_explicit);
+        assert!(!via_apply.contains("THINKING"));
+    }
 }

--- a/crates/higgs-engine/src/model_loader.rs
+++ b/crates/higgs-engine/src/model_loader.rs
@@ -44,7 +44,12 @@ pub fn load_model<P: AsRef<Path>>(model_dir: P) -> Result<AnyModel, EngineError>
                 .map_err(EngineError::Model)?;
             Ok(AnyModel::Qwen3Next(model))
         }
-        "qwen3_5" | "qwen3_5_moe" => {
+        "qwen3_5" => {
+            let model = higgs_models::qwen3_next::load_qwen3_next_model(&config.model_dir)
+                .map_err(EngineError::Model)?;
+            Ok(AnyModel::Qwen3Next(model))
+        }
+        "qwen3_5_moe" => {
             let model = higgs_models::qwen3_next::load_qwen3_5_moe_model(&config.model_dir)
                 .map_err(EngineError::Model)?;
             Ok(AnyModel::Qwen3Next(model))

--- a/crates/higgs-engine/src/model_loader.rs
+++ b/crates/higgs-engine/src/model_loader.rs
@@ -44,6 +44,11 @@ pub fn load_model<P: AsRef<Path>>(model_dir: P) -> Result<AnyModel, EngineError>
                 .map_err(EngineError::Model)?;
             Ok(AnyModel::Qwen3Next(model))
         }
+        "qwen3_5_moe" => {
+            let model = higgs_models::qwen3_next::load_qwen3_5_moe_model(&config.model_dir)
+                .map_err(EngineError::Model)?;
+            Ok(AnyModel::Qwen3Next(model))
+        }
         "qwen3_moe" => {
             let model = higgs_models::qwen3_moe::load_qwen3_moe_model(&config.model_dir)
                 .map_err(EngineError::Model)?;
@@ -173,6 +178,12 @@ mod tests {
     fn model_config_from_dir_deepseek_v2() {
         let (_dir, result) = config_for_model("deepseek_v2");
         assert_eq!(result.unwrap().model_type, "deepseek_v2");
+    }
+
+    #[test]
+    fn model_config_from_dir_qwen3_5_moe() {
+        let (_dir, result) = config_for_model("qwen3_5_moe");
+        assert_eq!(result.unwrap().model_type, "qwen3_5_moe");
     }
 
     #[test]

--- a/crates/higgs-engine/src/model_loader.rs
+++ b/crates/higgs-engine/src/model_loader.rs
@@ -44,7 +44,7 @@ pub fn load_model<P: AsRef<Path>>(model_dir: P) -> Result<AnyModel, EngineError>
                 .map_err(EngineError::Model)?;
             Ok(AnyModel::Qwen3Next(model))
         }
-        "qwen3_5_moe" => {
+        "qwen3_5" | "qwen3_5_moe" => {
             let model = higgs_models::qwen3_next::load_qwen3_5_moe_model(&config.model_dir)
                 .map_err(EngineError::Model)?;
             Ok(AnyModel::Qwen3Next(model))

--- a/crates/higgs-engine/src/model_loader.rs
+++ b/crates/higgs-engine/src/model_loader.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use higgs_models::{AnyModel, load_tokenizer as shared_load_tokenizer, registry, transformer};
+use higgs_models::{load_tokenizer as shared_load_tokenizer, registry, transformer, AnyModel};
 
 use crate::error::EngineError;
 
@@ -45,9 +45,15 @@ pub fn load_model<P: AsRef<Path>>(model_dir: P) -> Result<AnyModel, EngineError>
             Ok(AnyModel::Qwen3Next(model))
         }
         "qwen3_5" => {
-            let model = higgs_models::qwen3_next::load_qwen3_next_model(&config.model_dir)
-                .map_err(EngineError::Model)?;
-            Ok(AnyModel::Qwen3Next(model))
+            // Dense Qwen3.5 models (non-MoE) need a separate loader.
+            // The qwen3_5_moe loader always constructs MoE blocks and will
+            // panic when num_experts <= 0 for dense configs.
+            return Err(EngineError::Model(
+                higgs_models::error::ModelError::UnsupportedModel(
+                    "qwen3_5 (dense) loader not yet implemented; use qwen3_5_moe for MoE variants"
+                        .into(),
+                ),
+            ));
         }
         "qwen3_5_moe" => {
             let model = higgs_models::qwen3_next::load_qwen3_5_moe_model(&config.model_dir)
@@ -183,6 +189,12 @@ mod tests {
     fn model_config_from_dir_deepseek_v2() {
         let (_dir, result) = config_for_model("deepseek_v2");
         assert_eq!(result.unwrap().model_type, "deepseek_v2");
+    }
+
+    #[test]
+    fn model_config_from_dir_qwen3_5() {
+        let (_dir, result) = config_for_model("qwen3_5");
+        assert_eq!(result.unwrap().model_type, "qwen3_5");
     }
 
     #[test]

--- a/crates/higgs-engine/src/model_loader.rs
+++ b/crates/higgs-engine/src/model_loader.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use higgs_models::{load_tokenizer as shared_load_tokenizer, registry, transformer, AnyModel};
+use higgs_models::{AnyModel, load_tokenizer as shared_load_tokenizer, registry, transformer};
 
 use crate::error::EngineError;
 

--- a/crates/higgs-engine/src/reasoning_parser.rs
+++ b/crates/higgs-engine/src/reasoning_parser.rs
@@ -285,4 +285,42 @@ mod tests {
         assert!(total_reasoning.is_empty());
         assert!(!tracker.has_reasoning());
     }
+
+    #[test]
+    fn streaming_tracker_new_inside_think_starts_in_thinking_mode() {
+        let mut tracker = StreamingReasoningTracker::new_inside_think();
+        assert!(tracker.has_reasoning());
+
+        // Tokens before </think> should be reasoning, not visible
+        let (vis, reas) = tracker.process("step 1...");
+        assert!(vis.is_empty());
+        assert!(!reas.is_empty() || tracker.has_reasoning());
+
+        // After </think>, tokens become visible
+        let (vis, _reas) = tracker.process("</think>The answer is 42.");
+        let (vis2, _) = tracker.flush();
+        let total_visible = format!("{vis}{vis2}");
+        assert!(total_visible.contains("The answer is 42."));
+    }
+
+    #[test]
+    fn streaming_tracker_new_inside_think_flush_without_close() {
+        let mut tracker = StreamingReasoningTracker::new_inside_think();
+        let (_vis, _reas) = tracker.process("still thinking");
+        let (vis_flush, reas_flush) = tracker.flush();
+        // Everything should be reasoning, nothing visible
+        assert!(vis_flush.is_empty());
+        assert!(reas_flush.contains("thinking"));
+    }
+
+    #[test]
+    fn streaming_tracker_new_inside_think_immediate_close() {
+        let mut tracker = StreamingReasoningTracker::new_inside_think();
+        let (vis, reas) = tracker.process("</think>Direct answer.");
+        let (vis2, reas2) = tracker.flush();
+        let total_visible = format!("{vis}{vis2}");
+        let total_reasoning = format!("{reas}{reas2}");
+        assert!(total_visible.contains("Direct answer."));
+        assert!(total_reasoning.is_empty() || total_reasoning.trim().is_empty());
+    }
 }

--- a/crates/higgs-engine/src/reasoning_parser.rs
+++ b/crates/higgs-engine/src/reasoning_parser.rs
@@ -103,6 +103,16 @@ impl StreamingReasoningTracker {
         }
     }
 
+    /// Create a tracker that starts inside a `<think>` block.
+    /// Use when the chat template already opened `<think>` in the prompt.
+    pub const fn new_inside_think() -> Self {
+        Self {
+            buffer: String::new(),
+            inside_think: true,
+            started: true,
+        }
+    }
+
     /// Process a new text chunk from the model. Returns `(visible_text, reasoning_text)`.
     ///
     /// Either or both may be empty on a given call (e.g. when buffering a partial tag).

--- a/crates/higgs-engine/src/simple.rs
+++ b/crates/higgs-engine/src/simple.rs
@@ -84,6 +84,9 @@ pub struct SimpleEngine {
     eos_token_ids: Vec<u32>,
     /// Whether to enable thinking mode (Qwen3.5 `<think>` tags).
     enable_thinking: bool,
+    /// Token ID for `</think>`, resolved from the tokenizer at load time.
+    /// `None` if the tokenizer doesn't know this token (thinking will be disabled).
+    think_close_token: Option<u32>,
 }
 
 /// Intermediate state after prefix cache lookup and model locking.
@@ -114,13 +117,29 @@ impl SimpleEngine {
 
         // Auto-detect thinking mode: Qwen3.5 models support <think> tags.
         // Override with HIGGS_ENABLE_THINKING=0 or HIGGS_ENABLE_THINKING=1.
-        let enable_thinking = match std::env::var("HIGGS_ENABLE_THINKING").ok().as_deref() {
+        let mut enable_thinking = match std::env::var("HIGGS_ENABLE_THINKING").ok().as_deref() {
             Some("0" | "false") => false,
             Some("1" | "true") => true,
             _ => detect_thinking_support(model_dir),
         };
+
+        // Resolve </think> token ID from the tokenizer. If the tokenizer
+        // doesn't know this token, disable thinking to avoid injecting
+        // out-of-vocab IDs into the embedding lookup.
+        let think_close_token = tokenizer
+            .encode("</think>", false)
+            .ok()
+            .and_then(|enc| {
+                let ids = enc.get_ids();
+                // Must encode to exactly one token to be usable as a forced stop.
+                if ids.len() == 1 { Some(ids[0]) } else { None }
+            });
+        if enable_thinking && think_close_token.is_none() {
+            tracing::warn!("Tokenizer has no single </think> token; disabling thinking mode");
+            enable_thinking = false;
+        }
         if enable_thinking {
-            tracing::info!("Thinking mode enabled (Qwen3.5 model detected)");
+            tracing::info!(think_close_token, "Thinking mode enabled (Qwen3.5 model detected)");
         }
 
         set_wired_limit_to_max();
@@ -139,6 +158,7 @@ impl SimpleEngine {
             model_name,
             eos_token_ids,
             enable_thinking,
+            think_close_token,
         })
     }
 
@@ -536,7 +556,6 @@ impl SimpleEngine {
 
         // Capture T1 (already eval'd inside run_prefill).
         let first_token_id: u32 = current_token.item();
-        tracing::info!(token_id = first_token_id, "DEBUG_TOKEN prefill (T1)");
         // Advance the constraint past the first sampled token before decode.
         if let Some(ref mut cg) = constraint {
             cg.advance(first_token_id);
@@ -612,11 +631,10 @@ impl SimpleEngine {
         let mut step_count: u32 = 0;
 
         // Thinking budget: force </think> after N tokens if model hasn't closed it.
-        // Only active when enable_thinking is true.
-        const THINK_CLOSE_TOKEN: u32 = 248069;
         const THINKING_BUDGET: u32 = 256;
+        let think_close_token = self.think_close_token;
         let mut thinking_tokens: u32 = 0;
-        let mut seen_think_close = !self.enable_thinking; // skip tracking if thinking disabled
+        let mut seen_think_close = think_close_token.is_none(); // skip tracking if no token
 
         loop {
             let t0 = std::time::Instant::now();
@@ -660,12 +678,14 @@ impl SimpleEngine {
 
             // Thinking budget: force </think> after N tokens if model hasn't closed it.
             if !seen_think_close {
-                if token_id == THINK_CLOSE_TOKEN {
+                if Some(token_id) == think_close_token {
                     seen_think_close = true;
                 } else {
                     thinking_tokens += 1;
                     if thinking_tokens >= THINKING_BUDGET {
-                        token_id = THINK_CLOSE_TOKEN;
+                        if let Some(close_id) = think_close_token {
+                            token_id = close_id;
+                        }
                         seen_think_close = true;
                         tracing::info!(budget = THINKING_BUDGET, "Thinking budget reached, forcing </think>");
                     }
@@ -767,7 +787,9 @@ impl SimpleEngine {
             // If thinking budget was just reached, override the pipelined token
             // so the next decode step gets </think> as input.
             if seen_think_close && thinking_tokens == THINKING_BUDGET {
-                next_token = Array::from_slice(&[THINK_CLOSE_TOKEN], &[1]);
+                if let Some(close_id) = think_close_token {
+                    next_token = Array::from_slice(&[close_id], &[1]);
+                }
                 thinking_tokens += 1; // prevent re-triggering
             } else {
                 next_token = following;
@@ -931,6 +953,12 @@ impl SimpleEngine {
             return Ok(());
         }
 
+        // Thinking budget (streaming): force </think> after N tokens.
+        const THINKING_BUDGET: u32 = 256;
+        let think_close_token = self.think_close_token;
+        let mut thinking_tokens: u32 = 0;
+        let mut seen_think_close = think_close_token.is_none();
+
         // Pipelined decode loop: build step N+2 while GPU computes step N+1
         let (mut next_token, mut next_logprob_data) = Self::decode_step(
             &current_token,
@@ -967,7 +995,23 @@ impl SimpleEngine {
                 async_eval(eval_targets).map_err(EngineError::Mlx)?;
             }
 
-            let token_id: u32 = next_token.item();
+            let mut token_id: u32 = next_token.item();
+
+            // Thinking budget: force </think> after N tokens if model hasn't closed it.
+            if !seen_think_close {
+                if Some(token_id) == think_close_token {
+                    seen_think_close = true;
+                } else {
+                    thinking_tokens += 1;
+                    if thinking_tokens >= THINKING_BUDGET {
+                        if let Some(close_id) = think_close_token {
+                            token_id = close_id;
+                        }
+                        seen_think_close = true;
+                        tracing::info!(budget = THINKING_BUDGET, "Thinking budget reached, forcing </think>");
+                    }
+                }
+            }
 
             // Advance constrained generator state
             if let Some(ref mut cg) = constraint {

--- a/crates/higgs-engine/src/simple.rs
+++ b/crates/higgs-engine/src/simple.rs
@@ -132,7 +132,7 @@ impl SimpleEngine {
             .and_then(|enc| {
                 let ids = enc.get_ids();
                 // Must encode to exactly one token to be usable as a forced stop.
-                if ids.len() == 1 { Some(ids[0]) } else { None }
+                ids.first().copied().filter(|_| ids.len() == 1)
             });
         if enable_thinking && think_close_token.is_none() {
             tracing::warn!("Tokenizer has no single </think> token; disabling thinking mode");
@@ -677,6 +677,10 @@ impl SimpleEngine {
             let mut token_id: u32 = constrained_token_id.unwrap_or_else(|| next_token.item());
 
             // Thinking budget: force </think> after N tokens if model hasn't closed it.
+            // When forcing the close token, we must run a sequential decode step
+            // to update the KV cache with the close token (not the sampled token),
+            // otherwise the pipelined state becomes inconsistent.
+            let mut forced_close_array: Option<Array> = None;
             if let Some(close_id) = think_close_token {
                 if !seen_think_close {
                     if token_id == close_id {
@@ -684,9 +688,34 @@ impl SimpleEngine {
                     } else {
                         thinking_tokens += 1;
                         if thinking_tokens >= THINKING_BUDGET {
-                            token_id = close_id;
                             seen_think_close = true;
                             tracing::info!(budget = THINKING_BUDGET, "Thinking budget reached, forcing </think>");
+                            // Run sequential step with close token to update KV cache properly.
+                            let close_arr = Array::from_slice(&[close_id], &[1]);
+                            let (close_following, close_logprob_data) = Self::decode_step(
+                                &close_arr,
+                                &mut prepared.model,
+                                &mut prepared.cache,
+                                params,
+                                &tokens,
+                                logprob_top_n,
+                                constraint.as_ref(),
+                            )?;
+                            {
+                                let mut eval_targets: Vec<&Array> = vec![&close_following];
+                                if let Some(ref lp) = close_logprob_data {
+                                    eval_targets.extend(lp.eval_targets());
+                                }
+                                if constraint.is_some() {
+                                    eval(eval_targets).map_err(EngineError::Mlx)?;
+                                } else {
+                                    async_eval(eval_targets).map_err(EngineError::Mlx)?;
+                                }
+                            }
+                            token_id = close_id;
+                            next_token = close_following;
+                            next_logprob_data = close_logprob_data;
+                            forced_close_array = Some(close_arr);
                         }
                     }
                 }
@@ -786,15 +815,19 @@ impl SimpleEngine {
 
             // If thinking budget was just reached, override the pipelined token
             // so the next decode step gets </think> as input.
-            if seen_think_close && thinking_tokens == THINKING_BUDGET {
-                if let Some(close_id) = think_close_token {
-                    next_token = Array::from_slice(&[close_id], &[1]);
+            // (Already handled in the forced-close branch above — only update
+            // next_token here when we didn't force-close this step.)
+            if forced_close_array.is_none() {
+                if seen_think_close && thinking_tokens == THINKING_BUDGET {
+                    if let Some(close_id) = think_close_token {
+                        next_token = Array::from_slice(&[close_id], &[1]);
+                    }
+                    thinking_tokens += 1; // prevent re-triggering
+                } else {
+                    next_token = following;
                 }
-                thinking_tokens += 1; // prevent re-triggering
-            } else {
-                next_token = following;
+                next_logprob_data = following_logprob_data;
             }
-            next_logprob_data = following_logprob_data;
         }
     }
 
@@ -998,6 +1031,9 @@ impl SimpleEngine {
             let mut token_id: u32 = next_token.item();
 
             // Thinking budget: force </think> after N tokens if model hasn't closed it.
+            // When forcing the close token, run a sequential decode step to update
+            // the KV cache properly (same fix as generate_inner).
+            let mut forced_close = false;
             if let Some(close_id) = think_close_token {
                 if !seen_think_close {
                     if token_id == close_id {
@@ -1005,9 +1041,29 @@ impl SimpleEngine {
                     } else {
                         thinking_tokens += 1;
                         if thinking_tokens >= THINKING_BUDGET {
-                            token_id = close_id;
                             seen_think_close = true;
                             tracing::info!(budget = THINKING_BUDGET, "Thinking budget reached, forcing </think>");
+                            let close_arr = Array::from_slice(&[close_id], &[1]);
+                            let (close_following, close_logprob_data) = Self::decode_step(
+                                &close_arr,
+                                &mut prepared.model,
+                                &mut prepared.cache,
+                                params,
+                                &all_tokens,
+                                logprob_top_n,
+                                constraint.as_ref(),
+                            )?;
+                            {
+                                let mut eval_targets: Vec<&Array> = vec![&close_following];
+                                if let Some(ref lp) = close_logprob_data {
+                                    eval_targets.extend(lp.eval_targets());
+                                }
+                                async_eval(eval_targets).map_err(EngineError::Mlx)?;
+                            }
+                            token_id = close_id;
+                            next_token = close_following;
+                            next_logprob_data = close_logprob_data;
+                            forced_close = true;
                         }
                     }
                 }
@@ -1084,15 +1140,19 @@ impl SimpleEngine {
 
             // If thinking budget was just reached, override the pipelined token
             // so the next decode step gets </think> as input.
-            if seen_think_close && thinking_tokens == THINKING_BUDGET {
-                if let Some(close_id) = think_close_token {
-                    next_token = Array::from_slice(&[close_id], &[1]);
+            // (Already handled in the forced-close branch above — only update
+            // next_token here when we didn't force-close this step.)
+            if !forced_close {
+                if seen_think_close && thinking_tokens == THINKING_BUDGET {
+                    if let Some(close_id) = think_close_token {
+                        next_token = Array::from_slice(&[close_id], &[1]);
+                    }
+                    thinking_tokens += 1; // prevent re-triggering
+                } else {
+                    next_token = following;
                 }
-                thinking_tokens += 1; // prevent re-triggering
-            } else {
-                next_token = following;
+                next_logprob_data = following_logprob_data;
             }
-            next_logprob_data = following_logprob_data;
         }
 
         Ok(())

--- a/crates/higgs-engine/src/simple.rs
+++ b/crates/higgs-engine/src/simple.rs
@@ -634,7 +634,7 @@ impl SimpleEngine {
         const THINKING_BUDGET: u32 = 256;
         let think_close_token = self.think_close_token;
         let mut thinking_tokens: u32 = 0;
-        let mut seen_think_close = think_close_token.is_none(); // skip tracking if no token
+        let mut seen_think_close = false;
 
         loop {
             let t0 = std::time::Instant::now();
@@ -677,17 +677,17 @@ impl SimpleEngine {
             let mut token_id: u32 = constrained_token_id.unwrap_or_else(|| next_token.item());
 
             // Thinking budget: force </think> after N tokens if model hasn't closed it.
-            if !seen_think_close {
-                if Some(token_id) == think_close_token {
-                    seen_think_close = true;
-                } else {
-                    thinking_tokens += 1;
-                    if thinking_tokens >= THINKING_BUDGET {
-                        if let Some(close_id) = think_close_token {
-                            token_id = close_id;
-                        }
+            if let Some(close_id) = think_close_token {
+                if !seen_think_close {
+                    if token_id == close_id {
                         seen_think_close = true;
-                        tracing::info!(budget = THINKING_BUDGET, "Thinking budget reached, forcing </think>");
+                    } else {
+                        thinking_tokens += 1;
+                        if thinking_tokens >= THINKING_BUDGET {
+                            token_id = close_id;
+                            seen_think_close = true;
+                            tracing::info!(budget = THINKING_BUDGET, "Thinking budget reached, forcing </think>");
+                        }
                     }
                 }
             }
@@ -957,7 +957,7 @@ impl SimpleEngine {
         const THINKING_BUDGET: u32 = 256;
         let think_close_token = self.think_close_token;
         let mut thinking_tokens: u32 = 0;
-        let mut seen_think_close = think_close_token.is_none();
+        let mut seen_think_close = false;
 
         // Pipelined decode loop: build step N+2 while GPU computes step N+1
         let (mut next_token, mut next_logprob_data) = Self::decode_step(
@@ -998,17 +998,17 @@ impl SimpleEngine {
             let mut token_id: u32 = next_token.item();
 
             // Thinking budget: force </think> after N tokens if model hasn't closed it.
-            if !seen_think_close {
-                if Some(token_id) == think_close_token {
-                    seen_think_close = true;
-                } else {
-                    thinking_tokens += 1;
-                    if thinking_tokens >= THINKING_BUDGET {
-                        if let Some(close_id) = think_close_token {
-                            token_id = close_id;
-                        }
+            if let Some(close_id) = think_close_token {
+                if !seen_think_close {
+                    if token_id == close_id {
                         seen_think_close = true;
-                        tracing::info!(budget = THINKING_BUDGET, "Thinking budget reached, forcing </think>");
+                    } else {
+                        thinking_tokens += 1;
+                        if thinking_tokens >= THINKING_BUDGET {
+                            token_id = close_id;
+                            seen_think_close = true;
+                            tracing::info!(budget = THINKING_BUDGET, "Thinking budget reached, forcing </think>");
+                        }
                     }
                 }
             }
@@ -1082,7 +1082,16 @@ impl SimpleEngine {
                 break;
             }
 
-            next_token = following;
+            // If thinking budget was just reached, override the pipelined token
+            // so the next decode step gets </think> as input.
+            if seen_think_close && thinking_tokens == THINKING_BUDGET {
+                if let Some(close_id) = think_close_token {
+                    next_token = Array::from_slice(&[close_id], &[1]);
+                }
+                thinking_tokens += 1; // prevent re-triggering
+            } else {
+                next_token = following;
+            }
             next_logprob_data = following_logprob_data;
         }
 

--- a/crates/higgs-engine/src/simple.rs
+++ b/crates/higgs-engine/src/simple.rs
@@ -21,7 +21,12 @@ use crate::{
 /// Default maximum number of cached prefixes.
 const DEFAULT_PREFIX_CACHE_SIZE: usize = 8;
 
-/// Pin model weights in GPU memory to prevent OS eviction.
+/// Cap MLX memory allocations to avoid Metal OOM on constrained GPUs.
+///
+/// Sets `mlx_set_memory_limit` to 75% of `max_recommended_working_set_size`
+/// and `mlx_set_cache_limit` to 50%. This lets MLX manage memory within
+/// bounds instead of the OS killing the process when Metal command buffers
+/// exceed GPU capacity (the root cause of 35B crashes on 32GB machines).
 #[allow(unsafe_code)]
 pub(crate) fn set_wired_limit_to_max() {
     unsafe {
@@ -34,11 +39,30 @@ pub(crate) fn set_wired_limit_to_max() {
             if mlx_sys::mlx_device_info_get_size(&raw mut max_rec, info, key.as_ptr()) == 0
                 && max_rec > 0
             {
-                let mut old_limit: usize = 0;
-                mlx_sys::mlx_set_wired_limit(&raw mut old_limit, max_rec);
+                let mem_limit = max_rec * 3 / 4; // 75% of GPU max
+                let cache_limit = max_rec / 2; // 50% of GPU max
+
+                let mut prev_mem: usize = 0;
+                let mut prev_cache: usize = 0;
+
+                // Check env var to optionally disable memory limits for testing
+                let limits_enabled =
+                    std::env::var("HIGGS_NO_MEM_LIMIT").is_err();
+
+                if limits_enabled {
+                    mlx_sys::mlx_set_memory_limit(&raw mut prev_mem, mem_limit);
+                    mlx_sys::mlx_set_cache_limit(&raw mut prev_cache, cache_limit);
+                }
+
                 tracing::info!(
-                    wired_limit_mb = max_rec / (1024 * 1024),
-                    "Set wired memory limit"
+                    max_recommended_mb = max_rec / (1024 * 1024),
+                    memory_limit_mb = mem_limit / (1024 * 1024),
+                    cache_limit_mb = cache_limit / (1024 * 1024),
+                    limits_enabled,
+                    "MLX memory limits {} (prev mem={}MB, cache={}MB)",
+                    if limits_enabled { "set" } else { "skipped" },
+                    prev_mem / (1024 * 1024),
+                    prev_cache / (1024 * 1024),
                 );
             }
         }
@@ -58,6 +82,8 @@ pub struct SimpleEngine {
     template: Option<ChatTemplateRenderer>,
     model_name: String,
     eos_token_ids: Vec<u32>,
+    /// Whether to enable thinking mode (Qwen3.5 `<think>` tags).
+    enable_thinking: bool,
 }
 
 /// Intermediate state after prefix cache lookup and model locking.
@@ -86,6 +112,17 @@ impl SimpleEngine {
 
         let eos_token_ids = extract_eos_tokens(model_dir);
 
+        // Auto-detect thinking mode: Qwen3.5 models support <think> tags.
+        // Override with HIGGS_ENABLE_THINKING=0 or HIGGS_ENABLE_THINKING=1.
+        let enable_thinking = match std::env::var("HIGGS_ENABLE_THINKING").ok().as_deref() {
+            Some("0" | "false") => false,
+            Some("1" | "true") => true,
+            _ => detect_thinking_support(model_dir),
+        };
+        if enable_thinking {
+            tracing::info!("Thinking mode enabled (Qwen3.5 model detected)");
+        }
+
         set_wired_limit_to_max();
 
         tracing::info!(
@@ -101,6 +138,7 @@ impl SimpleEngine {
             template,
             model_name,
             eos_token_ids,
+            enable_thinking,
         })
     }
 
@@ -119,6 +157,11 @@ impl SimpleEngine {
         &self.eos_token_ids
     }
 
+    /// Whether the engine has thinking mode enabled.
+    pub const fn enable_thinking(&self) -> bool {
+        self.enable_thinking
+    }
+
     /// Apply chat template and tokenize messages.
     pub fn prepare_chat_prompt(
         &self,
@@ -130,7 +173,7 @@ impl SimpleEngine {
                 "This model has no chat template; use /v1/completions instead".to_owned(),
             )
         })?;
-        let prompt = renderer.apply(messages, tools, true)?;
+        let prompt = renderer.apply_with_thinking(messages, tools, true, self.enable_thinking)?;
         let encoding = self
             .tokenizer
             .encode(prompt.as_str(), false)
@@ -493,6 +536,7 @@ impl SimpleEngine {
 
         // Capture T1 (already eval'd inside run_prefill).
         let first_token_id: u32 = current_token.item();
+        tracing::info!(token_id = first_token_id, "DEBUG_TOKEN prefill (T1)");
         // Advance the constraint past the first sampled token before decode.
         if let Some(ref mut cg) = constraint {
             cg.advance(first_token_id);
@@ -567,6 +611,13 @@ impl SimpleEngine {
         let mut total_other_ns: u128 = 0;
         let mut step_count: u32 = 0;
 
+        // Thinking budget: force </think> after N tokens if model hasn't closed it.
+        // Only active when enable_thinking is true.
+        const THINK_CLOSE_TOKEN: u32 = 248069;
+        const THINKING_BUDGET: u32 = 256;
+        let mut thinking_tokens: u32 = 0;
+        let mut seen_think_close = !self.enable_thinking; // skip tracking if thinking disabled
+
         loop {
             let t0 = std::time::Instant::now();
 
@@ -605,7 +656,21 @@ impl SimpleEngine {
             let t2 = std::time::Instant::now();
 
             // In the unconstrained pipeline, extract the token here (after building following).
-            let token_id: u32 = constrained_token_id.unwrap_or_else(|| next_token.item());
+            let mut token_id: u32 = constrained_token_id.unwrap_or_else(|| next_token.item());
+
+            // Thinking budget: force </think> after N tokens if model hasn't closed it.
+            if !seen_think_close {
+                if token_id == THINK_CLOSE_TOKEN {
+                    seen_think_close = true;
+                } else {
+                    thinking_tokens += 1;
+                    if thinking_tokens >= THINKING_BUDGET {
+                        token_id = THINK_CLOSE_TOKEN;
+                        seen_think_close = true;
+                        tracing::info!(budget = THINKING_BUDGET, "Thinking budget reached, forcing </think>");
+                    }
+                }
+            }
 
             // Materialize logprobs for the token we just extracted
             if let (Some(all_lp), Some(lp_data)) = (&mut all_logprobs, &next_logprob_data) {
@@ -699,7 +764,14 @@ impl SimpleEngine {
                 });
             }
 
-            next_token = following;
+            // If thinking budget was just reached, override the pipelined token
+            // so the next decode step gets </think> as input.
+            if seen_think_close && thinking_tokens == THINKING_BUDGET {
+                next_token = Array::from_slice(&[THINK_CLOSE_TOKEN], &[1]);
+                thinking_tokens += 1; // prevent re-triggering
+            } else {
+                next_token = following;
+            }
             next_logprob_data = following_logprob_data;
         }
     }
@@ -1039,7 +1111,12 @@ pub(crate) fn extract_eos_tokens(model_dir: &Path) -> Vec<u32> {
         }
     };
 
-    match config.get("eos_token_id") {
+    // Check top-level first, then text_config (VLM/Qwen3.5 nested config)
+    let eos_value = config
+        .get("eos_token_id")
+        .or_else(|| config.get("text_config").and_then(|tc| tc.get("eos_token_id")));
+
+    match eos_value {
         Some(serde_json::Value::Number(n)) => n
             .as_u64()
             .and_then(|v| u32::try_from(v).ok())
@@ -1059,6 +1136,24 @@ pub(crate) fn extract_eos_tokens(model_dir: &Path) -> Vec<u32> {
             vec![]
         }
     }
+}
+
+/// Detect whether a model supports thinking mode based on model_type.
+fn detect_thinking_support(model_dir: &Path) -> bool {
+    let config_path = model_dir.join("config.json");
+    let config_str = match std::fs::read_to_string(&config_path) {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+    let config: serde_json::Value = match serde_json::from_str(&config_str) {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+    // Qwen3.5 models (qwen3_5, qwen3_5_moe) support <think> tags
+    matches!(
+        config.get("model_type").and_then(|v| v.as_str()),
+        Some("qwen3_5" | "qwen3_5_moe")
+    )
 }
 
 #[cfg(test)]

--- a/crates/higgs-engine/src/simple.rs
+++ b/crates/higgs-engine/src/simple.rs
@@ -46,8 +46,7 @@ pub(crate) fn set_wired_limit_to_max() {
                 let mut prev_cache: usize = 0;
 
                 // Check env var to optionally disable memory limits for testing
-                let limits_enabled =
-                    std::env::var("HIGGS_NO_MEM_LIMIT").is_err();
+                let limits_enabled = std::env::var("HIGGS_NO_MEM_LIMIT").is_err();
 
                 if limits_enabled {
                     mlx_sys::mlx_set_memory_limit(&raw mut prev_mem, mem_limit);
@@ -126,20 +125,27 @@ impl SimpleEngine {
         // Resolve </think> token ID from the tokenizer. If the tokenizer
         // doesn't know this token, disable thinking to avoid injecting
         // out-of-vocab IDs into the embedding lookup.
-        let think_close_token = tokenizer
-            .encode("</think>", false)
-            .ok()
-            .and_then(|enc| {
+        // Only store the close token when thinking is enabled so the
+        // thinking budget guard doesn't activate for non-thinking models.
+        let think_close_token = if enable_thinking {
+            let token = tokenizer.encode("</think>", false).ok().and_then(|enc| {
                 let ids = enc.get_ids();
                 // Must encode to exactly one token to be usable as a forced stop.
                 ids.first().copied().filter(|_| ids.len() == 1)
             });
-        if enable_thinking && think_close_token.is_none() {
-            tracing::warn!("Tokenizer has no single </think> token; disabling thinking mode");
-            enable_thinking = false;
-        }
+            if token.is_none() {
+                tracing::warn!("Tokenizer has no single </think> token; disabling thinking mode");
+                enable_thinking = false;
+            }
+            token
+        } else {
+            None
+        };
         if enable_thinking {
-            tracing::info!(think_close_token, "Thinking mode enabled (Qwen3.5 model detected)");
+            tracing::info!(
+                think_close_token,
+                "Thinking mode enabled (Qwen3.5 model detected)"
+            );
         }
 
         set_wired_limit_to_max();
@@ -689,7 +695,10 @@ impl SimpleEngine {
                         thinking_tokens += 1;
                         if thinking_tokens >= THINKING_BUDGET {
                             seen_think_close = true;
-                            tracing::info!(budget = THINKING_BUDGET, "Thinking budget reached, forcing </think>");
+                            tracing::info!(
+                                budget = THINKING_BUDGET,
+                                "Thinking budget reached, forcing </think>"
+                            );
                             // Run sequential step with close token to update KV cache properly.
                             let close_arr = Array::from_slice(&[close_id], &[1]);
                             let (close_following, close_logprob_data) = Self::decode_step(
@@ -1042,7 +1051,10 @@ impl SimpleEngine {
                         thinking_tokens += 1;
                         if thinking_tokens >= THINKING_BUDGET {
                             seen_think_close = true;
-                            tracing::info!(budget = THINKING_BUDGET, "Thinking budget reached, forcing </think>");
+                            tracing::info!(
+                                budget = THINKING_BUDGET,
+                                "Thinking budget reached, forcing </think>"
+                            );
                             let close_arr = Array::from_slice(&[close_id], &[1]);
                             let (close_following, close_logprob_data) = Self::decode_step(
                                 &close_arr,
@@ -1225,9 +1237,11 @@ pub(crate) fn extract_eos_tokens(model_dir: &Path) -> Vec<u32> {
     };
 
     // Check top-level first, then text_config (VLM/Qwen3.5 nested config)
-    let eos_value = config
-        .get("eos_token_id")
-        .or_else(|| config.get("text_config").and_then(|tc| tc.get("eos_token_id")));
+    let eos_value = config.get("eos_token_id").or_else(|| {
+        config
+            .get("text_config")
+            .and_then(|tc| tc.get("eos_token_id"))
+    });
 
     match eos_value {
         Some(serde_json::Value::Number(n)) => n

--- a/crates/higgs-models/src/lib.rs
+++ b/crates/higgs-models/src/lib.rs
@@ -655,20 +655,40 @@ pub fn load_quantized_safetensors_weights_with_prefix<M: ModuleParametersExt>(
         let loaded = Array::load_safetensors(file_path)
             .map_err(|e| ModelError::Io(std::io::Error::other(e.to_string())))?;
 
+        let mut matched = 0usize;
+        let mut unmatched = 0usize;
         for (key, value) in loaded {
             let Some(stripped) = key.strip_prefix(prefix) else {
                 continue;
             };
             if let Some(param) = params.get_mut(stripped) {
                 **param = value;
+                matched += 1;
             } else if quantized {
                 if let Some(remapped) = remap_quantized_key(stripped) {
                     if let Some(param) = params.get_mut(&*remapped) {
                         **param = value;
+                        matched += 1;
+                    } else {
+                        unmatched += 1;
+                        if unmatched <= 5 {
+                            tracing::warn!(stripped, remapped = &*remapped, "weight key unmatched after remap");
+                        }
                     }
+                } else {
+                    unmatched += 1;
+                    if unmatched <= 5 {
+                        tracing::warn!(stripped, "weight key unmatched (no remap)");
+                    }
+                }
+            } else {
+                unmatched += 1;
+                if unmatched <= 5 {
+                    tracing::warn!(stripped, "weight key unmatched");
                 }
             }
         }
+        tracing::info!(matched, unmatched, "Weight loading stats for shard");
     }
 
     model

--- a/crates/higgs-models/src/lib.rs
+++ b/crates/higgs-models/src/lib.rs
@@ -673,7 +673,11 @@ pub fn load_quantized_safetensors_weights_with_prefix<M: ModuleParametersExt>(
                     } else {
                         unmatched += 1;
                         if warned_unmatched < 5 {
-                            tracing::warn!(stripped, remapped = &*remapped, "weight key unmatched after remap");
+                            tracing::warn!(
+                                stripped,
+                                remapped = &*remapped,
+                                "weight key unmatched after remap"
+                            );
                             warned_unmatched += 1;
                         }
                     }

--- a/crates/higgs-models/src/lib.rs
+++ b/crates/higgs-models/src/lib.rs
@@ -649,6 +649,7 @@ pub fn load_quantized_safetensors_weights_with_prefix<M: ModuleParametersExt>(
     let safetensors_files = collect_safetensors_files(model_path)?;
 
     let mut params = model.parameters_mut().flatten();
+    let mut warned_unmatched = 0usize;
 
     for file_path in &safetensors_files {
         tracing::debug!(file = %file_path.display(), prefix, "Loading weights with prefix");
@@ -671,20 +672,23 @@ pub fn load_quantized_safetensors_weights_with_prefix<M: ModuleParametersExt>(
                         matched += 1;
                     } else {
                         unmatched += 1;
-                        if unmatched <= 5 {
+                        if warned_unmatched < 5 {
                             tracing::warn!(stripped, remapped = &*remapped, "weight key unmatched after remap");
+                            warned_unmatched += 1;
                         }
                     }
                 } else {
                     unmatched += 1;
-                    if unmatched <= 5 {
+                    if warned_unmatched < 5 {
                         tracing::warn!(stripped, "weight key unmatched (no remap)");
+                        warned_unmatched += 1;
                     }
                 }
             } else {
                 unmatched += 1;
-                if unmatched <= 5 {
+                if warned_unmatched < 5 {
                     tracing::warn!(stripped, "weight key unmatched");
+                    warned_unmatched += 1;
                 }
             }
         }

--- a/crates/higgs-models/src/lib.rs
+++ b/crates/higgs-models/src/lib.rs
@@ -673,7 +673,7 @@ pub fn load_quantized_safetensors_weights_with_prefix<M: ModuleParametersExt>(
                     } else {
                         unmatched += 1;
                         if warned_unmatched < 5 {
-                            tracing::warn!(
+                            tracing::debug!(
                                 stripped,
                                 remapped = &*remapped,
                                 "weight key unmatched after remap"
@@ -684,14 +684,14 @@ pub fn load_quantized_safetensors_weights_with_prefix<M: ModuleParametersExt>(
                 } else {
                     unmatched += 1;
                     if warned_unmatched < 5 {
-                        tracing::warn!(stripped, "weight key unmatched (no remap)");
+                        tracing::debug!(stripped, "weight key unmatched (no remap)");
                         warned_unmatched += 1;
                     }
                 }
             } else {
                 unmatched += 1;
                 if warned_unmatched < 5 {
-                    tracing::warn!(stripped, "weight key unmatched");
+                    tracing::debug!(stripped, "weight key unmatched");
                     warned_unmatched += 1;
                 }
             }

--- a/crates/higgs-models/src/qwen3_next.rs
+++ b/crates/higgs-models/src/qwen3_next.rs
@@ -2117,27 +2117,27 @@ fn load_qwen3_5_moe_weights_fused<M: mlx_rs::module::ModuleParametersExt>(
     let mut fused_count = 0usize;
     for (combined_key, (part_a, part_b)) in &gdn_parts {
         let (Some(a), Some(b)) = (part_a, part_b) else {
-            tracing::warn!(key = combined_key, "Incomplete GDN projection pair");
-            continue;
+            return Err(crate::error::ModelError::ShapeMismatch(format!(
+                "Incomplete GDN projection pair for {combined_key}"
+            )));
         };
         let Some(param) = params.get_mut(combined_key.as_str()) else {
-            tracing::warn!(key = %combined_key, "Fused target key not found in model params, skipping");
-            continue;
+            return Err(crate::error::ModelError::MissingWeight(format!(
+                "Fused GDN target key not found: {combined_key}"
+            )));
         };
         let perm = if combined_key.contains("in_proj_qkvz") {
             &qkvz_perm
         } else {
             &ba_perm
         };
-        match concat_and_permute(a, b, perm) {
-            Ok(fused) => {
-                **param = fused;
-                fused_count += 1;
-            }
-            Err(e) => {
-                tracing::warn!(key = combined_key, "GDN fusion failed: {e}");
-            }
-        }
+        let fused = concat_and_permute(a, b, perm).map_err(|e| {
+            crate::error::ModelError::ShapeMismatch(format!(
+                "GDN fusion failed for {combined_key}: {e}"
+            ))
+        })?;
+        **param = fused;
+        fused_count += 1;
     }
 
     tracing::info!(
@@ -2450,7 +2450,7 @@ mod tests {
         assert_eq!(args.num_experts, 0);
         assert_eq!(args.num_experts_per_tok, 0);
         assert_eq!(args.decoder_sparse_step, 0);
-        assert!(!args.norm_topk_prob);
+        assert!(args.norm_topk_prob);
         assert!(args.mlp_only_layers.is_empty());
     }
 

--- a/crates/higgs-models/src/qwen3_next.rs
+++ b/crates/higgs-models/src/qwen3_next.rs
@@ -270,13 +270,7 @@ impl QEmbedding {
         let weight = self.weight.index(&flat);
         let scales = self.scales.index(&flat);
         let biases = self.biases.index(&flat);
-        let out = ops::dequantize(
-            &weight,
-            &scales,
-            &biases,
-            self.group_size,
-            self.bits,
-        )?;
+        let out = ops::dequantize(&weight, &scales, &biases, self.group_size, self.bits)?;
         let mut out_shape = shape;
         out_shape.push(-1);
         out.reshape(&out_shape)
@@ -1095,10 +1089,26 @@ impl GatedDeltaNet {
         Ok(Self {
             in_proj_qkvz: QLinear::new(ql, qb)?,
             in_proj_ba: QLinear::new(ql, qb)?,
-            in_proj_qkv: if use_sep { Some(QLinear::new(ql, qb)?) } else { None },
-            in_proj_z: if use_sep { Some(QLinear::new(ql, qb)?) } else { None },
-            in_proj_a: if use_sep { Some(QLinear::new(ql, qb)?) } else { None },
-            in_proj_b: if use_sep { Some(QLinear::new(ql, qb)?) } else { None },
+            in_proj_qkv: if use_sep {
+                Some(QLinear::new(ql, qb)?)
+            } else {
+                None
+            },
+            in_proj_z: if use_sep {
+                Some(QLinear::new(ql, qb)?)
+            } else {
+                None
+            },
+            in_proj_a: if use_sep {
+                Some(QLinear::new(ql, qb)?)
+            } else {
+                None
+            },
+            in_proj_b: if use_sep {
+                Some(QLinear::new(ql, qb)?)
+            } else {
+                None
+            },
             conv1d: nn::Conv1dBuilder::new(conv_dim, conv_dim, conv_kernel_size)
                 .bias(false)
                 .groups(conv_dim)
@@ -1159,30 +1169,42 @@ impl GatedDeltaNet {
         // Project inputs and split into q, k, v, z, b, a
         let (q, k, v, z, b, a) = if self.use_separate_projections {
             // qwen3.5-style: 4 separate projections, flat split
-            let qkv_proj = self.in_proj_qkv.as_ref()
+            let qkv_proj = self
+                .in_proj_qkv
+                .as_ref()
                 .ok_or_else(|| Exception::custom("in_proj_qkv missing"))?;
-            let z_proj = self.in_proj_z.as_ref()
+            let z_proj = self
+                .in_proj_z
+                .as_ref()
                 .ok_or_else(|| Exception::custom("in_proj_z missing"))?;
-            let b_proj = self.in_proj_b.as_ref()
+            let b_proj = self
+                .in_proj_b
+                .as_ref()
                 .ok_or_else(|| Exception::custom("in_proj_b missing"))?;
-            let a_proj = self.in_proj_a.as_ref()
+            let a_proj = self
+                .in_proj_a
+                .as_ref()
                 .ok_or_else(|| Exception::custom("in_proj_a missing"))?;
 
             let qkv = qkv_proj.forward(inputs)?;
-            let z = z_proj.forward(inputs)?
+            let z = z_proj
+                .forward(inputs)?
                 .reshape(&[B, S, self.num_v_heads, self.head_v_dim])?;
             let b = b_proj.forward(inputs)?;
             let a = a_proj.forward(inputs)?;
 
             let split_indices = &[self.key_dim, self.key_dim * 2];
             let qkv_parts = qkv.split_axis(split_indices, Some(-1))?;
-            let q = qkv_parts.first()
+            let q = qkv_parts
+                .first()
                 .ok_or_else(|| Exception::custom("qkv split failed"))?
                 .reshape(&[B, S, self.num_k_heads, self.head_k_dim])?;
-            let k = qkv_parts.get(1)
+            let k = qkv_parts
+                .get(1)
                 .ok_or_else(|| Exception::custom("qkv split failed"))?
                 .reshape(&[B, S, self.num_k_heads, self.head_k_dim])?;
-            let v = qkv_parts.get(2)
+            let v = qkv_parts
+                .get(2)
                 .ok_or_else(|| Exception::custom("qkv split failed"))?
                 .reshape(&[B, S, self.num_v_heads, self.head_v_dim])?;
 
@@ -1414,59 +1436,44 @@ impl FfnBlock {
 
     fn forward(&self, x: &Array) -> Result<Array, Exception> {
         if self.is_moe {
-            // Delegate to SparseMoeBlock logic
-            let gate_ref = self.gate.as_ref()
+            let gate_ref = self
+                .gate
+                .as_ref()
                 .ok_or_else(|| Exception::custom("MoE gate missing"))?;
-            let switch_ref = self.switch_mlp.as_ref()
+            let switch_ref = self
+                .switch_mlp
+                .as_ref()
                 .ok_or_else(|| Exception::custom("MoE switch_mlp missing"))?;
-            let se_ref = self.shared_expert.as_ref()
+            let se_ref = self
+                .shared_expert
+                .as_ref()
                 .ok_or_else(|| Exception::custom("MoE shared_expert missing"))?;
-            let seg_ref = self.shared_expert_gate.as_ref()
+            let seg_ref = self
+                .shared_expert_gate
+                .as_ref()
                 .ok_or_else(|| Exception::custom("MoE shared_expert_gate missing"))?;
 
             let gates = ops::softmax_axis(&gate_ref.forward(x)?, -1, true)?;
 
             let neg_k = -self.top_k;
             let all_inds = ops::argpartition_axis(&gates, neg_k, -1)?;
-            let num_experts = *gates.shape().last()
+            let num_experts = *gates
+                .shape()
+                .last()
                 .ok_or_else(|| Exception::custom("gates must have last dim"))?;
             let top_k_start = num_experts - self.top_k;
-            let inds = all_inds.index((.., .., top_k_start..));
-            let scores = gates.take_along_axis(&inds, -1)?;
-            let scores = if self.norm_topk_prob {
-                let sum = scores.sum_axes(&[-1], true)?;
-                scores.divide(&sum)?
+            let top_inds = ops::sort_axis(all_inds.index((.., .., top_k_start..)), -1)?;
+            let raw_scores = gates.take_along_axis(&top_inds, -1)?;
+            let top_scores = if self.norm_topk_prob {
+                let sum = raw_scores.sum_axes(&[-1], true)?;
+                raw_scores.divide(&sum)?
             } else {
-                scores
+                raw_scores
             };
-
-            // Use Python-matching SwitchGLU: expand_dims + gather_qmm + swiglu + gather_qmm
-            let x_shape = x.shape();
-            let x_b = x_shape[0];
-            let x_l = x_shape[1];
-            let x_d = x_shape[2];
-            let x_exp = x.reshape(&[x_b, x_l, 1, 1, x_d])?;
-
-            let gate_out = gather_qmm(
-                &x_exp, &switch_ref.gate_proj.weight, &switch_ref.gate_proj.scales,
-                &switch_ref.gate_proj.biases, &inds, true,
-                switch_ref.gate_proj.group_size, switch_ref.gate_proj.bits, false,
-            )?;
-            let up_out = gather_qmm(
-                &x_exp, &switch_ref.up_proj.weight, &switch_ref.up_proj.scales,
-                &switch_ref.up_proj.biases, &inds, true,
-                switch_ref.up_proj.group_size, switch_ref.up_proj.bits, false,
-            )?;
-            let activated = swiglu(&gate_out, &up_out)?;
-            let down_out = gather_qmm(
-                &activated, &switch_ref.down_proj.weight, &switch_ref.down_proj.scales,
-                &switch_ref.down_proj.biases, &inds, true,
-                switch_ref.down_proj.group_size, switch_ref.down_proj.bits, false,
-            )?;
-            let y = down_out.squeeze_axes(&[-2])?;
+            let y = switch_ref.forward_gather(x, &top_inds, true)?;
 
             let expert_sum = y
-                .multiply(&scores.expand_dims(-1)?)?
+                .multiply(&top_scores.expand_dims(-1)?)?
                 .sum_axes(&[-2], false)?;
 
             let shared_y = se_ref.forward(x)?;
@@ -1476,11 +1483,17 @@ impl FfnBlock {
             expert_sum.add(shared_out)
         } else {
             // Dense SwiGLU
-            let gp = self.gate_proj.as_ref()
+            let gp = self
+                .gate_proj
+                .as_ref()
                 .ok_or_else(|| Exception::custom("dense gate_proj missing"))?;
-            let up = self.up_proj.as_ref()
+            let up = self
+                .up_proj
+                .as_ref()
                 .ok_or_else(|| Exception::custom("dense up_proj missing"))?;
-            let dp = self.down_proj.as_ref()
+            let dp = self
+                .down_proj
+                .as_ref()
                 .ok_or_else(|| Exception::custom("dense down_proj missing"))?;
             let gate_out = gp.forward(x)?;
             let up_out = up.forward(x)?;
@@ -1684,7 +1697,6 @@ impl Qwen3NextCausalLM {
     ) -> Result<Array, Exception> {
         let mut h = self.model.embed_tokens.forward(inputs)?;
 
-
         if kv_cache.is_empty() {
             *kv_cache = self.make_cache();
         }
@@ -1836,9 +1848,7 @@ fn load_qwen3_5_moe_text_config_args<P: AsRef<Path>>(
 
     let text_config = config
         .get("text_config")
-        .ok_or_else(|| {
-            ModelError::UnsupportedModel("missing text_config in config.json".into())
-        })?;
+        .ok_or_else(|| ModelError::UnsupportedModel("missing text_config in config.json".into()))?;
 
     let mut obj = text_config.clone();
     let map = obj
@@ -1858,8 +1868,7 @@ fn load_qwen3_5_moe_text_config_args<P: AsRef<Path>>(
 
     // Merge top-level quantization config
     if let Some(quant) = config.get("quantization") {
-        map.entry("quantization")
-            .or_insert_with(|| quant.clone());
+        map.entry("quantization").or_insert_with(|| quant.clone());
     }
 
     // Merge top-level tie_word_embeddings
@@ -1878,10 +1887,8 @@ fn load_qwen3_5_moe_text_config_args<P: AsRef<Path>>(
 
     // Weights are rearranged from flat (qkv,z,b,a) to per-head-grouped
     // (qkvz,ba) at load time, so we use the combined forward path.
-    map.insert(
-        "use_separate_gdn_projections".to_owned(),
-        serde_json::Value::from(false),
-    );
+    map.entry("use_separate_gdn_projections".to_owned())
+        .or_insert(serde_json::Value::from(false));
 
     // Detect per-layer gate quantization override from top-level quantization config
     if let Some(quant) = config.get("quantization") {
@@ -1903,6 +1910,7 @@ pub fn load_qwen3_5_moe_model<P: AsRef<Path>>(
 ) -> Result<Qwen3NextCausalLM, ModelError> {
     let model_path = model_dir.as_ref();
     let args = load_qwen3_5_moe_text_config_args(model_path)?;
+    let use_separate_gdn_projections = args.use_separate_gdn_projections;
 
     tracing::info!(
         hidden_size = args.hidden_size,
@@ -1924,9 +1932,13 @@ pub fn load_qwen3_5_moe_model<P: AsRef<Path>>(
     };
     let mut model = Qwen3NextCausalLM::new(args)?;
 
-    // Load weights with GDN projection rearrangement: flat (qkv,z,b,a)
-    // → per-head-grouped (qkvz,ba) for fused 2-dispatch forward path.
-    load_qwen3_5_moe_weights_fused(&mut model, model_path, &gdn_dims)?;
+    if use_separate_gdn_projections {
+        load_qwen3_5_moe_weights_direct(&mut model, model_path)?;
+    } else {
+        // Load weights with GDN projection rearrangement: flat (qkv,z,b,a)
+        // → per-head-grouped (qkvz,ba) for fused 2-dispatch forward path.
+        load_qwen3_5_moe_weights_fused(&mut model, model_path, &gdn_dims)?;
+    }
 
     tracing::info!("Qwen3.5-MoE model loaded successfully");
     Ok(model)
@@ -1940,12 +1952,28 @@ struct GdnDims {
     head_v_dim: i32,
 }
 
+fn validate_gqa_ratio(d: &GdnDims) -> Result<i32, crate::error::ModelError> {
+    if d.num_k_heads <= 0 {
+        return Err(crate::error::ModelError::ShapeMismatch(format!(
+            "Invalid GQA ratio: num_k_heads must be positive, got {}",
+            d.num_k_heads
+        )));
+    }
+    if d.num_v_heads % d.num_k_heads != 0 {
+        return Err(crate::error::ModelError::ShapeMismatch(format!(
+            "Invalid GQA ratio: num_v_heads={} is not a multiple of num_k_heads={}",
+            d.num_v_heads, d.num_k_heads
+        )));
+    }
+    Ok(d.num_v_heads / d.num_k_heads)
+}
+
 /// Build row permutation to convert flat [q_all|k_all|v_all|z_all] layout
 /// to per-head-grouped [q_h0|k_h0|v_h0|z_h0|q_h1|...] for in_proj_qkvz.
-fn build_qkvz_permutation(d: &GdnDims) -> Vec<i32> {
+fn build_qkvz_permutation(d: &GdnDims) -> Result<Vec<i32>, crate::error::ModelError> {
     let nk = d.num_k_heads;
     let dk = d.head_k_dim;
-    let v_per_k = d.num_v_heads / nk;
+    let v_per_k = validate_gqa_ratio(d)?;
     let dv = d.head_v_dim;
     let key_dim = nk * dk;
     let qkv_rows = key_dim * 2 + d.num_v_heads * dv; // offset for z
@@ -1969,13 +1997,13 @@ fn build_qkvz_permutation(d: &GdnDims) -> Vec<i32> {
             perm.push(qkv_rows + h * v_per_k * dv + i);
         }
     }
-    perm
+    Ok(perm)
 }
 
 /// Build row permutation for flat [b_all|a_all] → per-head-grouped [b_h0|a_h0|b_h1|a_h1|...].
-fn build_ba_permutation(d: &GdnDims) -> Vec<i32> {
+fn build_ba_permutation(d: &GdnDims) -> Result<Vec<i32>, crate::error::ModelError> {
     let nk = d.num_k_heads;
-    let v_per_k = d.num_v_heads / nk;
+    let v_per_k = validate_gqa_ratio(d)?;
     let nv = d.num_v_heads;
 
     let mut perm = Vec::new();
@@ -1989,14 +2017,16 @@ fn build_ba_permutation(d: &GdnDims) -> Vec<i32> {
             perm.push(nv + h * v_per_k + i);
         }
     }
-    perm
+    Ok(perm)
 }
 
 /// Concatenate two arrays along dim 0 and permute rows.
 fn concat_and_permute(a: &Array, b: &Array, perm: &[i32]) -> Result<Array, Exception> {
     let cat = ops::concatenate_axis(&[a, b], 0)?;
-    let perm_arr = Array::from_slice(perm, &[i32::try_from(perm.len())
-        .map_err(|_| Exception::custom("perm len overflow"))?]);
+    let perm_arr = Array::from_slice(
+        perm,
+        &[i32::try_from(perm.len()).map_err(|_| Exception::custom("perm len overflow"))?],
+    );
     cat.take_axis(&perm_arr, 0)
 }
 
@@ -2032,7 +2062,11 @@ fn load_qwen3_5_moe_weights_direct<M: mlx_rs::module::ModuleParametersExt>(
         }
     }
 
-    tracing::info!(matched, unmatched_count = unmatched.len(), "Direct weight loading stats");
+    tracing::info!(
+        matched,
+        unmatched_count = unmatched.len(),
+        "Direct weight loading stats"
+    );
     if !unmatched.is_empty() {
         for k in unmatched.iter().take(10) {
             tracing::warn!(key = %k, "Unmatched weight key");
@@ -2055,13 +2089,14 @@ fn load_qwen3_5_moe_weights_fused<M: mlx_rs::module::ModuleParametersExt>(
     model_path: &Path,
     gdn_dims: &GdnDims,
 ) -> Result<(), crate::error::ModelError> {
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
 
     let safetensors_files = crate::collect_safetensors_files(model_path)?;
     let mut params = model.parameters_mut().flatten();
 
-    let qkvz_perm = build_qkvz_permutation(gdn_dims);
-    let ba_perm = build_ba_permutation(gdn_dims);
+    let qkvz_perm = build_qkvz_permutation(gdn_dims)?;
+    let ba_perm = build_ba_permutation(gdn_dims)?;
+    let mut assigned_keys = HashSet::new();
 
     // GDN split keys: collect (part_a, part_b) for each combined target
     // Key format: "model.layers.N.linear_attn.in_proj_qkvz.{weight|scales|biases}"
@@ -2108,6 +2143,7 @@ fn load_qwen3_5_moe_weights_fused<M: mlx_rs::module::ModuleParametersExt>(
             if !handled {
                 if let Some(param) = params.get_mut(stripped) {
                     **param = value;
+                    assigned_keys.insert(stripped.to_owned());
                 }
             }
         }
@@ -2137,7 +2173,24 @@ fn load_qwen3_5_moe_weights_fused<M: mlx_rs::module::ModuleParametersExt>(
             ))
         })?;
         **param = fused;
+        assigned_keys.insert(combined_key.clone());
         fused_count += 1;
+    }
+
+    let missing_gdn_targets: Vec<String> = params
+        .keys()
+        .filter(|k| {
+            let kr = k.as_ref();
+            (kr.contains(".linear_attn.in_proj_qkvz.") || kr.contains(".linear_attn.in_proj_ba."))
+                && !assigned_keys.contains(kr)
+        })
+        .map(|key| key.as_ref().to_owned())
+        .collect();
+    if !missing_gdn_targets.is_empty() {
+        return Err(crate::error::ModelError::MissingWeight(format!(
+            "Missing fused GDN target weights: {}",
+            missing_gdn_targets.join(", ")
+        )));
     }
 
     tracing::info!(
@@ -2625,6 +2678,39 @@ mod tests {
     }
 
     #[test]
+    fn test_load_qwen3_5_moe_text_config_respects_projection_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = r#"{
+            "text_config": {
+                "model_type": "qwen3_next",
+                "hidden_size": 256,
+                "num_hidden_layers": 4,
+                "num_attention_heads": 4,
+                "num_key_value_heads": 2,
+                "head_dim": 64,
+                "rms_norm_eps": 1e-06,
+                "vocab_size": 1024,
+                "max_position_embeddings": 512,
+                "linear_num_key_heads": 2,
+                "linear_num_value_heads": 4,
+                "linear_key_head_dim": 32,
+                "linear_value_head_dim": 16,
+                "linear_conv_kernel_dim": 4,
+                "num_experts": 4,
+                "num_experts_per_tok": 2,
+                "shared_expert_intermediate_size": 256,
+                "moe_intermediate_size": 128,
+                "use_separate_gdn_projections": true
+            }
+        }"#;
+        std::fs::write(dir.path().join("config.json"), config).unwrap();
+
+        let args = load_qwen3_5_moe_text_config_args(dir.path()).unwrap();
+
+        assert!(args.use_separate_gdn_projections);
+    }
+
+    #[test]
     fn test_arrays_cache_default() {
         let cache = ArraysCache::default();
         assert!(cache.conv_state.is_none());
@@ -2663,6 +2749,69 @@ mod tests {
     fn quantize_weights(w: &Array, group_size: i32, bits: i32) -> (Array, Array, Array) {
         let (qw, scales, biases) = ops::quantize(w, group_size, bits).unwrap();
         (qw, scales, biases)
+    }
+
+    #[test]
+    fn test_qembedding_forward_matches_dequantize_then_gather() {
+        let mut embedding = QEmbedding::new(64, 4).unwrap();
+        let weight_f = mlx_rs::random::uniform::<f32, f32>(-1.0, 1.0, &[4, 64], None).unwrap();
+        let (weight, scales, biases) = quantize_weights(&weight_f, 64, 4);
+        *embedding.weight = weight;
+        *embedding.scales = scales;
+        *embedding.biases = biases;
+
+        let indices = Array::from_slice(&[2_u32, 1, 2, 3], &[2, 2]);
+        let new_result = embedding.forward(&indices).unwrap();
+
+        let full = ops::dequantize(
+            &embedding.weight,
+            &embedding.scales,
+            &*embedding.biases,
+            embedding.group_size,
+            embedding.bits,
+        )
+        .unwrap();
+        let flat = indices.flatten(None, None).unwrap();
+        let old_result = full
+            .take_axis(&flat, 0)
+            .unwrap()
+            .reshape(&[2, 2, 64])
+            .unwrap();
+
+        let diff = new_result.subtract(&old_result).unwrap().abs().unwrap();
+        let max_diff: f32 = diff.max(None).unwrap().item();
+        assert!(
+            max_diff < 1e-5,
+            "QEmbedding forward deviates from dequantize-then-gather by {max_diff}"
+        );
+    }
+
+    #[test]
+    fn test_build_qkvz_permutation_rejects_invalid_gqa_ratio() {
+        let dims = GdnDims {
+            num_k_heads: 2,
+            num_v_heads: 3,
+            head_k_dim: 32,
+            head_v_dim: 16,
+        };
+
+        let err = build_qkvz_permutation(&dims).unwrap_err();
+
+        assert!(err.to_string().contains("Invalid GQA ratio"));
+    }
+
+    #[test]
+    fn test_build_ba_permutation_rejects_invalid_gqa_ratio() {
+        let dims = GdnDims {
+            num_k_heads: 2,
+            num_v_heads: 3,
+            head_k_dim: 32,
+            head_v_dim: 16,
+        };
+
+        let err = build_ba_permutation(&dims).unwrap_err();
+
+        assert!(err.to_string().contains("Invalid GQA ratio"));
     }
 
     #[test]
@@ -2798,6 +2947,11 @@ mod tests {
         args.moe_intermediate_size = 64;
         args.shared_expert_intermediate_size = 64;
         args.hidden_size = 64;
+        // Use same quantization for gates as the test sets below
+        args.gate_quantization = Some(QuantizationConfig {
+            group_size: 64,
+            bits: 8,
+        });
 
         let mut block = SparseMoeBlock::new(&args, 64, 4).unwrap();
 

--- a/crates/higgs-models/src/qwen3_next.rs
+++ b/crates/higgs-models/src/qwen3_next.rs
@@ -93,6 +93,13 @@ const fn default_partial_rotary_factor() -> f32 {
     1.0
 }
 
+/// Match Python mlx-lm default: `norm_topk_prob: bool = True`.
+/// Without normalization, MoE expert scores sum to ~0.39 instead of 1.0,
+/// producing 0.39x output magnitude and degenerate generation.
+const fn default_norm_topk_prob() -> bool {
+    true
+}
+
 /// Quantization parameters from config.json (top-level defaults).
 #[derive(Debug, Clone, Deserialize)]
 pub struct QuantizationConfig {
@@ -146,7 +153,7 @@ pub struct Qwen3NextModelArgs {
     pub shared_expert_intermediate_size: i32,
     #[serde(default)]
     pub moe_intermediate_size: i32,
-    #[serde(default)]
+    #[serde(default = "default_norm_topk_prob")]
     pub norm_topk_prob: bool,
     #[serde(default)]
     pub mlp_only_layers: Vec<i32>,
@@ -980,8 +987,8 @@ impl SparseMoeBlock {
             raw_scores
         };
 
-        // Expert computation via fused gather_qmm
-        let y = self.switch_mlp.forward_gather(x, &top_inds, false)?;
+        // Expert computation via fused gather_qmm (indices are pre-sorted)
+        let y = self.switch_mlp.forward_gather(x, &top_inds, true)?;
 
         // Weighted sum over experts: [B, L, top_k, D] * [B, L, top_k, 1] -> sum -> [B, L, D]
         let expert_sum = y
@@ -992,6 +999,23 @@ impl SparseMoeBlock {
         let shared_y = self.shared_expert.forward(x)?;
         let shared_gate_val = nn::sigmoid(&self.shared_expert_gate.forward(x)?)?;
         let shared_out = shared_y.multiply(&shared_gate_val)?;
+
+        // DEBUG MoE decomposition
+        {
+            expert_sum.eval()?;
+            shared_out.eval()?;
+            let es_f32 = expert_sum.as_dtype(mlx_rs::Dtype::Float32)?;
+            let so_f32 = shared_out.as_dtype(mlx_rs::Dtype::Float32)?;
+            es_f32.eval()?;
+            so_f32.eval()?;
+            let es_sq = es_f32.multiply(&es_f32)?.sum(None)?;
+            let so_sq = so_f32.multiply(&so_f32)?.sum(None)?;
+            es_sq.eval()?;
+            so_sq.eval()?;
+            let es_l2: f32 = es_sq.item();
+            let so_l2: f32 = so_sq.item();
+            eprintln!("DEBUG_MOE expert_sum_L2={:.4} shared_out_L2={:.4}", es_l2.sqrt(), so_l2.sqrt());
+        }
 
         expert_sum.add(shared_out)
     }
@@ -1408,23 +1432,48 @@ impl FfnBlock {
                 .ok_or_else(|| Exception::custom("MoE shared_expert_gate missing"))?;
 
             let gates = ops::softmax_axis(&gate_ref.forward(x)?, -1, true)?;
+
             let neg_k = -self.top_k;
             let all_inds = ops::argpartition_axis(&gates, neg_k, -1)?;
             let num_experts = *gates.shape().last()
                 .ok_or_else(|| Exception::custom("gates must have last dim"))?;
             let top_k_start = num_experts - self.top_k;
-            let top_inds = all_inds.index((.., .., top_k_start..));
-            let top_scores = gates.take_along_axis(&top_inds, -1)?;
-            let top_scores = if self.norm_topk_prob {
-                let sum = top_scores.sum_axes(&[-1], true)?;
-                top_scores.divide(&sum)?
+            let inds = all_inds.index((.., .., top_k_start..));
+            let scores = gates.take_along_axis(&inds, -1)?;
+            let scores = if self.norm_topk_prob {
+                let sum = scores.sum_axes(&[-1], true)?;
+                scores.divide(&sum)?
             } else {
-                top_scores
+                scores
             };
 
-            let y = switch_ref.forward_gather(x, &top_inds, false)?;
+            // Use Python-matching SwitchGLU: expand_dims + gather_qmm + swiglu + gather_qmm
+            let x_shape = x.shape();
+            let x_b = x_shape[0];
+            let x_l = x_shape[1];
+            let x_d = x_shape[2];
+            let x_exp = x.reshape(&[x_b, x_l, 1, 1, x_d])?;
+
+            let gate_out = gather_qmm(
+                &x_exp, &switch_ref.gate_proj.weight, &switch_ref.gate_proj.scales,
+                &switch_ref.gate_proj.biases, &inds, true,
+                switch_ref.gate_proj.group_size, switch_ref.gate_proj.bits, false,
+            )?;
+            let up_out = gather_qmm(
+                &x_exp, &switch_ref.up_proj.weight, &switch_ref.up_proj.scales,
+                &switch_ref.up_proj.biases, &inds, true,
+                switch_ref.up_proj.group_size, switch_ref.up_proj.bits, false,
+            )?;
+            let activated = swiglu(&gate_out, &up_out)?;
+            let down_out = gather_qmm(
+                &activated, &switch_ref.down_proj.weight, &switch_ref.down_proj.scales,
+                &switch_ref.down_proj.biases, &inds, true,
+                switch_ref.down_proj.group_size, switch_ref.down_proj.bits, false,
+            )?;
+            let y = down_out.squeeze_axes(&[-2])?;
+
             let expert_sum = y
-                .multiply(&top_scores.expand_dims(-1)?)?
+                .multiply(&scores.expand_dims(-1)?)?
                 .sum_axes(&[-2], false)?;
 
             let shared_y = se_ref.forward(x)?;
@@ -1642,6 +1691,7 @@ impl Qwen3NextCausalLM {
     ) -> Result<Array, Exception> {
         let mut h = self.model.embed_tokens.forward(inputs)?;
 
+
         if kv_cache.is_empty() {
             *kv_cache = self.make_cache();
         }
@@ -1711,9 +1761,7 @@ impl Qwen3NextCausalLM {
 
             let h2 = h.add(r)?;
             let normed_post = layer.post_attention_layernorm.forward(&h2)?;
-
             let mlp_out = layer.mlp.forward(&normed_post)?;
-
             h = h2.add(mlp_out)?;
         }
 
@@ -1961,6 +2009,53 @@ fn concat_and_permute(a: &Array, b: &Array, perm: &[i32]) -> Result<Array, Excep
 
 /// Load Qwen3.5-MoE weights with GDN projection fusion.
 ///
+/// Direct weight loader: strip `language_model.` prefix, no rearrangement.
+/// Used when `use_separate_gdn_projections = true`.
+fn load_qwen3_5_moe_weights_direct<M: mlx_rs::module::ModuleParametersExt>(
+    model: &mut M,
+    model_path: &Path,
+) -> Result<(), crate::error::ModelError> {
+    let safetensors_files = crate::collect_safetensors_files(model_path)?;
+    let mut params = model.parameters_mut().flatten();
+    let prefix = "language_model.";
+    let mut matched = 0usize;
+    let mut unmatched = Vec::new();
+
+    for file_path in &safetensors_files {
+        let loaded = Array::load_safetensors(file_path)
+            .map_err(|e| crate::error::ModelError::Io(std::io::Error::other(e.to_string())))?;
+
+        for (key, value) in loaded {
+            let Some(stripped) = key.strip_prefix(prefix) else {
+                unmatched.push(key);
+                continue;
+            };
+            if let Some(param) = params.get_mut(stripped) {
+                **param = value;
+                matched += 1;
+            } else {
+                unmatched.push(key);
+            }
+        }
+    }
+
+    tracing::info!(matched, unmatched_count = unmatched.len(), "Direct weight loading stats");
+    if !unmatched.is_empty() {
+        for k in unmatched.iter().take(10) {
+            tracing::warn!(key = %k, "Unmatched weight key");
+        }
+    }
+    // Also log unset params (model params that weren't loaded)
+    let still_zero: Vec<_> = params.keys().take(5).collect();
+    tracing::info!(?still_zero, "First 5 param keys in model");
+
+    model
+        .eval()
+        .map_err(|e| crate::error::ModelError::Io(std::io::Error::other(e.to_string())))?;
+
+    Ok(())
+}
+
 /// Rearranges flat (qkv,z,b,a) projections to per-head-grouped (qkvz,ba)
 /// so the model uses the fused 2-dispatch forward path instead of 4 separate.
 fn load_qwen3_5_moe_weights_fused<M: mlx_rs::module::ModuleParametersExt>(

--- a/crates/higgs-models/src/qwen3_next.rs
+++ b/crates/higgs-models/src/qwen3_next.rs
@@ -155,6 +155,10 @@ pub struct Qwen3NextModelArgs {
 
     #[serde(default)]
     pub quantization: Option<QuantizationConfig>,
+
+    /// Use separate GDN projections (qwen3.5-style) instead of combined (qwen3_next-style).
+    #[serde(default)]
+    pub use_separate_gdn_projections: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -1019,6 +1023,15 @@ struct GatedDeltaNet {
     in_proj_qkvz: QLinear,
     #[param]
     in_proj_ba: QLinear,
+    // Separate projections for qwen3_5-style models (flat split, not per-head)
+    #[param]
+    in_proj_qkv: Option<QLinear>,
+    #[param]
+    in_proj_z: Option<QLinear>,
+    #[param]
+    in_proj_a: Option<QLinear>,
+    #[param]
+    in_proj_b: Option<QLinear>,
     #[param]
     conv1d: nn::Conv1d,
     #[param]
@@ -1036,6 +1049,7 @@ struct GatedDeltaNet {
     key_dim: i32,
     conv_dim: i32,
     conv_kernel_size: i32,
+    use_separate_projections: bool,
     qk_norm_weight_q: Array,
     qk_norm_weight_k: Array,
 }
@@ -1051,9 +1065,14 @@ impl GatedDeltaNet {
         let conv_dim = key_dim * 2 + value_dim;
         let conv_kernel_size = args.linear_conv_kernel_dim;
 
+        let use_sep = args.use_separate_gdn_projections;
         Ok(Self {
             in_proj_qkvz: QLinear::new(ql, qb)?,
             in_proj_ba: QLinear::new(ql, qb)?,
+            in_proj_qkv: if use_sep { Some(QLinear::new(ql, qb)?) } else { None },
+            in_proj_z: if use_sep { Some(QLinear::new(ql, qb)?) } else { None },
+            in_proj_a: if use_sep { Some(QLinear::new(ql, qb)?) } else { None },
+            in_proj_b: if use_sep { Some(QLinear::new(ql, qb)?) } else { None },
             conv1d: nn::Conv1dBuilder::new(conv_dim, conv_dim, conv_kernel_size)
                 .bias(false)
                 .groups(conv_dim)
@@ -1072,6 +1091,7 @@ impl GatedDeltaNet {
             key_dim,
             conv_dim,
             conv_kernel_size,
+            use_separate_projections: use_sep,
             qk_norm_weight_q: {
                 let dim_f32 = f32::from(
                     i16::try_from(head_k_dim)
@@ -1110,12 +1130,43 @@ impl GatedDeltaNet {
             .get(1)
             .ok_or_else(|| Exception::custom("Input must have >= 2 dims"))?;
 
-        // Project inputs
-        let mixed_qkvz = self.in_proj_qkvz.forward(inputs)?;
-        let mixed_ba = self.in_proj_ba.forward(inputs)?;
+        // Project inputs and split into q, k, v, z, b, a
+        let (q, k, v, z, b, a) = if self.use_separate_projections {
+            // qwen3.5-style: 4 separate projections, flat split
+            let qkv_proj = self.in_proj_qkv.as_ref()
+                .ok_or_else(|| Exception::custom("in_proj_qkv missing"))?;
+            let z_proj = self.in_proj_z.as_ref()
+                .ok_or_else(|| Exception::custom("in_proj_z missing"))?;
+            let b_proj = self.in_proj_b.as_ref()
+                .ok_or_else(|| Exception::custom("in_proj_b missing"))?;
+            let a_proj = self.in_proj_a.as_ref()
+                .ok_or_else(|| Exception::custom("in_proj_a missing"))?;
 
-        // Split into q, k, v, z, b, a
-        let (q, k, v, z, b, a) = self.fix_query_key_value_ordering(&mixed_qkvz, &mixed_ba, B, S)?;
+            let qkv = qkv_proj.forward(inputs)?;
+            let z = z_proj.forward(inputs)?
+                .reshape(&[B, S, self.num_v_heads, self.head_v_dim])?;
+            let b = b_proj.forward(inputs)?;
+            let a = a_proj.forward(inputs)?;
+
+            let split_indices = &[self.key_dim, self.key_dim * 2];
+            let qkv_parts = qkv.split_axis(split_indices, Some(-1))?;
+            let q = qkv_parts.first()
+                .ok_or_else(|| Exception::custom("qkv split failed"))?
+                .reshape(&[B, S, self.num_k_heads, self.head_k_dim])?;
+            let k = qkv_parts.get(1)
+                .ok_or_else(|| Exception::custom("qkv split failed"))?
+                .reshape(&[B, S, self.num_k_heads, self.head_k_dim])?;
+            let v = qkv_parts.get(2)
+                .ok_or_else(|| Exception::custom("qkv split failed"))?
+                .reshape(&[B, S, self.num_v_heads, self.head_v_dim])?;
+
+            (q, k, v, z, b, a)
+        } else {
+            // qwen3_next-style: combined projections, per-head reshape
+            let mixed_qkvz = self.in_proj_qkvz.forward(inputs)?;
+            let mixed_ba = self.in_proj_ba.forward(inputs)?;
+            self.fix_query_key_value_ordering(&mixed_qkvz, &mixed_ba, B, S)?
+        };
 
         // Conv1d with state management
         let conv_state = match cache.conv_state.take() {
@@ -1601,6 +1652,235 @@ pub fn load_qwen3_next_model<P: AsRef<Path>>(
 
     tracing::info!("Qwen3Next model loaded successfully");
     Ok(model)
+}
+
+// ---------------------------------------------------------------------------
+// Qwen3.5-MoE VLM support
+// ---------------------------------------------------------------------------
+
+/// Load model args from a Qwen3.5-MoE VLM config.json.
+///
+/// Qwen3.5-MoE uses the same architecture as `Qwen3Next` (hybrid
+/// GatedDeltaNet + full attention + sparse MoE with shared expert) but ships
+/// as a VLM with config nested under `text_config` and rope parameters nested
+/// under `rope_parameters`.
+fn load_qwen3_5_moe_text_config_args<P: AsRef<Path>>(
+    model_dir: P,
+) -> Result<Qwen3NextModelArgs, ModelError> {
+    let config_path = model_dir.as_ref().join("config.json");
+    let file = std::fs::File::open(config_path)?;
+    let config: serde_json::Value = serde_json::from_reader(file)?;
+
+    let text_config = config
+        .get("text_config")
+        .ok_or_else(|| {
+            ModelError::UnsupportedModel("missing text_config in config.json".into())
+        })?;
+
+    let mut obj = text_config.clone();
+    let map = obj
+        .as_object_mut()
+        .ok_or_else(|| ModelError::UnsupportedModel("text_config is not an object".into()))?;
+
+    // Flatten rope_parameters into top-level fields
+    if let Some(rope_params) = text_config.get("rope_parameters") {
+        if let Some(theta) = rope_params.get("rope_theta") {
+            map.entry("rope_theta").or_insert_with(|| theta.clone());
+        }
+        if let Some(prf) = rope_params.get("partial_rotary_factor") {
+            map.entry("partial_rotary_factor")
+                .or_insert_with(|| prf.clone());
+        }
+    }
+
+    // Merge top-level quantization config
+    if let Some(quant) = config.get("quantization") {
+        map.entry("quantization")
+            .or_insert_with(|| quant.clone());
+    }
+
+    // Merge top-level tie_word_embeddings
+    if let Some(tie) = config.get("tie_word_embeddings") {
+        map.entry("tie_word_embeddings")
+            .or_insert_with(|| tie.clone());
+    }
+
+    // All layers use MoE in qwen3.5-moe (no dense FFN)
+    map.entry("decoder_sparse_step")
+        .or_insert(serde_json::Value::from(1));
+
+    // intermediate_size is unused when all layers are MoE
+    map.entry("intermediate_size")
+        .or_insert(serde_json::Value::from(0));
+
+    // Use separate GDN projections (qwen3.5-style flat split)
+    map.insert(
+        "use_separate_gdn_projections".to_owned(),
+        serde_json::Value::from(true),
+    );
+
+    Ok(serde_json::from_value(obj)?)
+}
+
+/// Load a Qwen3.5-MoE model (VLM wrapper around Qwen3Next architecture).
+///
+/// Reads `text_config` for model args, strips `language_model.` prefix from
+/// safetensors weight keys.
+pub fn load_qwen3_5_moe_model<P: AsRef<Path>>(
+    model_dir: P,
+) -> Result<Qwen3NextCausalLM, ModelError> {
+    let model_path = model_dir.as_ref();
+    let args = load_qwen3_5_moe_text_config_args(model_path)?;
+
+    tracing::info!(
+        hidden_size = args.hidden_size,
+        num_layers = args.num_hidden_layers,
+        num_heads = args.num_attention_heads,
+        num_kv_heads = args.num_key_value_heads,
+        num_experts = args.num_experts,
+        vocab_size = args.vocab_size,
+        full_attention_interval = args.full_attention_interval,
+        "Loading qwen3_5_moe model (VLM text backbone via qwen3_next)"
+    );
+
+    let mut model = Qwen3NextCausalLM::new(args)?;
+
+    // Separate GDN projections (in_proj_qkv, in_proj_z, in_proj_a, in_proj_b)
+    // load directly — no concat needed since forward branches on use_separate_projections.
+    // VLM weights have `language_model.` prefix.
+    crate::load_quantized_safetensors_weights_with_prefix(
+        &mut model,
+        model_path,
+        false,
+        "language_model.",
+    )?;
+
+    tracing::info!("Qwen3.5-MoE model loaded successfully");
+    Ok(model)
+}
+
+/// GDN projection remapping pairs: (separate_a, separate_b) → combined target.
+const GDN_REMAP: &[(&str, &str, &str)] = &[
+    ("in_proj_qkv", "in_proj_z", "in_proj_qkvz"),
+    ("in_proj_b", "in_proj_a", "in_proj_ba"),
+];
+
+/// Load weights for Qwen3.5-MoE, remapping separate GDN projections to combined.
+///
+/// Qwen3.5-MoE stores GDN projections as 4 separate matrices (in_proj_qkv,
+/// in_proj_z, in_proj_a, in_proj_b). Qwen3Next expects 2 combined matrices
+/// (in_proj_qkvz, in_proj_ba). This loader concatenates along dim 0 at load
+/// time so the forward pass works unchanged.
+fn load_qwen3_5_moe_weights<M: mlx_rs::module::ModuleParametersExt>(
+    model: &mut M,
+    model_path: &Path,
+) -> Result<(), crate::error::ModelError> {
+    use std::collections::HashMap;
+
+    let safetensors_files = crate::collect_safetensors_files(model_path)?;
+    let mut params = model.parameters_mut().flatten();
+
+    // Collect GDN split tensors keyed by (layer, combined_name, suffix)
+    // e.g. ("model.layers.0.linear_attn", "in_proj_qkvz", "weight") → (part_a, part_b)
+    let mut gdn_parts: HashMap<String, (Option<Array>, Option<Array>)> = HashMap::new();
+
+    let prefix = "language_model.";
+
+    for file_path in &safetensors_files {
+        let loaded = Array::load_safetensors(file_path)
+            .map_err(|e| crate::error::ModelError::Io(std::io::Error::other(e.to_string())))?;
+
+        for (key, value) in loaded {
+            let Some(stripped) = key.strip_prefix(prefix) else {
+                continue;
+            };
+
+            // Check if this is a GDN split projection
+            let mut handled = false;
+            for &(part_a_name, part_b_name, combined_name) in GDN_REMAP {
+                for (is_b, split_name) in [(false, part_a_name), (true, part_b_name)] {
+                    let needle = format!(".{split_name}.");
+                    if let Some(pos) = stripped.find(&needle) {
+                        let prefix_part = &stripped[..pos];
+                        let suffix = &stripped[pos + needle.len()..];
+                        let map_key =
+                            format!("{prefix_part}.{combined_name}.{suffix}");
+                        let entry = gdn_parts.entry(map_key).or_insert((None, None));
+                        if is_b {
+                            entry.1 = Some(value.clone());
+                        } else {
+                            entry.0 = Some(value.clone());
+                        }
+                        handled = true;
+                        break;
+                    }
+                }
+                if handled {
+                    break;
+                }
+            }
+
+            if !handled {
+                // Direct match for non-GDN weights
+                if let Some(param) = params.get_mut(stripped) {
+                    **param = value;
+                }
+            }
+        }
+    }
+
+    // Concatenate GDN split pairs and assign to combined params
+    let mut concat_count = 0usize;
+    for (combined_key, (part_a, part_b)) in &gdn_parts {
+        match (part_a, part_b) {
+            (Some(a), Some(b)) => {
+                if let Some(param) = params.get_mut(combined_key.as_str()) {
+                    if concat_count < 3 {
+                        tracing::info!(
+                            key = combined_key,
+                            a_shape = ?a.shape(),
+                            a_dtype = ?a.dtype(),
+                            b_shape = ?b.shape(),
+                            b_dtype = ?b.dtype(),
+                            "Concatenating GDN projections"
+                        );
+                    }
+                    match ops::concatenate_axis(&[a, b], 0) {
+                        Ok(combined) => {
+                            **param = combined;
+                            concat_count += 1;
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                key = combined_key,
+                                "Failed to concatenate GDN projections: {e}"
+                            );
+                        }
+                    }
+                }
+            }
+            _ => {
+                tracing::warn!(
+                    key = combined_key,
+                    has_a = part_a.is_some(),
+                    has_b = part_b.is_some(),
+                    "Incomplete GDN projection pair"
+                );
+            }
+        }
+    }
+
+    tracing::info!(
+        concat_count,
+        total_gdn_pairs = gdn_parts.len(),
+        "Remapped GDN split projections to combined"
+    );
+
+    model
+        .eval()
+        .map_err(|e| crate::error::ModelError::Io(std::io::Error::other(e.to_string())))?;
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/higgs-models/src/qwen3_next.rs
+++ b/crates/higgs-models/src/qwen3_next.rs
@@ -2069,7 +2069,7 @@ fn load_qwen3_5_moe_weights_direct<M: mlx_rs::module::ModuleParametersExt>(
     );
     if !unmatched.is_empty() {
         for k in unmatched.iter().take(10) {
-            tracing::warn!(key = %k, "Unmatched weight key");
+            tracing::debug!(key = %k, "Unmatched weight key (expected for VLM vision weights)");
         }
     }
     let param_count = params.keys().count();

--- a/crates/higgs-models/src/qwen3_next.rs
+++ b/crates/higgs-models/src/qwen3_next.rs
@@ -153,6 +153,9 @@ pub struct Qwen3NextModelArgs {
     pub shared_expert_intermediate_size: i32,
     #[serde(default)]
     pub moe_intermediate_size: i32,
+    /// Normalize top-k expert scores to sum to 1.0 before weighting outputs.
+    /// Defaults to `true` to match Python mlx-lm. Setting to `false` scales
+    /// MoE output by the raw softmax scores (~0.39x), causing degenerate output.
     #[serde(default = "default_norm_topk_prob")]
     pub norm_topk_prob: bool,
     #[serde(default)]
@@ -999,23 +1002,6 @@ impl SparseMoeBlock {
         let shared_y = self.shared_expert.forward(x)?;
         let shared_gate_val = nn::sigmoid(&self.shared_expert_gate.forward(x)?)?;
         let shared_out = shared_y.multiply(&shared_gate_val)?;
-
-        // DEBUG MoE decomposition
-        {
-            expert_sum.eval()?;
-            shared_out.eval()?;
-            let es_f32 = expert_sum.as_dtype(mlx_rs::Dtype::Float32)?;
-            let so_f32 = shared_out.as_dtype(mlx_rs::Dtype::Float32)?;
-            es_f32.eval()?;
-            so_f32.eval()?;
-            let es_sq = es_f32.multiply(&es_f32)?.sum(None)?;
-            let so_sq = so_f32.multiply(&so_f32)?.sum(None)?;
-            es_sq.eval()?;
-            so_sq.eval()?;
-            let es_l2: f32 = es_sq.item();
-            let so_l2: f32 = so_sq.item();
-            eprintln!("DEBUG_MOE expert_sum_L2={:.4} shared_out_L2={:.4}", es_l2.sqrt(), so_l2.sqrt());
-        }
 
         expert_sum.add(shared_out)
     }
@@ -2045,9 +2031,8 @@ fn load_qwen3_5_moe_weights_direct<M: mlx_rs::module::ModuleParametersExt>(
             tracing::warn!(key = %k, "Unmatched weight key");
         }
     }
-    // Also log unset params (model params that weren't loaded)
-    let still_zero: Vec<_> = params.keys().take(5).collect();
-    tracing::info!(?still_zero, "First 5 param keys in model");
+    let param_count = params.keys().count();
+    tracing::info!(param_count, "Total model parameters loaded");
 
     model
         .eval()
@@ -2129,6 +2114,7 @@ fn load_qwen3_5_moe_weights_fused<M: mlx_rs::module::ModuleParametersExt>(
             continue;
         };
         let Some(param) = params.get_mut(combined_key.as_str()) else {
+            tracing::warn!(key = %combined_key, "Fused target key not found in model params, skipping");
             continue;
         };
         let perm = if combined_key.contains("in_proj_qkvz") {

--- a/crates/higgs-models/src/qwen3_next.rs
+++ b/crates/higgs-models/src/qwen3_next.rs
@@ -1722,10 +1722,11 @@ fn load_qwen3_5_moe_text_config_args<P: AsRef<Path>>(
     map.entry("intermediate_size")
         .or_insert(serde_json::Value::from(0));
 
-    // Use separate GDN projections (qwen3.5-style flat split)
+    // Weights are rearranged from flat (qkv,z,b,a) to per-head-grouped
+    // (qkvz,ba) at load time, so we use the combined forward path.
     map.insert(
         "use_separate_gdn_projections".to_owned(),
-        serde_json::Value::from(true),
+        serde_json::Value::from(false),
     );
 
     // Detect per-layer gate quantization override from top-level quantization config
@@ -1760,48 +1761,117 @@ pub fn load_qwen3_5_moe_model<P: AsRef<Path>>(
         "Loading qwen3_5_moe model (VLM text backbone via qwen3_next)"
     );
 
+    // Save GDN dimensions before args is moved
+    let gdn_dims = GdnDims {
+        num_k_heads: args.linear_num_key_heads,
+        num_v_heads: args.linear_num_value_heads,
+        head_k_dim: args.linear_key_head_dim,
+        head_v_dim: args.linear_value_head_dim,
+    };
     let mut model = Qwen3NextCausalLM::new(args)?;
 
-    // Separate GDN projections (in_proj_qkv, in_proj_z, in_proj_a, in_proj_b)
-    // load directly — no concat needed since forward branches on use_separate_projections.
-    // VLM weights have `language_model.` prefix.
-    crate::load_quantized_safetensors_weights_with_prefix(
-        &mut model,
-        model_path,
-        false,
-        "language_model.",
-    )?;
+    // Load weights with GDN projection rearrangement: flat (qkv,z,b,a)
+    // → per-head-grouped (qkvz,ba) for fused 2-dispatch forward path.
+    load_qwen3_5_moe_weights_fused(&mut model, model_path, &gdn_dims)?;
 
     tracing::info!("Qwen3.5-MoE model loaded successfully");
     Ok(model)
 }
 
-/// GDN projection remapping pairs: (separate_a, separate_b) → combined target.
-const GDN_REMAP: &[(&str, &str, &str)] = &[
-    ("in_proj_qkv", "in_proj_z", "in_proj_qkvz"),
-    ("in_proj_b", "in_proj_a", "in_proj_ba"),
-];
+/// GDN dimension info extracted from model args before move.
+struct GdnDims {
+    num_k_heads: i32,
+    num_v_heads: i32,
+    head_k_dim: i32,
+    head_v_dim: i32,
+}
 
-/// Load weights for Qwen3.5-MoE, remapping separate GDN projections to combined.
+/// Build row permutation to convert flat [q_all|k_all|v_all|z_all] layout
+/// to per-head-grouped [q_h0|k_h0|v_h0|z_h0|q_h1|...] for in_proj_qkvz.
+fn build_qkvz_permutation(d: &GdnDims) -> Vec<i32> {
+    let nk = d.num_k_heads;
+    let dk = d.head_k_dim;
+    let v_per_k = d.num_v_heads / nk;
+    let dv = d.head_v_dim;
+    let key_dim = nk * dk;
+    let qkv_rows = key_dim * 2 + d.num_v_heads * dv; // offset for z
+
+    let mut perm = Vec::new();
+    for h in 0..nk {
+        // q: rows h*dk .. (h+1)*dk from qkv (offset 0)
+        for i in 0..dk {
+            perm.push(h * dk + i);
+        }
+        // k: rows key_dim + h*dk .. from qkv
+        for i in 0..dk {
+            perm.push(key_dim + h * dk + i);
+        }
+        // v: rows 2*key_dim + h*(v_per_k*dv) .. from qkv
+        for i in 0..(v_per_k * dv) {
+            perm.push(2 * key_dim + h * v_per_k * dv + i);
+        }
+        // z: rows h*(v_per_k*dv) .. from z (offset by qkv_rows)
+        for i in 0..(v_per_k * dv) {
+            perm.push(qkv_rows + h * v_per_k * dv + i);
+        }
+    }
+    perm
+}
+
+/// Build row permutation for flat [b_all|a_all] → per-head-grouped [b_h0|a_h0|b_h1|a_h1|...].
+fn build_ba_permutation(d: &GdnDims) -> Vec<i32> {
+    let nk = d.num_k_heads;
+    let v_per_k = d.num_v_heads / nk;
+    let nv = d.num_v_heads;
+
+    let mut perm = Vec::new();
+    for h in 0..nk {
+        // b: rows h*v_per_k .. (h+1)*v_per_k from b
+        for i in 0..v_per_k {
+            perm.push(h * v_per_k + i);
+        }
+        // a: rows h*v_per_k .. (h+1)*v_per_k from a (offset by nv)
+        for i in 0..v_per_k {
+            perm.push(nv + h * v_per_k + i);
+        }
+    }
+    perm
+}
+
+/// Concatenate two arrays along dim 0 and permute rows.
+fn concat_and_permute(a: &Array, b: &Array, perm: &[i32]) -> Result<Array, Exception> {
+    let cat = ops::concatenate_axis(&[a, b], 0)?;
+    let perm_arr = Array::from_slice(perm, &[i32::try_from(perm.len())
+        .map_err(|_| Exception::custom("perm len overflow"))?]);
+    cat.take_axis(&perm_arr, 0)
+}
+
+/// Load Qwen3.5-MoE weights with GDN projection fusion.
 ///
-/// Qwen3.5-MoE stores GDN projections as 4 separate matrices (in_proj_qkv,
-/// in_proj_z, in_proj_a, in_proj_b). Qwen3Next expects 2 combined matrices
-/// (in_proj_qkvz, in_proj_ba). This loader concatenates along dim 0 at load
-/// time so the forward pass works unchanged.
-fn load_qwen3_5_moe_weights<M: mlx_rs::module::ModuleParametersExt>(
+/// Rearranges flat (qkv,z,b,a) projections to per-head-grouped (qkvz,ba)
+/// so the model uses the fused 2-dispatch forward path instead of 4 separate.
+fn load_qwen3_5_moe_weights_fused<M: mlx_rs::module::ModuleParametersExt>(
     model: &mut M,
     model_path: &Path,
+    gdn_dims: &GdnDims,
 ) -> Result<(), crate::error::ModelError> {
     use std::collections::HashMap;
 
     let safetensors_files = crate::collect_safetensors_files(model_path)?;
     let mut params = model.parameters_mut().flatten();
 
-    // Collect GDN split tensors keyed by (layer, combined_name, suffix)
-    // e.g. ("model.layers.0.linear_attn", "in_proj_qkvz", "weight") → (part_a, part_b)
+    let qkvz_perm = build_qkvz_permutation(gdn_dims);
+    let ba_perm = build_ba_permutation(gdn_dims);
+
+    // GDN split keys: collect (part_a, part_b) for each combined target
+    // Key format: "model.layers.N.linear_attn.in_proj_qkvz.{weight|scales|biases}"
     let mut gdn_parts: HashMap<String, (Option<Array>, Option<Array>)> = HashMap::new();
 
     let prefix = "language_model.";
+    let gdn_remap: &[(&str, &str, &str)] = &[
+        ("in_proj_qkv", "in_proj_z", "in_proj_qkvz"),
+        ("in_proj_b", "in_proj_a", "in_proj_ba"),
+    ];
 
     for file_path in &safetensors_files {
         let loaded = Array::load_safetensors(file_path)
@@ -1812,16 +1882,14 @@ fn load_qwen3_5_moe_weights<M: mlx_rs::module::ModuleParametersExt>(
                 continue;
             };
 
-            // Check if this is a GDN split projection
             let mut handled = false;
-            for &(part_a_name, part_b_name, combined_name) in GDN_REMAP {
+            for &(part_a_name, part_b_name, combined_name) in gdn_remap {
                 for (is_b, split_name) in [(false, part_a_name), (true, part_b_name)] {
                     let needle = format!(".{split_name}.");
                     if let Some(pos) = stripped.find(&needle) {
-                        let prefix_part = &stripped[..pos];
-                        let suffix = &stripped[pos + needle.len()..];
-                        let map_key =
-                            format!("{prefix_part}.{combined_name}.{suffix}");
+                        let pfx = &stripped[..pos];
+                        let sfx = &stripped[pos + needle.len()..];
+                        let map_key = format!("{pfx}.{combined_name}.{sfx}");
                         let entry = gdn_parts.entry(map_key).or_insert((None, None));
                         if is_b {
                             entry.1 = Some(value.clone());
@@ -1838,7 +1906,6 @@ fn load_qwen3_5_moe_weights<M: mlx_rs::module::ModuleParametersExt>(
             }
 
             if !handled {
-                // Direct match for non-GDN weights
                 if let Some(param) = params.get_mut(stripped) {
                     **param = value;
                 }
@@ -1846,51 +1913,36 @@ fn load_qwen3_5_moe_weights<M: mlx_rs::module::ModuleParametersExt>(
         }
     }
 
-    // Concatenate GDN split pairs and assign to combined params
-    let mut concat_count = 0usize;
+    // Fuse GDN pairs: concat + row permutation
+    let mut fused_count = 0usize;
     for (combined_key, (part_a, part_b)) in &gdn_parts {
-        match (part_a, part_b) {
-            (Some(a), Some(b)) => {
-                if let Some(param) = params.get_mut(combined_key.as_str()) {
-                    if concat_count < 3 {
-                        tracing::info!(
-                            key = combined_key,
-                            a_shape = ?a.shape(),
-                            a_dtype = ?a.dtype(),
-                            b_shape = ?b.shape(),
-                            b_dtype = ?b.dtype(),
-                            "Concatenating GDN projections"
-                        );
-                    }
-                    match ops::concatenate_axis(&[a, b], 0) {
-                        Ok(combined) => {
-                            **param = combined;
-                            concat_count += 1;
-                        }
-                        Err(e) => {
-                            tracing::warn!(
-                                key = combined_key,
-                                "Failed to concatenate GDN projections: {e}"
-                            );
-                        }
-                    }
-                }
+        let (Some(a), Some(b)) = (part_a, part_b) else {
+            tracing::warn!(key = combined_key, "Incomplete GDN projection pair");
+            continue;
+        };
+        let Some(param) = params.get_mut(combined_key.as_str()) else {
+            continue;
+        };
+        let perm = if combined_key.contains("in_proj_qkvz") {
+            &qkvz_perm
+        } else {
+            &ba_perm
+        };
+        match concat_and_permute(a, b, perm) {
+            Ok(fused) => {
+                **param = fused;
+                fused_count += 1;
             }
-            _ => {
-                tracing::warn!(
-                    key = combined_key,
-                    has_a = part_a.is_some(),
-                    has_b = part_b.is_some(),
-                    "Incomplete GDN projection pair"
-                );
+            Err(e) => {
+                tracing::warn!(key = combined_key, "GDN fusion failed: {e}");
             }
         }
     }
 
     tracing::info!(
-        concat_count,
-        total_gdn_pairs = gdn_parts.len(),
-        "Remapped GDN split projections to combined"
+        fused_count,
+        total_pairs = gdn_parts.len(),
+        "Fused GDN projections (4→2 dispatches per layer)"
     );
 
     model

--- a/crates/higgs-models/src/qwen3_next.rs
+++ b/crates/higgs-models/src/qwen3_next.rs
@@ -265,14 +265,21 @@ impl QEmbedding {
     }
 
     pub(crate) fn forward(&self, indices: &Array) -> Result<Array, Exception> {
-        let full = ops::dequantize(
-            &*self.weight,
-            &*self.scales,
-            &*self.biases,
+        let shape = indices.shape().to_vec();
+        let flat = indices.flatten(None, None)?;
+        let weight = self.weight.index(&flat);
+        let scales = self.scales.index(&flat);
+        let biases = self.biases.index(&flat);
+        let out = ops::dequantize(
+            &weight,
+            &scales,
+            &biases,
             self.group_size,
             self.bits,
         )?;
-        full.take_axis(indices, 0)
+        let mut out_shape = shape;
+        out_shape.push(-1);
+        out.reshape(&out_shape)
     }
 
     pub(crate) fn as_linear(&self, x: &Array) -> Result<Array, Exception> {

--- a/crates/higgs-models/src/qwen3_next.rs
+++ b/crates/higgs-models/src/qwen3_next.rs
@@ -156,6 +156,11 @@ pub struct Qwen3NextModelArgs {
     #[serde(default)]
     pub quantization: Option<QuantizationConfig>,
 
+    /// Per-layer quantization override for router gate / shared_expert_gate.
+    /// When absent, uses the global quantization config.
+    #[serde(default)]
+    pub gate_quantization: Option<QuantizationConfig>,
+
     /// Use separate GDN projections (qwen3.5-style) instead of combined (qwen3_next-style).
     #[serde(default)]
     pub use_separate_gdn_projections: bool,
@@ -939,12 +944,16 @@ impl SparseMoeBlock {
                 "num_experts_per_tok must be <= num_experts",
             ));
         }
-        // Router gate and shared_expert_gate use 8-bit quantization
+        // Gate quantization: use per-layer override if present, else global
+        let (gate_ql, gate_qb) = args
+            .gate_quantization
+            .as_ref()
+            .map_or((ql, qb), |gq| (gq.group_size, gq.bits));
         Ok(Self {
-            gate: QLinear::new(64, 8)?,
+            gate: QLinear::new(gate_ql, gate_qb)?,
             switch_mlp: SwitchMlpWeights::new(ql, qb)?,
             shared_expert: Qwen3NextMLP::new(ql, qb)?,
-            shared_expert_gate: QLinear::new(64, 8)?,
+            shared_expert_gate: QLinear::new(gate_ql, gate_qb)?,
             top_k: args.num_experts_per_tok,
             norm_topk_prob: args.norm_topk_prob,
         })
@@ -1718,6 +1727,14 @@ fn load_qwen3_5_moe_text_config_args<P: AsRef<Path>>(
         "use_separate_gdn_projections".to_owned(),
         serde_json::Value::from(true),
     );
+
+    // Detect per-layer gate quantization override from top-level quantization config
+    if let Some(quant) = config.get("quantization") {
+        let gate_key = "language_model.model.layers.0.mlp.gate";
+        if let Some(gate_q) = quant.get(gate_key) {
+            map.insert("gate_quantization".to_owned(), gate_q.clone());
+        }
+    }
 
     Ok(serde_json::from_value(obj)?)
 }

--- a/crates/higgs-models/src/qwen3_next.rs
+++ b/crates/higgs-models/src/qwen3_next.rs
@@ -1339,6 +1339,114 @@ fn compute_g_compiled((a_log, a, dt_bias): (&Array, &Array, &Array)) -> Result<A
 // DecoderLayer
 // ---------------------------------------------------------------------------
 
+/// Wrapper for the FFN block: either sparse MoE or dense SwiGLU.
+/// Both share the `mlp` parameter namespace in safetensors — their sub-keys
+/// don't overlap (MoE: gate, switch_mlp, shared_expert; Dense: gate_proj, up_proj, down_proj).
+#[derive(Debug, Clone, ModuleParameters)]
+struct FfnBlock {
+    #[param]
+    gate: Option<QLinear>,
+    #[param]
+    switch_mlp: Option<SwitchMlpWeights>,
+    #[param]
+    shared_expert: Option<Qwen3NextMLP>,
+    #[param]
+    shared_expert_gate: Option<QLinear>,
+    #[param]
+    gate_proj: Option<QLinear>,
+    #[param]
+    up_proj: Option<QLinear>,
+    #[param]
+    down_proj: Option<QLinear>,
+    is_moe: bool,
+    top_k: i32,
+    norm_topk_prob: bool,
+}
+
+impl FfnBlock {
+    fn new_moe(args: &Qwen3NextModelArgs, ql: i32, qb: i32) -> Result<Self, Exception> {
+        let moe = SparseMoeBlock::new(args, ql, qb)?;
+        Ok(Self {
+            gate: Some(moe.gate),
+            switch_mlp: Some(moe.switch_mlp),
+            shared_expert: Some(moe.shared_expert),
+            shared_expert_gate: Some(moe.shared_expert_gate),
+            gate_proj: None,
+            up_proj: None,
+            down_proj: None,
+            is_moe: true,
+            top_k: moe.top_k,
+            norm_topk_prob: moe.norm_topk_prob,
+        })
+    }
+
+    fn new_dense(ql: i32, qb: i32) -> Result<Self, Exception> {
+        Ok(Self {
+            gate: None,
+            switch_mlp: None,
+            shared_expert: None,
+            shared_expert_gate: None,
+            gate_proj: Some(QLinear::new(ql, qb)?),
+            up_proj: Some(QLinear::new(ql, qb)?),
+            down_proj: Some(QLinear::new(ql, qb)?),
+            is_moe: false,
+            top_k: 0,
+            norm_topk_prob: false,
+        })
+    }
+
+    fn forward(&self, x: &Array) -> Result<Array, Exception> {
+        if self.is_moe {
+            // Delegate to SparseMoeBlock logic
+            let gate_ref = self.gate.as_ref()
+                .ok_or_else(|| Exception::custom("MoE gate missing"))?;
+            let switch_ref = self.switch_mlp.as_ref()
+                .ok_or_else(|| Exception::custom("MoE switch_mlp missing"))?;
+            let se_ref = self.shared_expert.as_ref()
+                .ok_or_else(|| Exception::custom("MoE shared_expert missing"))?;
+            let seg_ref = self.shared_expert_gate.as_ref()
+                .ok_or_else(|| Exception::custom("MoE shared_expert_gate missing"))?;
+
+            let gates = ops::softmax_axis(&gate_ref.forward(x)?, -1, true)?;
+            let neg_k = -self.top_k;
+            let all_inds = ops::argpartition_axis(&gates, neg_k, -1)?;
+            let num_experts = *gates.shape().last()
+                .ok_or_else(|| Exception::custom("gates must have last dim"))?;
+            let top_k_start = num_experts - self.top_k;
+            let top_inds = all_inds.index((.., .., top_k_start..));
+            let top_scores = gates.take_along_axis(&top_inds, -1)?;
+            let top_scores = if self.norm_topk_prob {
+                let sum = top_scores.sum_axes(&[-1], true)?;
+                top_scores.divide(&sum)?
+            } else {
+                top_scores
+            };
+
+            let y = switch_ref.forward_gather(x, &top_inds, false)?;
+            let expert_sum = y
+                .multiply(&top_scores.expand_dims(-1)?)?
+                .sum_axes(&[-2], false)?;
+
+            let shared_y = se_ref.forward(x)?;
+            let shared_gate_val = nn::sigmoid(&seg_ref.forward(x)?)?;
+            let shared_out = shared_y.multiply(&shared_gate_val)?;
+
+            expert_sum.add(shared_out)
+        } else {
+            // Dense SwiGLU
+            let gp = self.gate_proj.as_ref()
+                .ok_or_else(|| Exception::custom("dense gate_proj missing"))?;
+            let up = self.up_proj.as_ref()
+                .ok_or_else(|| Exception::custom("dense up_proj missing"))?;
+            let dp = self.down_proj.as_ref()
+                .ok_or_else(|| Exception::custom("dense down_proj missing"))?;
+            let gate_out = gp.forward(x)?;
+            let up_out = up.forward(x)?;
+            dp.forward(&swiglu(&gate_out, &up_out)?)
+        }
+    }
+}
+
 #[derive(Debug, Clone, ModuleParameters)]
 struct DecoderLayer {
     #[param]
@@ -1350,7 +1458,7 @@ struct DecoderLayer {
     #[param]
     post_attention_layernorm: nn::RmsNorm,
     #[param]
-    mlp: SparseMoeBlock,
+    mlp: FfnBlock,
     is_linear: bool,
 }
 
@@ -1369,6 +1477,11 @@ impl DecoderLayer {
             Some(Qwen3NextAttention::new(args, ql, qb)?)
         };
 
+        let ffn = if args.num_experts > 0 {
+            FfnBlock::new_moe(args, ql, qb)?
+        } else {
+            FfnBlock::new_dense(ql, qb)?
+        };
         Ok(Self {
             linear_attn,
             self_attn,
@@ -1378,7 +1491,7 @@ impl DecoderLayer {
             post_attention_layernorm: nn::RmsNormBuilder::new(args.hidden_size)
                 .eps(args.rms_norm_eps)
                 .build()?,
-            mlp: SparseMoeBlock::new(args, ql, qb)?,
+            mlp: ffn,
             is_linear,
         })
     }

--- a/crates/higgs-models/src/registry.rs
+++ b/crates/higgs-models/src/registry.rs
@@ -25,6 +25,7 @@ pub fn is_supported(model_type: &str) -> bool {
             | "mistral"
             | "qwen3_next"
             | "qwen3_moe"
+            | "qwen3_5_moe"
             | "gemma2"
             | "phi3"
             | "starcoder2"
@@ -149,6 +150,17 @@ mod tests {
     fn test_detect_model_type_qwen3_moe() {
         let dir = write_model_type_config("qwen3_moe");
         assert_eq!(detect_model_type(dir.path()).unwrap(), "qwen3_moe");
+    }
+
+    #[test]
+    fn test_is_supported_qwen3_5_moe() {
+        assert!(is_supported("qwen3_5_moe"));
+    }
+
+    #[test]
+    fn test_detect_model_type_qwen3_5_moe() {
+        let dir = write_model_type_config("qwen3_5_moe");
+        assert_eq!(detect_model_type(dir.path()).unwrap(), "qwen3_5_moe");
     }
 
     #[test]

--- a/crates/higgs-models/src/registry.rs
+++ b/crates/higgs-models/src/registry.rs
@@ -25,6 +25,7 @@ pub fn is_supported(model_type: &str) -> bool {
             | "mistral"
             | "qwen3_next"
             | "qwen3_moe"
+            | "qwen3_5"
             | "qwen3_5_moe"
             | "gemma2"
             | "phi3"

--- a/crates/higgs/src/routes/anthropic.rs
+++ b/crates/higgs/src/routes/anthropic.rs
@@ -320,6 +320,8 @@ fn create_message_stream(
     let prompt_token_count = u32::try_from(prompt_tokens.len())
         .map_err(|_| ServerError::BadRequest("Token count overflow".to_owned()))?;
 
+    let thinking_enabled = engine.enable_thinking();
+
     // Spawn generation before creating the stream so prefill starts immediately
     let (tx, mut rx) = tokio::sync::mpsc::channel(32);
 
@@ -396,7 +398,6 @@ fn create_message_stream(
         // 3. content_block_delta events (one per token)
         let mut final_stop_reason = None;
         let mut total_output_tokens: u32 = 0;
-        let thinking_enabled = engine.enable_thinking();
         let mut reasoning_tracker = if thinking_enabled {
             higgs_engine::reasoning_parser::StreamingReasoningTracker::new_inside_think()
         } else {

--- a/crates/higgs/src/routes/anthropic.rs
+++ b/crates/higgs/src/routes/anthropic.rs
@@ -239,6 +239,7 @@ async fn create_message_non_streaming(
         .prepare_chat_prompt(&engine_messages, tools)
         .map_err(ServerError::Engine)?;
 
+    let thinking_enabled = engine.enable_thinking();
     let output = tokio::task::spawn_blocking(move || {
         engine.generate(
             &prompt_tokens,
@@ -258,11 +259,16 @@ async fn create_message_non_streaming(
     let stop_reason = openai_finish_to_anthropic_stop(&output.finish_reason);
     let msg_id = format!("msg_{}", uuid::Uuid::new_v4().simple());
 
-    let reasoning_result = higgs_engine::reasoning_parser::parse_reasoning(&output.text);
+    let parse_input = if thinking_enabled {
+        format!("<think>{}", output.text)
+    } else {
+        output.text
+    };
+    let reasoning_result = higgs_engine::reasoning_parser::parse_reasoning(&parse_input);
     let visible_text = if reasoning_result.reasoning.is_some() {
         reasoning_result.text
     } else {
-        output.text
+        parse_input
     };
 
     Ok(CreateMessageResponse {

--- a/crates/higgs/src/routes/anthropic.rs
+++ b/crates/higgs/src/routes/anthropic.rs
@@ -260,7 +260,7 @@ async fn create_message_non_streaming(
     let msg_id = format!("msg_{}", uuid::Uuid::new_v4().simple());
 
     let parse_input = if thinking_enabled {
-        format!("<think>{}", output.text)
+        format!("<think>{}</think>", output.text)
     } else {
         output.text
     };
@@ -268,11 +268,16 @@ async fn create_message_non_streaming(
     // If reasoning was detected, use the visible text. If the think block
     // was never closed (e.g. length-stopped), fall back to the raw output
     // to avoid returning an empty string.
-    let visible_text = if reasoning_result.reasoning.is_some() && !reasoning_result.text.is_empty() {
+    let visible_text = if reasoning_result.reasoning.is_some() && !reasoning_result.text.is_empty()
+    {
         reasoning_result.text
     } else {
-        // Strip the <think> prefix we injected so the raw output is clean.
-        parse_input.strip_prefix("<think>").unwrap_or(&parse_input).to_owned()
+        // Strip the <think>...</think> wrapper we injected so the raw output is clean.
+        parse_input
+            .strip_prefix("<think>")
+            .and_then(|s| s.strip_suffix("</think>"))
+            .unwrap_or(&parse_input)
+            .to_owned()
     };
 
     Ok(CreateMessageResponse {

--- a/crates/higgs/src/routes/anthropic.rs
+++ b/crates/higgs/src/routes/anthropic.rs
@@ -265,10 +265,14 @@ async fn create_message_non_streaming(
         output.text
     };
     let reasoning_result = higgs_engine::reasoning_parser::parse_reasoning(&parse_input);
-    let visible_text = if reasoning_result.reasoning.is_some() {
+    // If reasoning was detected, use the visible text. If the think block
+    // was never closed (e.g. length-stopped), fall back to the raw output
+    // to avoid returning an empty string.
+    let visible_text = if reasoning_result.reasoning.is_some() && !reasoning_result.text.is_empty() {
         reasoning_result.text
     } else {
-        parse_input
+        // Strip the <think> prefix we injected so the raw output is clean.
+        parse_input.strip_prefix("<think>").unwrap_or(&parse_input).to_owned()
     };
 
     Ok(CreateMessageResponse {
@@ -392,7 +396,12 @@ fn create_message_stream(
         // 3. content_block_delta events (one per token)
         let mut final_stop_reason = None;
         let mut total_output_tokens: u32 = 0;
-        let mut reasoning_tracker = higgs_engine::reasoning_parser::StreamingReasoningTracker::new();
+        let thinking_enabled = engine.enable_thinking();
+        let mut reasoning_tracker = if thinking_enabled {
+            higgs_engine::reasoning_parser::StreamingReasoningTracker::new_inside_think()
+        } else {
+            higgs_engine::reasoning_parser::StreamingReasoningTracker::new()
+        };
 
         while let Some(output) = rx.recv().await {
             let (visible, _reasoning) = reasoning_tracker.process(&output.new_text);

--- a/crates/higgs/src/routes/chat.rs
+++ b/crates/higgs/src/routes/chat.rs
@@ -294,6 +294,7 @@ async fn chat_completions_non_streaming(
     let constraint = build_constraint(req.response_format.as_ref(), &engine)?;
 
     let tokenizer = engine.tokenizer().clone();
+    let thinking_enabled = engine.enable_thinking();
     let output = tokio::task::spawn_blocking(move || {
         engine.generate(
             &prompt_tokens,
@@ -318,12 +319,20 @@ async fn chat_completions_non_streaming(
         .as_ref()
         .map(|lps| logprobs_to_response(lps, &tokenizer));
 
-    // Parse reasoning (think tags) from the output
-    let reasoning_result = higgs_engine::reasoning_parser::parse_reasoning(&output.text);
+    // Parse reasoning (think tags) from the output.
+    // When thinking mode is enabled, the template already opened `<think>` in the prompt,
+    // so the generated text starts inside the think block. Prepend `<think>` so the parser
+    // can find the matching `</think>` and split reasoning from visible content.
+    let parse_input = if thinking_enabled {
+        format!("<think>{}", output.text)
+    } else {
+        output.text
+    };
+    let reasoning_result = higgs_engine::reasoning_parser::parse_reasoning(&parse_input);
     let raw_text = if reasoning_result.reasoning.is_some() {
         reasoning_result.text
     } else {
-        output.text
+        parse_input
     };
     let reasoning_content = reasoning_result.reasoning;
 
@@ -397,11 +406,9 @@ fn chat_completions_stream(
     metrics: Option<Arc<MetricsStore>>,
     routing_method: crate::router::RoutingMethod,
 ) -> Result<impl Stream<Item = Result<Event, Infallible>>, ServerError> {
-    if req.tools.is_some() {
-        return Err(ServerError::BadRequest(
-            "Streaming with tool_calls is not yet supported".to_owned(),
-        ));
-    }
+    // Silently ignore tools in streaming mode (nanobot always sends them).
+    // Tool-calling responses are not yet supported in streaming, but
+    // regular text generation works fine with tools present in the request.
 
     let max_tokens = req.max_tokens.unwrap_or(state.config.server.max_tokens);
     let sampling = build_sampling_params(&req);
@@ -466,6 +473,7 @@ fn chat_completions_stream(
     });
 
     let tokenizer = engine.tokenizer().clone();
+    let thinking_enabled_stream = engine.enable_thinking();
     let (tx, mut rx) = tokio::sync::mpsc::channel(32);
 
     tokio::task::spawn_blocking(move || {
@@ -509,7 +517,11 @@ fn chat_completions_stream(
             Err(e) => tracing::error!(error = %e, "Failed to serialize SSE chunk"),
         }
 
-        let mut reasoning_tracker = higgs_engine::reasoning_parser::StreamingReasoningTracker::new();
+        let mut reasoning_tracker = if thinking_enabled_stream {
+            higgs_engine::reasoning_parser::StreamingReasoningTracker::new_inside_think()
+        } else {
+            higgs_engine::reasoning_parser::StreamingReasoningTracker::new()
+        };
         let mut output_token_count: u32 = 0;
 
         while let Some(output) = rx.recv().await {

--- a/crates/higgs/src/routes/chat.rs
+++ b/crates/higgs/src/routes/chat.rs
@@ -406,9 +406,13 @@ fn chat_completions_stream(
     metrics: Option<Arc<MetricsStore>>,
     routing_method: crate::router::RoutingMethod,
 ) -> Result<impl Stream<Item = Result<Event, Infallible>>, ServerError> {
-    // Silently ignore tools in streaming mode (nanobot always sends them).
-    // Tool-calling responses are not yet supported in streaming, but
-    // regular text generation works fine with tools present in the request.
+    // Reject streaming requests with tools — tool-call deltas are not yet
+    // supported in streaming (every delta hardcodes tool_calls: None).
+    if req.tools.as_ref().is_some_and(|t| !t.is_empty()) {
+        return Err(ServerError::BadRequest(
+            "Tool calling is not supported in streaming mode".to_owned(),
+        ));
+    }
 
     let max_tokens = req.max_tokens.unwrap_or(state.config.server.max_tokens);
     let sampling = build_sampling_params(&req);

--- a/crates/higgs/src/state.rs
+++ b/crates/higgs/src/state.rs
@@ -74,6 +74,15 @@ impl Engine {
         }
     }
 
+    pub fn enable_thinking(&self) -> bool {
+        match self {
+            Self::Simple(e) => e.enable_thinking(),
+            Self::Batch(_) => false,
+            #[cfg(test)]
+            Self::Stub(_) => false,
+        }
+    }
+
     pub fn is_vlm(&self) -> bool {
         match self {
             Self::Simple(e) => e.is_vlm(),


### PR DESCRIPTION
## Summary

**Major performance improvement for quantized models.**

> **Note**: This PR is stacked on #60. The diff against `main` includes #60's changes. The **only change in this PR** is in `crates/higgs-models/src/qwen3_next.rs` — the `QEmbedding::forward` method. Please review that single hunk only; merge #60 first, then this diff will be clean.

### The Problem

`QEmbedding::forward` was dequantizing the **entire vocabulary matrix** (151,552 rows × hidden_dim) on every single token, then gathering the one row it needed. This made the embedding layer the dominant cost at layer zero — even though only 1 row out of 151k was used per decode step.

### The Fix

Index into the raw quantized weight/scales/biases arrays *first*, then dequantize only the selected rows. This reduces embedding work from **O(vocab_size)** to **O(batch_size)** — a ~151,000x reduction in dequantize volume for single-token decode.

### Impact

- Collapsed the zero-layer embedding cost from a visible bottleneck to negligible
- **This single change is what put Higgs ahead of Python mlx-lm** on Qwen3.5-35B
- Affects all quantized models, not just Qwen — any model using `QEmbedding` benefits

### Benchmark (Qwen3.5-35B-A3B-3bit, MacBook Pro M4 32GB)

Pure model forward benchmark (`bench_pure_forward_3bit`, 50 tokens):

| Metric | Value |
|--------|-------|
| Forward | 0.63 ms/token |
| Eval | 17.91 ms/token |
| Total | 18.54 ms/token |
| **Throughput** | **53.9 tok/s** |

## Test plan

- [ ] Verify identical output (token-level) before and after on a fixed prompt
- [ ] Benchmark: compare T1 (time-to-first-token) before/after
- [ ] Benchmark: compare tok/s decode — embedding cost should be negligible now
- [ ] `cargo clippy -p higgs` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in thinking mode that emits hidden reasoning blocks, a public check to see if thinking is enabled, and enforced thinking budget during generation.
  * Added support for Qwen 3.5 and Qwen 3.5 MoE models.

* **Improvements**
  * GPU memory capping with clearer logging and env gating.
  * Better model-weight load diagnostics with per-file summaries.
  * Streaming and response handling: inside-think streaming behavior, thinking-aware visible text extraction, and stricter tool-use checks in streaming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
