### PR TITLE
perf(dtype): preserve fp16 through scalar multiply in deepseek_v2 + siglip

### DIFF
--- a/crates/higgs-models/src/deepseek_v2.rs
+++ b/crates/higgs-models/src/deepseek_v2.rs
@@ -216,7 +216,11 @@ fn apply_deepseek_rope(
     offset: i32,
 ) -> Result<Array, Exception> {
     let x_scaled = if (yarn_mscale - 1.0).abs() > f32::EPSILON {
-        x.multiply(mlx_rs::array!(yarn_mscale))?
+        // Match x's dtype to avoid silent fp16->f32 upcast. `mlx_rs::array!`
+        // promotes a f32 scalar literal which would propagate f32 through
+        // the entire attention chain (rope -> SDPA -> o_proj -> residual).
+        let scalar = Array::from_f32(yarn_mscale).as_dtype(x.dtype())?;
+        x.multiply(&scalar)?
     } else {
         x.clone()
     };
@@ -622,7 +626,9 @@ impl DeepSeekV2MlpBlock {
 
         // Scale scores
         let scaled_scores = if (self.scaling_factor - 1.0).abs() > f32::EPSILON {
-            top_scores.multiply(mlx_rs::array!(self.scaling_factor))?
+            // Preserve top_scores dtype; same fp16->f32 promotion bug as apply_deepseek_rope.
+            let scalar = Array::from_f32(self.scaling_factor).as_dtype(top_scores.dtype())?;
+            top_scores.multiply(&scalar)?
         } else {
             top_scores
         };
@@ -1196,5 +1202,23 @@ mod tests {
         args.first_k_dense_replace = 0;
         let model = DeepSeekV2CausalLM::new(args).unwrap();
         assert!(model.args.n_routed_experts.is_none());
+    }
+
+    #[test]
+    fn apply_deepseek_rope_preserves_input_dtype_under_yarn_scaling() {
+        use mlx_rs::Dtype;
+
+        // Shape matches MLA RoPE input: [batch, n_heads, seq, head_dim].
+        let x_fp16 = Array::ones::<f32>(&[1, 1, 4, 8])
+            .unwrap()
+            .as_dtype(Dtype::Float16)
+            .unwrap();
+
+        // yarn_mscale != 1.0 triggers the scalar-multiply branch. Before the
+        // fix, multiplying fp16 by an `array!(f32)` scalar silently upcast the
+        // entire chain to f32, propagating through SDPA -> o_proj -> residual.
+        let result = apply_deepseek_rope(&x_fp16, 8, 10000.0, None, 1.5, 0).unwrap();
+
+        assert_eq!(result.dtype(), Dtype::Float16);
     }
 }

--- a/crates/higgs-models/src/siglip.rs
+++ b/crates/higgs-models/src/siglip.rs
@@ -103,9 +103,11 @@ impl SigLipAttention {
             .reshape(&[b, seq_len, self.num_heads, self.head_dim])?
             .transpose_axes(&[0, 2, 1, 3])?;
 
-        // Scaled dot-product attention
-        let scores = ops::matmul(&queries, &keys.transpose_axes(&[0, 1, 3, 2])?)?
-            .multiply(mlx_rs::array!(self.scale))?;
+        // Scaled dot-product attention; preserve scores dtype to avoid silent
+        // fp16->f32 upcast through softmax and the rest of the attention path.
+        let scores_raw = ops::matmul(&queries, &keys.transpose_axes(&[0, 1, 3, 2])?)?;
+        let scale_arr = Array::from_f32(self.scale).as_dtype(scores_raw.dtype())?;
+        let scores = scores_raw.multiply(&scale_arr)?;
         let weights = ops::softmax_axis(&scores, -1, None)?;
         let attn_output = ops::matmul(&weights, &values)?
             .transpose_axes(&[0, 2, 1, 3])?


### PR DESCRIPTION
## Problem
`mlx_rs::array!(<f32 var>)` creates an f32 scalar Array. Multiplying an fp16
input by it silently promotes the result to f32, propagating through softmax,
SDPA, residuals, and the rest of the attention path. Three sites still had
this pattern after the dtype fix in #18.

## Approach
Match the pattern already used elsewhere in the codebase (see `gemma2.rs:260`,
`gemma2.rs:371` — `array!(scale).as_dtype(scores.dtype())`): construct the
scalar via `Array::from_f32(s).as_dtype(<lhs>.dtype())` so the input dtype
is preserved through the multiply.

Three call sites fixed:
- `deepseek_v2.rs:219` — `apply_deepseek_rope` yarn_mscale
- `deepseek_v2.rs:625` — `forward_moe` scaling_factor
- `siglip.rs:108` — `SigLipAttention` attention scale

## Evidence
The same bug class on a different (non-upstream) call site delivered a
+2.83× / +2.11× decode speedup when fixed. With yarn factor = 4.0,
`mscale ≈ 1.139` fires the multiply branch on every rope call (72×/step
on an 8B model), which compounds across every layer of attention:

- Before fix on the analogous site: 22 tok/s (8B), 87 tok/s (1.7B)
- After: 64 tok/s (8B), 184 tok/s (1.7B)
- Bench source: 1-bit Qwen3.5 derivative on Apple M4

End-to-end speedup specifically for deepseek_v2 + siglip hasn't been
re-measured here — happy to add follow-up data if you want a host with
those models loaded; the bug class and pattern match exactly.

## Test plan
- [x] New unit test \`apply_deepseek_rope_preserves_input_dtype_under_yarn_scaling\`
- [x] \`cargo fmt --check\`
- [x] \`cargo clippy -p higgs-models --all-targets -- -D warnings\`
- [x] \`cargo test -p higgs-models --lib deepseek_v2\` → 23/23 passed

## Risk
Behavior-preserving for any path already running in f32 (most prod paths).
Paths running in fp16 stop being silently upgraded to f32 — outputs are
identical to ULP for the multiply itself; downstream ops just stay in fp16.
Same shape as the fix landed in #18.

## Out of scope
- The four \`mlx_rs::array!(1.0 / temperature)\` sites in \`batch_engine.rs\`
  and \`simple.rs\` — logits there are already f32, no upcast bug.
- A separate set of identical patterns lives in fork-only files
  (yarn.rs, bonsai_q1.rs, rwkv7.rs) which aren't on main; they'll come in
  follow-up PRs only if the underlying features land upstream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved data type preservation in tensor operations to prevent unintended precision conversions during scaling calculations in neural network computations.
  * Added verification tests to ensure numerical dtype consistency across attention mechanisms and rope scaling operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->