### PR TITLE
Stop pinning release-please at 1.0.0

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,3 @@
+reviews:
+  commit_status: false
+  fail_commit_status: false

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "rust",
-  "release-as": "1.0.0",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "include-v-in-tag": true,
@@ -18,16 +17,13 @@
   ],
   "packages": {
     "crates/higgs-models": {
-      "component": "higgs-models",
-      "release-as": "1.0.0"
+      "component": "higgs-models"
     },
     "crates/higgs-engine": {
-      "component": "higgs-engine",
-      "release-as": "1.0.0"
+      "component": "higgs-engine"
     },
     "crates/higgs": {
-      "component": "higgs",
-      "release-as": "1.0.0"
+      "component": "higgs"
     }
   }
 }


### PR DESCRIPTION
This removes the top-level and per-package release-as pins from release-please-config.json. Those pins are why release-please opened PR #114 as another 1.0.0 release after the fix commit on main. Once this lands, the existing fix commit already merged into crates/higgs should let release-please generate the next patch release PR instead of duplicating 1.0.0.

@coderabbitai ignore