### PR TITLE
Prepare 1.0.0 release metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "1.0.0"
 edition = "2024"
 license = "MIT"
 rust-version = "1.88.0"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "rust",
-  "release-as": "1.0.0",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "include-v-in-tag": true,

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "rust",
+  "release-as": "1.0.0",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "include-v-in-tag": true,


### PR DESCRIPTION
## Summary
- align `[workspace.package].version` in `Cargo.toml` to `1.0.0`
- trigger the next `release-please` PR via commit `b199a87` using the `Release-As: 1.0.0` footer instead of a config override

## Testing
- `cargo metadata --no-deps --format-version 1 >/dev/null`

If this PR is squash-merged, keep `Release-As: 1.0.0` in the final squash commit body or the override will be lost.