### PR TITLE
Trigger next release from main

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Install:
 brew install panbanda/brews/higgs
 ```
 
+The Homebrew release currently targets Apple Silicon (`aarch64-apple-darwin`).
+
 Or build from source (Rust 1.88.0+, Xcode CLI Tools):
 
 ```bash

--- a/crates/higgs/src/main.rs
+++ b/crates/higgs/src/main.rs
@@ -334,7 +334,7 @@ fn ensure_local_runtime_ready(config: &HiggsConfig) -> Result<(), Box<dyn std::e
         }
         if !metallib.exists() {
             return Err(format!(
-                "mlx.metallib not found next to executable at {}\nhint: rebuild Higgs or use a release artifact that bundles mlx.metallib",
+                "mlx.metallib not found next to executable at {}\nhint: rebuild Higgs, reinstall the Apple Silicon Homebrew package, or use a release artifact that bundles mlx.metallib",
                 metallib.display()
             )
             .into());


### PR DESCRIPTION
This PR adds two small follow-up fixes after PR #112 merged without the later releasable commit. It clarifies the Apple Silicon Homebrew target in the root README and updates the  metallib error hint to mention reinstalling the Homebrew package. The  path change is intentional because release-please only picked up package-path commits in the 2026-04-24 run, so merging this should give it a releasable  commit on .