### PR TITLE
fix: pin next release to 1.0.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "rust",
+  "release-as": "1.0.0",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "include-v-in-tag": true,
@@ -17,13 +18,16 @@
   ],
   "packages": {
     "crates/higgs-models": {
-      "component": "higgs-models"
+      "component": "higgs-models",
+      "release-as": "1.0.0"
     },
     "crates/higgs-engine": {
-      "component": "higgs-engine"
+      "component": "higgs-engine",
+      "release-as": "1.0.0"
     },
     "crates/higgs": {
-      "component": "higgs"
+      "component": "higgs",
+      "release-as": "1.0.0"
     }
   }
 }


### PR DESCRIPTION
## Summary
- add an explicit top-level release-as override for release-please
- add matching per-package release-as overrides for all releasable crates
- force the next generated release PR to target 1.0.0 instead of the pre-1.0 0.2.0 bump

## Testing
- jq empty release-please-config.json

This override should be removed after the 1.0.0 release PR is merged and tagged, otherwise future release PRs will keep trying to use 1.0.0.
