### PR TITLE
feat(bench): higgs-bench crate with output contract + bench_decode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target/
+target/bench-results/
 .DS_Store
 .env
 *.swp

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "built"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ed6191a7e78c36abdb16ab65341eefd73d64d303fffccdbb00d51e4205967b"
+dependencies = [
+ "git2",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1410,6 +1419,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1582,6 +1604,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "higgs-bench"
+version = "1.0.0"
+dependencies = [
+ "anyhow",
+ "built",
+ "chrono",
+ "clap",
+ "futures",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sysinfo",
+ "tokio",
+ "toml",
+]
+
+[[package]]
 name = "higgs-engine"
 version = "1.1.0"
 dependencies = [
@@ -1737,7 +1776,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2123,6 +2162,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.18.3+1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2139,6 +2190,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2457,6 +2520,15 @@ name = "nonzero_ext"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -3738,6 +3810,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c33cd241af0f2e9e3b5c32163b873b29956890b5342e6745b917ce9d490f4af"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "rayon",
+ "windows",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4430,6 +4516,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4746,16 +4838,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4763,6 +4888,17 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4793,8 +4929,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
  "windows-link",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/benchmarks/models.toml
+++ b/benchmarks/models.toml
@@ -1,0 +1,46 @@
+# Higgs bench model manifest.
+#
+# Source of truth for which models the `higgs-bench` binaries can target.
+# Bench binaries take `--model <key>` and look up the entry below; pass
+# `--tag <tag>` to run against everything matching a tag.
+#
+# Adding a model is one entry. After adding, you can run e.g.
+#   cargo run --release -p higgs-bench --bin bench_decode -- \
+#     --model <key> --port 8899
+# and paste the JSON output into your PR description.
+
+[[models]]
+key = "qwen3-1.7B-4bit"
+label = "Qwen3-1.7B-4bit (Dense)"
+path = "mlx-community/Qwen3-1.7B-4bit"
+quantization = "4bit"
+approx_size_gb = 1.2
+context = 32768
+tags = ["small", "dense"]
+
+[[models]]
+key = "deepseek-v2-lite-4bit"
+label = "DeepSeek-V2-Lite-4bit (MoE)"
+path = "mlx-community/DeepSeek-Coder-V2-Lite-Instruct-4bit-mlx"
+quantization = "4bit"
+approx_size_gb = 9.5
+context = 32768
+tags = ["medium", "moe"]
+
+[[models]]
+key = "qwen3.5-27B-4bit"
+label = "Qwen3.5-27B-4bit (Dense)"
+path = "mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit"
+quantization = "4bit"
+approx_size_gb = 16.0
+context = 32768
+tags = ["large", "dense"]
+
+[[models]]
+key = "qwen3.5-35B-a3b-3bit"
+label = "Qwen3.5-35B-A3B-3bit (MoE)"
+path = "NexVeridian/Qwen3.5-35B-A3B-3bit"
+quantization = "3bit"
+approx_size_gb = 14.0
+context = 32768
+tags = ["large", "moe"]

--- a/crates/higgs-bench/Cargo.toml
+++ b/crates/higgs-bench/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "higgs-bench"
+version = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+rust-version = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow = "1"
+chrono = { workspace = true }
+clap = { workspace = true }
+futures = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sysinfo = "0.32"
+tokio = { workspace = true }
+toml = "0.8"
+
+[build-dependencies]
+built = { version = "0.7", features = ["git2"] }
+
+[[bin]]
+name = "bench_decode"
+path = "src/bin/bench_decode.rs"
+
+[[bin]]
+name = "bench_summarize"
+path = "src/bin/bench_summarize.rs"

--- a/crates/higgs-bench/build.rs
+++ b/crates/higgs-bench/build.rs
@@ -1,0 +1,5 @@
+#![allow(clippy::expect_used)]
+
+fn main() {
+    built::write_built_file().expect("Failed to acquire build-time information");
+}

--- a/crates/higgs-bench/src/bin/bench_decode.rs
+++ b/crates/higgs-bench/src/bin/bench_decode.rs
@@ -244,6 +244,7 @@ async fn run(args: Args) -> Result<()> {
     Ok(())
 }
 
+#[allow(clippy::too_many_lines)]
 async fn run_trial(
     client: &reqwest::Client,
     base_url: &str,
@@ -326,10 +327,16 @@ async fn run_trial(
             };
             // Terminal usage chunk: empty `choices`, populated `usage`.
             if let Some(usage) = value.get("usage").filter(|u| u.is_object()) {
-                if let Some(ct) = usage.get("completion_tokens").and_then(|n| n.as_u64()) {
+                if let Some(ct) = usage
+                    .get("completion_tokens")
+                    .and_then(serde_json::Value::as_u64)
+                {
                     server_completion_tokens = Some(u32::try_from(ct).unwrap_or(u32::MAX));
                 }
-                if let Some(pt) = usage.get("prompt_tokens").and_then(|n| n.as_u64()) {
+                if let Some(pt) = usage
+                    .get("prompt_tokens")
+                    .and_then(serde_json::Value::as_u64)
+                {
                     server_prompt_tokens = Some(u32::try_from(pt).unwrap_or(u32::MAX));
                 }
             }
@@ -357,15 +364,12 @@ async fn run_trial(
     let ttft_ms = first_at.duration_since(started).as_secs_f64() * 1000.0;
     let after_first = total_elapsed.saturating_sub(first_at.duration_since(started));
 
-    // Prefer server-reported completion_tokens. Fall back to SSE-chunk count
-    // only when the server omits the usage chunk (legacy / non-higgs backends
-    // that don't honor `stream_options.include_usage`).
-    let tokens_after_first = match server_completion_tokens {
-        // server reports total completion tokens; subtract one for the first
-        // visible token (already counted as TTFT, not part of decode wall).
-        Some(total) => total.saturating_sub(1),
-        None => chunks_after_first,
-    };
+    // Prefer server-reported completion_tokens. Subtract one for the first
+    // visible token (already counted as TTFT, not part of decode wall). Fall
+    // back to SSE-chunk count only when the server omits the usage chunk
+    // (legacy / non-higgs backends that don't honor `stream_options.include_usage`).
+    let tokens_after_first = server_completion_tokens
+        .map_or(chunks_after_first, |total| total.saturating_sub(1));
     let decode_tokps = if after_first.as_secs_f64() > 0.0 && tokens_after_first > 0 {
         f64::from(tokens_after_first) / after_first.as_secs_f64()
     } else {

--- a/crates/higgs-bench/src/bin/bench_decode.rs
+++ b/crates/higgs-bench/src/bin/bench_decode.rs
@@ -368,8 +368,8 @@ async fn run_trial(
     // visible token (already counted as TTFT, not part of decode wall). Fall
     // back to SSE-chunk count only when the server omits the usage chunk
     // (legacy / non-higgs backends that don't honor `stream_options.include_usage`).
-    let tokens_after_first = server_completion_tokens
-        .map_or(chunks_after_first, |total| total.saturating_sub(1));
+    let tokens_after_first =
+        server_completion_tokens.map_or(chunks_after_first, |total| total.saturating_sub(1));
     let decode_tokps = if after_first.as_secs_f64() > 0.0 && tokens_after_first > 0 {
         f64::from(tokens_after_first) / after_first.as_secs_f64()
     } else {

--- a/crates/higgs-bench/src/bin/bench_decode.rs
+++ b/crates/higgs-bench/src/bin/bench_decode.rs
@@ -251,10 +251,20 @@ async fn run_trial(
     prompt: &str,
     args: &Args,
 ) -> Result<TrialResult> {
+    // Request the terminal usage chunk so we measure throughput against
+    // server-reported token counts rather than SSE chunk count (which can
+    // diverge once the server emits buffered visible text).
+    //
+    // Disable reasoning so the bench measures time-to-first-generated-token,
+    // not time-to-first-visible-answer. Qwen3.5+ models default to thinking
+    // mode in higgs and would otherwise emit `reasoning_content` deltas the
+    // current code skips, biasing TTFT high.
     let mut body = serde_json::json!({
         "model": model_path,
         "messages": [{"role": "user", "content": prompt}],
         "stream": true,
+        "stream_options": { "include_usage": true },
+        "reasoning": { "effort": "none" },
         "max_tokens": args.max_tokens,
         "temperature": args.temperature,
     });
@@ -288,7 +298,12 @@ async fn run_trial(
 
     let mut stream = resp.bytes_stream();
     let mut first_token_at: Option<Instant> = None;
-    let mut tokens_seen: u32 = 0;
+    // SSE-chunk-based estimate. Used only as a fallback when the server
+    // doesn't send a terminal usage chunk.
+    let mut chunks_after_first: u32 = 0;
+    // Server-reported token counts from the terminal `usage` chunk (preferred).
+    let mut server_completion_tokens: Option<u32> = None;
+    let mut server_prompt_tokens: Option<u32> = None;
     let mut buf = String::new();
 
     while let Some(chunk) = stream.next().await {
@@ -309,6 +324,15 @@ async fn run_trial(
                 Ok(v) => v,
                 Err(_) => continue,
             };
+            // Terminal usage chunk: empty `choices`, populated `usage`.
+            if let Some(usage) = value.get("usage").filter(|u| u.is_object()) {
+                if let Some(ct) = usage.get("completion_tokens").and_then(|n| n.as_u64()) {
+                    server_completion_tokens = Some(u32::try_from(ct).unwrap_or(u32::MAX));
+                }
+                if let Some(pt) = usage.get("prompt_tokens").and_then(|n| n.as_u64()) {
+                    server_prompt_tokens = Some(u32::try_from(pt).unwrap_or(u32::MAX));
+                }
+            }
             let delta = value
                 .get("choices")
                 .and_then(|c| c.get(0))
@@ -320,7 +344,7 @@ async fn run_trial(
                     if first_token_at.is_none() {
                         first_token_at = Some(Instant::now());
                     } else {
-                        tokens_seen += 1;
+                        chunks_after_first += 1;
                     }
                 }
             }
@@ -332,17 +356,30 @@ async fn run_trial(
         first_token_at.ok_or_else(|| anyhow::anyhow!("no streamed tokens received from server"))?;
     let ttft_ms = first_at.duration_since(started).as_secs_f64() * 1000.0;
     let after_first = total_elapsed.saturating_sub(first_at.duration_since(started));
-    let decode_tokps = if after_first.as_secs_f64() > 0.0 && tokens_seen > 0 {
-        f64::from(tokens_seen) / after_first.as_secs_f64()
+
+    // Prefer server-reported completion_tokens. Fall back to SSE-chunk count
+    // only when the server omits the usage chunk (legacy / non-higgs backends
+    // that don't honor `stream_options.include_usage`).
+    let tokens_after_first = match server_completion_tokens {
+        // server reports total completion tokens; subtract one for the first
+        // visible token (already counted as TTFT, not part of decode wall).
+        Some(total) => total.saturating_sub(1),
+        None => chunks_after_first,
+    };
+    let decode_tokps = if after_first.as_secs_f64() > 0.0 && tokens_after_first > 0 {
+        f64::from(tokens_after_first) / after_first.as_secs_f64()
     } else {
         0.0
     };
 
+    let total_tokens = server_completion_tokens.unwrap_or(chunks_after_first + 1);
+    let _ = server_prompt_tokens; // currently unused; surface in future result schema.
+
     Ok(TrialResult {
         ttft_ms,
         decode_tokps,
-        tokens_after_first: tokens_seen,
-        total_tokens: tokens_seen + 1,
+        tokens_after_first,
+        total_tokens,
         wall_ms: total_elapsed.as_secs_f64() * 1000.0,
     })
 }

--- a/crates/higgs-bench/src/bin/bench_decode.rs
+++ b/crates/higgs-bench/src/bin/bench_decode.rs
@@ -150,6 +150,10 @@ fn main() -> ExitCode {
 }
 
 async fn run(args: Args) -> Result<()> {
+    if args.trials == 0 {
+        anyhow::bail!("--trials must be >= 1");
+    }
+
     let mut metadata = RunMetadata::capture("bench_decode");
     let started = Instant::now();
 
@@ -305,57 +309,37 @@ async fn run_trial(
     // Server-reported token counts from the terminal `usage` chunk (preferred).
     let mut server_completion_tokens: Option<u32> = None;
     let mut server_prompt_tokens: Option<u32> = None;
-    let mut buf = String::new();
+    // Byte buffer so multibyte UTF-8 sequences split across network chunks
+    // aren't corrupted by a per-chunk lossy decode.
+    let mut buf: Vec<u8> = Vec::new();
 
     while let Some(chunk) = stream.next().await {
         let chunk = chunk.context("read SSE chunk")?;
-        buf.push_str(&String::from_utf8_lossy(&chunk));
+        buf.extend_from_slice(&chunk);
 
-        while let Some(idx) = buf.find('\n') {
-            let line: String = buf.drain(..=idx).collect();
-            let line = line.trim();
-            if line.is_empty() || !line.starts_with("data:") {
-                continue;
-            }
-            let data = line[5..].trim();
-            if data == "[DONE]" {
-                continue;
-            }
-            let value: serde_json::Value = match serde_json::from_str(data) {
-                Ok(v) => v,
-                Err(_) => continue,
-            };
-            // Terminal usage chunk: empty `choices`, populated `usage`.
-            if let Some(usage) = value.get("usage").filter(|u| u.is_object()) {
-                if let Some(ct) = usage
-                    .get("completion_tokens")
-                    .and_then(serde_json::Value::as_u64)
-                {
-                    server_completion_tokens = Some(u32::try_from(ct).unwrap_or(u32::MAX));
-                }
-                if let Some(pt) = usage
-                    .get("prompt_tokens")
-                    .and_then(serde_json::Value::as_u64)
-                {
-                    server_prompt_tokens = Some(u32::try_from(pt).unwrap_or(u32::MAX));
-                }
-            }
-            let delta = value
-                .get("choices")
-                .and_then(|c| c.get(0))
-                .and_then(|c| c.get("delta"))
-                .and_then(|d| d.get("content"))
-                .and_then(|s| s.as_str());
-            if let Some(s) = delta {
-                if !s.is_empty() {
-                    if first_token_at.is_none() {
-                        first_token_at = Some(Instant::now());
-                    } else {
-                        chunks_after_first += 1;
-                    }
-                }
-            }
+        while let Some(idx) = buf.iter().position(|&b| b == b'\n') {
+            let line_bytes: Vec<u8> = buf.drain(..=idx).collect();
+            handle_sse_line(
+                &line_bytes,
+                &mut first_token_at,
+                &mut chunks_after_first,
+                &mut server_completion_tokens,
+                &mut server_prompt_tokens,
+            );
         }
+    }
+
+    // Some servers close the stream without a trailing newline on the final
+    // `data:` line. Flush whatever's left so we don't drop the terminal usage
+    // chunk silently.
+    if !buf.is_empty() {
+        handle_sse_line(
+            &buf,
+            &mut first_token_at,
+            &mut chunks_after_first,
+            &mut server_completion_tokens,
+            &mut server_prompt_tokens,
+        );
     }
 
     let total_elapsed = started.elapsed();
@@ -386,4 +370,56 @@ async fn run_trial(
         total_tokens,
         wall_ms: total_elapsed.as_secs_f64() * 1000.0,
     })
+}
+
+/// Parse one raw SSE line (without trailing newline) and update the rolling
+/// counters. Tolerates non-UTF-8 prefixes, blank lines, and `[DONE]`.
+fn handle_sse_line(
+    line_bytes: &[u8],
+    first_token_at: &mut Option<Instant>,
+    chunks_after_first: &mut u32,
+    server_completion_tokens: &mut Option<u32>,
+    server_prompt_tokens: &mut Option<u32>,
+) {
+    let line = String::from_utf8_lossy(line_bytes);
+    let line = line.trim();
+    if line.is_empty() || !line.starts_with("data:") {
+        return;
+    }
+    let data = line[5..].trim();
+    if data == "[DONE]" {
+        return;
+    }
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(data) else {
+        return;
+    };
+    if let Some(usage) = value.get("usage").filter(|u| u.is_object()) {
+        if let Some(ct) = usage
+            .get("completion_tokens")
+            .and_then(serde_json::Value::as_u64)
+        {
+            *server_completion_tokens = Some(u32::try_from(ct).unwrap_or(u32::MAX));
+        }
+        if let Some(pt) = usage
+            .get("prompt_tokens")
+            .and_then(serde_json::Value::as_u64)
+        {
+            *server_prompt_tokens = Some(u32::try_from(pt).unwrap_or(u32::MAX));
+        }
+    }
+    let delta = value
+        .get("choices")
+        .and_then(|c| c.get(0))
+        .and_then(|c| c.get("delta"))
+        .and_then(|d| d.get("content"))
+        .and_then(|s| s.as_str());
+    if let Some(s) = delta {
+        if !s.is_empty() {
+            if first_token_at.is_none() {
+                *first_token_at = Some(Instant::now());
+            } else {
+                *chunks_after_first += 1;
+            }
+        }
+    }
 }

--- a/crates/higgs-bench/src/bin/bench_decode.rs
+++ b/crates/higgs-bench/src/bin/bench_decode.rs
@@ -1,0 +1,348 @@
+#![allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::print_stderr,
+    clippy::as_conversions,
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::indexing_slicing,
+    clippy::shadow_unrelated,
+    clippy::shadow_reuse,
+    clippy::shadow_same
+)]
+//! `bench_decode` drives a running higgs server over HTTP and reports
+//! per-trial decode tok/s and TTFT (time to first token).
+
+use std::process::ExitCode;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use futures::StreamExt;
+use higgs_bench::{
+    BenchOutput, ModelInfo, OutputFormat, RunMetadata, default_manifest_path, format_json,
+    format_markdown, models, persist_result, server, stats,
+};
+use serde::Serialize;
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "bench_decode",
+    about = "Measure decode tok/s and TTFT against a running higgs server",
+    version
+)]
+struct Args {
+    /// Port the higgs server is listening on.
+    #[arg(long, default_value_t = 8899)]
+    port: u16,
+
+    /// Host the higgs server is listening on.
+    #[arg(long, default_value = "127.0.0.1")]
+    host: String,
+
+    /// Model key from `benchmarks/models.toml`.
+    #[arg(long)]
+    model: String,
+
+    /// Override the manifest path.
+    #[arg(long)]
+    manifest: Option<std::path::PathBuf>,
+
+    /// Maximum tokens to generate per trial.
+    #[arg(long, default_value_t = 200)]
+    max_tokens: u32,
+
+    /// Number of warmup trials (not measured).
+    #[arg(long, default_value_t = 1)]
+    warmup: u32,
+
+    /// Number of measured trials.
+    #[arg(long, default_value_t = 5)]
+    trials: u32,
+
+    #[arg(long, default_value_t = 0.7)]
+    temperature: f32,
+
+    #[arg(long)]
+    top_k: Option<u32>,
+
+    #[arg(long)]
+    top_p: Option<f32>,
+
+    #[arg(long)]
+    repetition_penalty: Option<f32>,
+
+    #[arg(long)]
+    frequency_penalty: Option<f32>,
+
+    /// Prompt to send. Defaults to a short fixed prompt.
+    #[arg(long)]
+    prompt: Option<String>,
+
+    /// Output format (json | markdown).
+    #[arg(long, value_enum, default_value_t = OutputFormat::Json)]
+    format: OutputFormat,
+
+    /// Skip the readiness probe and start measuring immediately.
+    #[arg(long)]
+    no_wait: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct Params {
+    host: String,
+    port: u16,
+    model_key: String,
+    model_path: String,
+    max_tokens: u32,
+    warmup: u32,
+    trials: u32,
+    temperature: f32,
+    top_k: Option<u32>,
+    top_p: Option<f32>,
+    repetition_penalty: Option<f32>,
+    frequency_penalty: Option<f32>,
+    prompt: String,
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct TrialResult {
+    ttft_ms: f64,
+    decode_tokps: f64,
+    tokens_after_first: u32,
+    total_tokens: u32,
+    wall_ms: f64,
+}
+
+#[derive(Debug, Serialize)]
+struct Results {
+    trials: Vec<TrialResult>,
+    ttft_ms_mean: f64,
+    ttft_ms_median: f64,
+    ttft_ms_p95: f64,
+    ttft_ms_stdev: f64,
+    decode_tokps_mean: f64,
+    decode_tokps_median: f64,
+    decode_tokps_p95: f64,
+    decode_tokps_stdev: f64,
+}
+
+const DEFAULT_PROMPT: &str = "What is 2+2? Answer in one word.";
+
+fn main() -> ExitCode {
+    let args = Args::parse();
+    let runtime = match tokio::runtime::Runtime::new() {
+        Ok(rt) => rt,
+        Err(e) => {
+            eprintln!("error: failed to start tokio runtime: {e}");
+            return ExitCode::from(2);
+        }
+    };
+    match runtime.block_on(run(args)) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("error: {e:#}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+async fn run(args: Args) -> Result<()> {
+    let mut metadata = RunMetadata::capture("bench_decode");
+    let started = Instant::now();
+
+    let manifest_path = args.manifest.clone().unwrap_or_else(default_manifest_path);
+    let model = models::find_by_key(&manifest_path, &args.model)?;
+    metadata.model = Some(ModelInfo {
+        key: model.key.clone(),
+        path: model.path.clone(),
+        quantization: model.quantization.clone(),
+        approx_size_gb: model.approx_size_gb,
+    });
+
+    let base_url = format!("http://{}:{}", args.host, args.port);
+    if !args.no_wait {
+        server::wait_until_ready(&base_url, Duration::from_secs(30))
+            .await
+            .with_context(|| {
+                format!(
+                    "higgs server not reachable at {base_url}; start it with `higgs serve --port {}`",
+                    args.port
+                )
+            })?;
+    }
+
+    let prompt = args
+        .prompt
+        .clone()
+        .unwrap_or_else(|| DEFAULT_PROMPT.to_owned());
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(600))
+        .build()?;
+
+    for i in 0..args.warmup {
+        eprintln!("[warmup {}/{}]", i + 1, args.warmup);
+        let _ = run_trial(&client, &base_url, &model.path, &prompt, &args).await?;
+    }
+
+    let mut trials = Vec::with_capacity(args.trials as usize);
+    for i in 0..args.trials {
+        eprintln!("[trial  {}/{}]", i + 1, args.trials);
+        let trial = run_trial(&client, &base_url, &model.path, &prompt, &args).await?;
+        trials.push(trial);
+    }
+
+    let ttft: Vec<f64> = trials.iter().map(|t| t.ttft_ms).collect();
+    let dec: Vec<f64> = trials.iter().map(|t| t.decode_tokps).collect();
+    let results = Results {
+        trials: trials.clone(),
+        ttft_ms_mean: stats::mean(&ttft),
+        ttft_ms_median: stats::median(&ttft),
+        ttft_ms_p95: stats::p95(&ttft),
+        ttft_ms_stdev: stats::stdev(&ttft),
+        decode_tokps_mean: stats::mean(&dec),
+        decode_tokps_median: stats::median(&dec),
+        decode_tokps_p95: stats::p95(&dec),
+        decode_tokps_stdev: stats::stdev(&dec),
+    };
+
+    metadata.duration_ms = started.elapsed().as_millis() as u64;
+
+    let params = Params {
+        host: args.host.clone(),
+        port: args.port,
+        model_key: model.key.clone(),
+        model_path: model.path.clone(),
+        max_tokens: args.max_tokens,
+        warmup: args.warmup,
+        trials: args.trials,
+        temperature: args.temperature,
+        top_k: args.top_k,
+        top_p: args.top_p,
+        repetition_penalty: args.repetition_penalty,
+        frequency_penalty: args.frequency_penalty,
+        prompt,
+    };
+
+    let output = BenchOutput {
+        metadata,
+        params,
+        results,
+    };
+
+    let path = persist_result(&output)?;
+    eprintln!("[persisted] {}", path.display());
+
+    let rendered = match args.format {
+        OutputFormat::Json => format_json(&output)?,
+        OutputFormat::Markdown => format_markdown(&output)?,
+    };
+    println!("{rendered}");
+
+    Ok(())
+}
+
+async fn run_trial(
+    client: &reqwest::Client,
+    base_url: &str,
+    model_path: &str,
+    prompt: &str,
+    args: &Args,
+) -> Result<TrialResult> {
+    let mut body = serde_json::json!({
+        "model": model_path,
+        "messages": [{"role": "user", "content": prompt}],
+        "stream": true,
+        "max_tokens": args.max_tokens,
+        "temperature": args.temperature,
+    });
+    if let Some(p) = args.top_p {
+        body["top_p"] = serde_json::json!(p);
+    }
+    if let Some(k) = args.top_k {
+        body["top_k"] = serde_json::json!(k);
+    }
+    if let Some(rp) = args.repetition_penalty {
+        body["repetition_penalty"] = serde_json::json!(rp);
+    }
+    if let Some(fp) = args.frequency_penalty {
+        body["frequency_penalty"] = serde_json::json!(fp);
+    }
+
+    let url = format!("{base_url}/v1/chat/completions");
+    let started = Instant::now();
+    let resp = client
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .with_context(|| format!("POST {url}"))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        anyhow::bail!("{url} returned HTTP {status}: {text}");
+    }
+
+    let mut stream = resp.bytes_stream();
+    let mut first_token_at: Option<Instant> = None;
+    let mut tokens_seen: u32 = 0;
+    let mut buf = String::new();
+
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.context("read SSE chunk")?;
+        buf.push_str(&String::from_utf8_lossy(&chunk));
+
+        while let Some(idx) = buf.find('\n') {
+            let line: String = buf.drain(..=idx).collect();
+            let line = line.trim();
+            if line.is_empty() || !line.starts_with("data:") {
+                continue;
+            }
+            let data = line[5..].trim();
+            if data == "[DONE]" {
+                continue;
+            }
+            let value: serde_json::Value = match serde_json::from_str(data) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+            let delta = value
+                .get("choices")
+                .and_then(|c| c.get(0))
+                .and_then(|c| c.get("delta"))
+                .and_then(|d| d.get("content"))
+                .and_then(|s| s.as_str());
+            if let Some(s) = delta {
+                if !s.is_empty() {
+                    if first_token_at.is_none() {
+                        first_token_at = Some(Instant::now());
+                    } else {
+                        tokens_seen += 1;
+                    }
+                }
+            }
+        }
+    }
+
+    let total_elapsed = started.elapsed();
+    let first_at =
+        first_token_at.ok_or_else(|| anyhow::anyhow!("no streamed tokens received from server"))?;
+    let ttft_ms = first_at.duration_since(started).as_secs_f64() * 1000.0;
+    let after_first = total_elapsed.saturating_sub(first_at.duration_since(started));
+    let decode_tokps = if after_first.as_secs_f64() > 0.0 && tokens_seen > 0 {
+        f64::from(tokens_seen) / after_first.as_secs_f64()
+    } else {
+        0.0
+    };
+
+    Ok(TrialResult {
+        ttft_ms,
+        decode_tokps,
+        tokens_after_first: tokens_seen,
+        total_tokens: tokens_seen + 1,
+        wall_ms: total_elapsed.as_secs_f64() * 1000.0,
+    })
+}

--- a/crates/higgs-bench/src/bin/bench_summarize.rs
+++ b/crates/higgs-bench/src/bin/bench_summarize.rs
@@ -1,0 +1,218 @@
+#![allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::print_stderr,
+    clippy::as_conversions,
+    clippy::doc_markdown,
+    clippy::map_unwrap_or,
+    clippy::unnecessary_map_or
+)]
+//! `bench_summarize` walks `target/bench-results/` and emits a Markdown
+//! table grouped by model, with one row per (bench_name, model) pair.
+
+use std::collections::BTreeMap;
+use std::process::ExitCode;
+
+use anyhow::Result;
+use clap::Parser;
+use higgs_bench::{OutputFormat, collect_results, results_dir};
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "bench_summarize",
+    about = "Summarize persisted bench results from target/bench-results/",
+    version
+)]
+struct Args {
+    /// Filter to one bench name (e.g., `bench_decode`). Default: all.
+    #[arg(long)]
+    bench: Option<String>,
+
+    /// Filter to a specific commit (short or full SHA). Default: all.
+    #[arg(long)]
+    commit: Option<String>,
+
+    /// Output format.
+    #[arg(long, value_enum, default_value_t = OutputFormat::Markdown)]
+    format: OutputFormat,
+}
+
+fn main() -> ExitCode {
+    let args = Args::parse();
+    match run(&args) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("error: {e:#}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Row {
+    bench_name: String,
+    model_key: String,
+    model_label: String,
+    commit_short: String,
+    started_at: String,
+    headline: String,
+}
+
+fn run(args: &Args) -> Result<()> {
+    let dir = results_dir();
+    let entries = collect_results(&dir)?;
+
+    if entries.is_empty() {
+        match args.format {
+            OutputFormat::Markdown => {
+                println!("# Bench summary\n");
+                println!("_No results found in `{}`._\n", dir.display());
+                println!("Run `bench_decode` (or another bench) first to populate this directory.");
+            }
+            OutputFormat::Json => {
+                println!("{}", serde_json::json!({"results": []}));
+            }
+        }
+        return Ok(());
+    }
+
+    let mut latest: BTreeMap<(String, String), (String, Row)> = BTreeMap::new();
+
+    for entry in entries {
+        let v = &entry.value;
+        let Some(metadata) = v.get("metadata") else {
+            continue;
+        };
+        let bench_name = metadata
+            .get("bench_name")
+            .and_then(|s| s.as_str())
+            .unwrap_or("unknown")
+            .to_owned();
+        if let Some(filter) = &args.bench {
+            if &bench_name != filter {
+                continue;
+            }
+        }
+        let commit = metadata
+            .get("git_commit")
+            .and_then(|s| s.as_str())
+            .unwrap_or("")
+            .to_owned();
+        let commit_short = metadata
+            .get("git_commit_short")
+            .and_then(|s| s.as_str())
+            .unwrap_or("")
+            .to_owned();
+        if let Some(filter) = &args.commit {
+            if !commit.starts_with(filter.as_str()) && !commit_short.starts_with(filter.as_str()) {
+                continue;
+            }
+        }
+        let model_key = metadata
+            .get("model")
+            .and_then(|m| m.get("key"))
+            .and_then(|s| s.as_str())
+            .unwrap_or("no-model")
+            .to_owned();
+        let model_label = metadata
+            .get("model")
+            .and_then(|m| m.get("path"))
+            .and_then(|s| s.as_str())
+            .unwrap_or(&model_key)
+            .to_owned();
+        let started_at = metadata
+            .get("started_at")
+            .and_then(|s| s.as_str())
+            .unwrap_or("")
+            .to_owned();
+
+        let headline = headline_for(&bench_name, v);
+
+        let row = Row {
+            bench_name: bench_name.clone(),
+            model_key: model_key.clone(),
+            model_label,
+            commit_short,
+            started_at: started_at.clone(),
+            headline,
+        };
+
+        let key = (model_key, bench_name);
+        let keep = latest
+            .get(&key)
+            .map_or(true, |(prev_ts, _)| started_at > *prev_ts);
+        if keep {
+            latest.insert(key, (started_at, row));
+        }
+    }
+
+    let mut by_model: BTreeMap<String, Vec<Row>> = BTreeMap::new();
+    for ((model, _bench), (_ts, row)) in latest {
+        by_model.entry(model).or_default().push(row);
+    }
+
+    match args.format {
+        OutputFormat::Markdown => render_markdown(&by_model),
+        OutputFormat::Json => render_json(&by_model)?,
+    }
+    Ok(())
+}
+
+fn headline_for(bench_name: &str, value: &serde_json::Value) -> String {
+    let Some(results) = value.get("results") else {
+        return String::new();
+    };
+    if bench_name == "bench_decode" {
+        let ttft = results
+            .get("ttft_ms_median")
+            .and_then(serde_json::Value::as_f64)
+            .unwrap_or(0.0);
+        let dec = results
+            .get("decode_tokps_median")
+            .and_then(serde_json::Value::as_f64)
+            .unwrap_or(0.0);
+        return format!("{dec:.1} tok/s decode, {ttft:.0} ms TTFT");
+    }
+    String::new()
+}
+
+fn render_markdown(by_model: &BTreeMap<String, Vec<Row>>) {
+    println!("# Bench summary\n");
+    for (model, rows) in by_model {
+        let label = rows
+            .first()
+            .map(|r| r.model_label.as_str())
+            .unwrap_or(model.as_str());
+        println!("## {model}");
+        println!("\n_path: `{label}`_\n");
+        println!("| Bench | Headline | Commit | When |");
+        println!("|---|---|---|---|");
+        for row in rows {
+            println!(
+                "| {} | {} | {} | {} |",
+                row.bench_name, row.headline, row.commit_short, row.started_at
+            );
+        }
+        println!();
+    }
+}
+
+fn render_json(by_model: &BTreeMap<String, Vec<Row>>) -> Result<()> {
+    let json = serde_json::json!({
+        "models": by_model.iter().map(|(model, rows)| {
+            serde_json::json!({
+                "model_key": model,
+                "rows": rows.iter().map(|r| serde_json::json!({
+                    "bench_name": r.bench_name,
+                    "model_key": r.model_key,
+                    "commit": r.commit_short,
+                    "started_at": r.started_at,
+                    "headline": r.headline,
+                })).collect::<Vec<_>>(),
+            })
+        }).collect::<Vec<_>>(),
+    });
+    println!("{}", serde_json::to_string_pretty(&json)?);
+    Ok(())
+}

--- a/crates/higgs-bench/src/bin/bench_summarize.rs
+++ b/crates/higgs-bench/src/bin/bench_summarize.rs
@@ -59,6 +59,7 @@ struct Row {
     headline: String,
 }
 
+#[allow(clippy::too_many_lines)]
 fn run(args: &Args) -> Result<()> {
     let dir = results_dir();
     let entries = collect_results(&dir)?;
@@ -150,6 +151,19 @@ fn run(args: &Args) -> Result<()> {
     let mut by_model: BTreeMap<String, Vec<Row>> = BTreeMap::new();
     for ((model, _bench), (_ts, row)) in latest {
         by_model.entry(model).or_default().push(row);
+    }
+
+    if by_model.is_empty() {
+        match args.format {
+            OutputFormat::Markdown => {
+                println!("# Bench summary\n");
+                println!("_No results matched the provided filters._\n");
+            }
+            OutputFormat::Json => {
+                println!("{}", serde_json::json!({"results": []}));
+            }
+        }
+        return Ok(());
     }
 
     match args.format {

--- a/crates/higgs-bench/src/lib.rs
+++ b/crates/higgs-bench/src/lib.rs
@@ -1,0 +1,393 @@
+#![allow(
+    clippy::as_conversions,
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
+//! Shared infrastructure for higgs end-to-end benches.
+//!
+//! Every bench binary in this crate produces output that conforms to the
+//! `BenchOutput<P, R>` schema: a `metadata` block describing the run host
+//! and git state, a `params` block describing the bench inputs, and a
+//! `results` block with the measurements. See `docs/benchmarking.md`.
+
+pub mod models;
+pub mod server;
+pub mod stats;
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sysinfo::System;
+
+#[allow(clippy::needless_raw_string_hashes, clippy::doc_markdown)]
+mod built_info {
+    include!(concat!(env!("OUT_DIR"), "/built.rs"));
+}
+
+/// Bench-crate version (from `CARGO_PKG_VERSION` at compile time).
+pub const BENCH_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Returns the short git commit hash captured at compile time.
+#[must_use]
+pub fn git_commit_short() -> String {
+    built_info::GIT_COMMIT_HASH_SHORT
+        .map_or_else(|| "unknown".into(), std::string::ToString::to_string)
+}
+
+/// Returns the full git commit hash captured at compile time.
+#[must_use]
+pub fn git_commit() -> String {
+    built_info::GIT_COMMIT_HASH.map_or_else(|| "unknown".into(), std::string::ToString::to_string)
+}
+
+/// Returns whether the working tree was dirty at compile time.
+#[must_use]
+pub fn git_dirty() -> bool {
+    built_info::GIT_DIRTY.unwrap_or(false)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HostInfo {
+    pub hostname: String,
+    pub os: String,
+    pub cpu: String,
+    pub ram_gb: f64,
+    pub gpu: Option<String>,
+}
+
+impl HostInfo {
+    #[must_use]
+    pub fn capture() -> Self {
+        let mut sys = System::new();
+        sys.refresh_memory();
+        sys.refresh_cpu_all();
+
+        let hostname = System::host_name().unwrap_or_else(|| "unknown".into());
+        let os_name = System::name().unwrap_or_else(|| "unknown".into());
+        let os_version = System::os_version().unwrap_or_else(|| "?".into());
+        let kernel = System::kernel_version().unwrap_or_else(|| "?".into());
+        let os = format!("{os_name} {os_version} ({kernel})");
+
+        let cpu = sys
+            .cpus()
+            .first()
+            .map_or_else(|| "unknown".into(), |c| c.brand().trim().to_owned());
+
+        let total_kb = sys.total_memory();
+        // sysinfo returns bytes since 0.30.
+        let ram_gb = (total_kb as f64) / 1_073_741_824.0_f64;
+
+        Self {
+            hostname,
+            os,
+            cpu,
+            ram_gb: round2(ram_gb),
+            gpu: detect_gpu(),
+        }
+    }
+}
+
+fn round2(v: f64) -> f64 {
+    (v * 100.0).round() / 100.0
+}
+
+fn detect_gpu() -> Option<String> {
+    // On Apple Silicon the GPU label is "Apple <CPU brand>" — sysinfo
+    // doesn't expose GPU info portably. Leave as best-effort.
+    cfg!(target_os = "macos").then(|| "Apple Silicon (MLX)".into())
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelInfo {
+    pub key: String,
+    pub path: String,
+    pub quantization: String,
+    pub approx_size_gb: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunMetadata {
+    pub bench_name: String,
+    pub bench_version: String,
+    pub higgs_version: Option<String>,
+    pub git_commit: String,
+    pub git_commit_short: String,
+    pub git_dirty: bool,
+    pub started_at: DateTime<Utc>,
+    pub duration_ms: u64,
+    pub host: HostInfo,
+    pub mlx_version: Option<String>,
+    pub model: Option<ModelInfo>,
+    pub args: Vec<String>,
+}
+
+impl RunMetadata {
+    /// Snapshots host + git + argv at bench startup. Caller fills in
+    /// `duration_ms`, `model`, and `higgs_version` once they're known.
+    #[must_use]
+    pub fn capture<S: Into<String>>(bench_name: S) -> Self {
+        Self {
+            bench_name: bench_name.into(),
+            bench_version: BENCH_VERSION.into(),
+            higgs_version: None,
+            git_commit: git_commit(),
+            git_commit_short: git_commit_short(),
+            git_dirty: git_dirty(),
+            started_at: Utc::now(),
+            duration_ms: 0,
+            host: HostInfo::capture(),
+            mlx_version: None,
+            model: None,
+            args: std::env::args().collect(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BenchOutput<P, R>
+where
+    P: Serialize,
+    R: Serialize,
+{
+    pub metadata: RunMetadata,
+    pub params: P,
+    pub results: R,
+}
+
+/// Serializes the output as pretty JSON.
+pub fn format_json<P, R>(output: &BenchOutput<P, R>) -> Result<String>
+where
+    P: Serialize,
+    R: Serialize,
+{
+    serde_json::to_string_pretty(output).context("serialize bench output to JSON")
+}
+
+/// Renders a human-readable Markdown report.
+///
+/// The results are rendered as a one-row-per-key table from a JSON
+/// flattening of `results` — benches that want richer tables should
+/// produce their own `Markdown` and return it here.
+pub fn format_markdown<P, R>(output: &BenchOutput<P, R>) -> Result<String>
+where
+    P: Serialize,
+    R: Serialize,
+{
+    use std::fmt::Write as _;
+    let meta = &output.metadata;
+    let mut s = String::new();
+    writeln!(s, "# {} run\n", meta.bench_name)?;
+
+    s.push_str("## How to reproduce\n\n");
+    s.push_str("```bash\n");
+    s.push_str(&shell_quote_argv(&meta.args));
+    s.push_str("\n```\n\n");
+
+    s.push_str("## Environment\n\n");
+    s.push_str("| Field | Value |\n|---|---|\n");
+    writeln!(s, "| host | {} |", meta.host.hostname)?;
+    writeln!(s, "| os | {} |", meta.host.os)?;
+    writeln!(s, "| cpu | {} |", meta.host.cpu)?;
+    writeln!(s, "| ram_gb | {} |", meta.host.ram_gb)?;
+    if let Some(gpu) = &meta.host.gpu {
+        writeln!(s, "| gpu | {gpu} |")?;
+    }
+    writeln!(
+        s,
+        "| git_commit | {}{} |",
+        meta.git_commit_short,
+        if meta.git_dirty { " (dirty)" } else { "" }
+    )?;
+    writeln!(s, "| started_at | {} |", meta.started_at.to_rfc3339())?;
+    writeln!(s, "| duration_ms | {} |", meta.duration_ms)?;
+    if let Some(model) = &meta.model {
+        writeln!(
+            s,
+            "| model | {} ({}, ~{} GB) |",
+            model.key, model.quantization, model.approx_size_gb
+        )?;
+    }
+    s.push('\n');
+
+    s.push_str("## Params\n\n");
+    s.push_str("```json\n");
+    s.push_str(&serde_json::to_string_pretty(&output.params)?);
+    s.push_str("\n```\n\n");
+
+    s.push_str("## Results\n\n");
+    let results_json = serde_json::to_value(&output.results)?;
+    if let Some(map) = results_json.as_object() {
+        s.push_str("| Metric | Value |\n|---|---|\n");
+        for (k, v) in map {
+            writeln!(s, "| {k} | {} |", render_json_value(v))?;
+        }
+    } else {
+        s.push_str("```json\n");
+        s.push_str(&serde_json::to_string_pretty(&results_json)?);
+        s.push_str("\n```\n");
+    }
+
+    Ok(s)
+}
+
+fn render_json_value(v: &serde_json::Value) -> String {
+    match v {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Null => "null".into(),
+        serde_json::Value::Array(_) | serde_json::Value::Object(_) => v.to_string(),
+    }
+}
+
+fn shell_quote_argv(args: &[String]) -> String {
+    args.iter()
+        .map(|a| {
+            if a.chars()
+                .all(|c| c.is_ascii_alphanumeric() || "-_./=".contains(c))
+            {
+                a.clone()
+            } else {
+                format!("'{}'", a.replace('\'', "'\\''"))
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Persists the bench output to
+/// `target/bench-results/<bench_name>/<commit>__<model>__<ts>.json`.
+/// Returns the path written.
+pub fn persist_result<P, R>(output: &BenchOutput<P, R>) -> Result<PathBuf>
+where
+    P: Serialize,
+    R: Serialize,
+{
+    let dir = results_dir().join(&output.metadata.bench_name);
+    fs::create_dir_all(&dir).with_context(|| format!("create results dir {}", dir.display()))?;
+
+    let model_key = output
+        .metadata
+        .model
+        .as_ref()
+        .map_or_else(|| "no-model".into(), |m| m.key.clone());
+    let ts = output.metadata.started_at.format("%Y%m%dT%H%M%SZ");
+    let filename = format!(
+        "{}__{}__{}.json",
+        output.metadata.git_commit_short, model_key, ts
+    );
+    let path = dir.join(filename);
+
+    let json = serde_json::to_string_pretty(output)?;
+    fs::write(&path, json).with_context(|| format!("write result file {}", path.display()))?;
+    Ok(path)
+}
+
+/// Returns the absolute path to `<workspace>/target/bench-results/`. Falls
+/// back to `target/bench-results/` relative to the current directory if
+/// the workspace root cannot be located.
+#[must_use]
+pub fn results_dir() -> PathBuf {
+    workspace_root()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("target")
+        .join("bench-results")
+}
+
+fn workspace_root() -> Option<PathBuf> {
+    // CARGO_MANIFEST_DIR points at this crate; the workspace root is two
+    // levels up (crates/higgs-bench → ..).
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let candidate = manifest_dir.parent()?.parent()?;
+    candidate
+        .join("Cargo.toml")
+        .exists()
+        .then(|| candidate.to_owned())
+}
+
+/// Looks up a model entry from the workspace `benchmarks/models.toml`.
+/// Convenience wrapper used by binary entrypoints.
+pub fn load_default_manifest() -> Result<models::Manifest> {
+    let path = workspace_root()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("benchmarks")
+        .join("models.toml");
+    models::load_manifest(&path)
+}
+
+/// Returns the path to the workspace `benchmarks/models.toml`.
+#[must_use]
+pub fn default_manifest_path() -> PathBuf {
+    workspace_root()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("benchmarks")
+        .join("models.toml")
+}
+
+/// Convenience: write `JSON` or `markdown` to stdout depending on `format`.
+pub fn render<P, R>(output: &BenchOutput<P, R>, format: OutputFormat) -> Result<String>
+where
+    P: Serialize,
+    R: Serialize,
+{
+    match format {
+        OutputFormat::Json => format_json(output),
+        OutputFormat::Markdown => format_markdown(output),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum OutputFormat {
+    Json,
+    Markdown,
+}
+
+impl std::fmt::Display for OutputFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Json => f.write_str("json"),
+            Self::Markdown => f.write_str("markdown"),
+        }
+    }
+}
+
+/// Walks `target/bench-results/` and returns one entry per `.json` file.
+pub fn collect_results(root: &Path) -> Result<Vec<StoredResult>> {
+    let mut out = Vec::new();
+    if !root.exists() {
+        return Ok(out);
+    }
+    for bench_entry_res in fs::read_dir(root)? {
+        let Ok(bench_entry) = bench_entry_res else {
+            continue;
+        };
+        if !bench_entry.file_type()?.is_dir() {
+            continue;
+        }
+        for file_entry_res in fs::read_dir(bench_entry.path())? {
+            let Ok(file_entry) = file_entry_res else {
+                continue;
+            };
+            let path = file_entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            let body = fs::read_to_string(&path)?;
+            if let Ok(value) = serde_json::from_str::<serde_json::Value>(&body) {
+                out.push(StoredResult { path, value });
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// One row of a persisted bench result (raw JSON).
+#[derive(Debug, Clone)]
+pub struct StoredResult {
+    pub path: PathBuf,
+    pub value: serde_json::Value,
+}

--- a/crates/higgs-bench/src/lib.rs
+++ b/crates/higgs-bench/src/lib.rs
@@ -34,14 +34,13 @@ pub const BENCH_VERSION: &str = env!("CARGO_PKG_VERSION");
 /// Returns the short git commit hash captured at compile time.
 #[must_use]
 pub fn git_commit_short() -> String {
-    built_info::GIT_COMMIT_HASH_SHORT
-        .map_or_else(|| "unknown".into(), std::string::ToString::to_string)
+    built_info::GIT_COMMIT_HASH_SHORT.map_or_else(|| "unknown".into(), str::to_owned)
 }
 
 /// Returns the full git commit hash captured at compile time.
 #[must_use]
 pub fn git_commit() -> String {
-    built_info::GIT_COMMIT_HASH.map_or_else(|| "unknown".into(), std::string::ToString::to_string)
+    built_info::GIT_COMMIT_HASH.map_or_else(|| "unknown".into(), str::to_owned)
 }
 
 /// Returns whether the working tree was dirty at compile time.
@@ -50,12 +49,18 @@ pub fn git_dirty() -> bool {
     built_info::GIT_DIRTY.unwrap_or(false)
 }
 
+/// Information about the host machine where the benchmark ran.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HostInfo {
+    /// Machine hostname.
     pub hostname: String,
+    /// Operating system name, version, and kernel.
     pub os: String,
+    /// CPU brand string.
     pub cpu: String,
+    /// Total RAM in gigabytes.
     pub ram_gb: f64,
+    /// GPU identifier, if detected.
     pub gpu: Option<String>,
 }
 
@@ -77,9 +82,9 @@ impl HostInfo {
             .first()
             .map_or_else(|| "unknown".into(), |c| c.brand().trim().to_owned());
 
-        let total_kb = sys.total_memory();
-        // sysinfo returns bytes since 0.30.
-        let ram_gb = (total_kb as f64) / 1_073_741_824.0_f64;
+        // sysinfo's `total_memory()` returns bytes since 0.30.
+        let total_bytes = sys.total_memory();
+        let ram_gb = (total_bytes as f64) / 1_073_741_824.0_f64;
 
         Self {
             hostname,
@@ -96,32 +101,52 @@ fn round2(v: f64) -> f64 {
 }
 
 fn detect_gpu() -> Option<String> {
-    // On Apple Silicon the GPU label is "Apple <CPU brand>" — sysinfo
-    // doesn't expose GPU info portably. Leave as best-effort.
-    cfg!(target_os = "macos").then(|| "Apple Silicon (MLX)".into())
+    // sysinfo doesn't expose GPU info portably; only label macOS+aarch64 as
+    // Apple Silicon. Intel Macs return None rather than getting mislabeled.
+    (cfg!(target_os = "macos") && std::env::consts::ARCH == "aarch64")
+        .then(|| "Apple Silicon (MLX)".into())
 }
 
+/// The model under test, captured into bench output for reproducibility.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelInfo {
+    /// Manifest key (e.g., `qwen3-1.7B-4bit`).
     pub key: String,
+    /// Model path used (`HuggingFace` repo ID or local path).
     pub path: String,
+    /// Quantization format (e.g., `4bit`).
     pub quantization: String,
+    /// Approximate model size in gigabytes.
     pub approx_size_gb: f64,
 }
 
+/// Reproducibility metadata recorded with every bench run.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RunMetadata {
+    /// Bench binary name (e.g., `bench_decode`).
     pub bench_name: String,
+    /// `higgs-bench` crate version.
     pub bench_version: String,
+    /// `higgs` server version under test, when known.
     pub higgs_version: Option<String>,
+    /// Full git commit captured at compile time.
     pub git_commit: String,
+    /// Short git commit (first 7 chars).
     pub git_commit_short: String,
+    /// Whether the working tree was dirty at compile time.
     pub git_dirty: bool,
+    /// RFC3339 UTC timestamp when the bench run started.
     pub started_at: DateTime<Utc>,
+    /// Wall-clock time of the entire bench run, in milliseconds.
     pub duration_ms: u64,
+    /// Host machine information (CPU, RAM, OS, GPU).
     pub host: HostInfo,
+    /// MLX runtime version when known.
     pub mlx_version: Option<String>,
+    /// Model under test; `None` for benches that don't pin to a model.
     pub model: Option<ModelInfo>,
+    /// Full argv that produced this run (used for the "How to reproduce"
+    /// block in `--format markdown`).
     pub args: Vec<String>,
 }
 
@@ -148,13 +173,17 @@ impl RunMetadata {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// Standardized output envelope produced by every bench binary.
 pub struct BenchOutput<P, R>
 where
     P: Serialize,
     R: Serialize,
 {
+    /// Reproducibility metadata (host, model, git, argv, timing).
     pub metadata: RunMetadata,
+    /// Bench-specific parameters (CLI flags, prompt, etc.).
     pub params: P,
+    /// Bench-specific results (numbers, derived stats).
     pub results: R,
 }
 
@@ -387,7 +416,10 @@ pub fn collect_results(root: &Path) -> Result<Vec<StoredResult>> {
 
 /// One row of a persisted bench result (raw JSON).
 #[derive(Debug, Clone)]
+/// One persisted JSON result, returned by `collect_results`.
 pub struct StoredResult {
+    /// Path to the JSON file under `target/bench-results/<bench>/...`.
     pub path: PathBuf,
+    /// Parsed JSON content.
     pub value: serde_json::Value,
 }

--- a/crates/higgs-bench/src/lib.rs
+++ b/crates/higgs-bench/src/lib.rs
@@ -299,12 +299,32 @@ where
     let dir = results_dir().join(&output.metadata.bench_name);
     fs::create_dir_all(&dir).with_context(|| format!("create results dir {}", dir.display()))?;
 
-    let model_key = output
-        .metadata
-        .model
-        .as_ref()
-        .map_or_else(|| "no-model".into(), |m| m.key.clone());
-    let ts = output.metadata.started_at.format("%Y%m%dT%H%M%SZ");
+    // Sanitize the model key before using it in the path: `--manifest`
+    // could feed in a key containing `/` or `..` and the filename gets
+    // joined into `target/bench-results/<bench>/`. Map anything outside
+    // [A-Za-z0-9._-] to `_`.
+    let model_key = output.metadata.model.as_ref().map_or_else(
+        || "no-model".to_owned(),
+        |m| {
+            m.key
+                .chars()
+                .map(|c| {
+                    if c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_') {
+                        c
+                    } else {
+                        '_'
+                    }
+                })
+                .collect()
+        },
+    );
+    // Include subsecond resolution so same-second reruns of the same
+    // (commit, model, bench) don't collide and overwrite each other.
+    let ts = format!(
+        "{}-{:03}",
+        output.metadata.started_at.format("%Y%m%dT%H%M%SZ"),
+        output.metadata.started_at.timestamp_subsec_millis()
+    );
     let filename = format!(
         "{}__{}__{}.json",
         output.metadata.git_commit_short, model_key, ts

--- a/crates/higgs-bench/src/models.rs
+++ b/crates/higgs-bench/src/models.rs
@@ -1,0 +1,65 @@
+//! Model manifest loader for `benchmarks/models.toml`.
+//!
+//! Each `[[models]]` entry describes one model that the benches can target.
+//! Adding a new model is one TOML entry; benches can filter by tag.
+
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Model {
+    pub key: String,
+    pub label: String,
+    pub path: String,
+    pub quantization: String,
+    pub approx_size_gb: f64,
+    pub context: u32,
+    #[serde(default)]
+    pub tags: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Manifest {
+    #[serde(default)]
+    pub models: Vec<Model>,
+}
+
+impl Manifest {
+    #[must_use]
+    pub fn find_by_key(&self, key: &str) -> Option<&Model> {
+        self.models.iter().find(|m| m.key == key)
+    }
+
+    #[must_use]
+    pub fn find_by_tag(&self, tag: &str) -> Vec<&Model> {
+        self.models
+            .iter()
+            .filter(|m| m.tags.iter().any(|t| t == tag))
+            .collect()
+    }
+}
+
+pub fn load_manifest(path: &Path) -> Result<Manifest> {
+    let body = fs::read_to_string(path)
+        .with_context(|| format!("read model manifest at {}", path.display()))?;
+    let manifest: Manifest = toml::from_str(&body).context("parse model manifest TOML")?;
+    Ok(manifest)
+}
+
+/// Convenience for binaries: load the manifest at `path` and look up `key`.
+pub fn find_by_key(path: &Path, key: &str) -> Result<Model> {
+    let manifest = load_manifest(path)?;
+    manifest
+        .find_by_key(key)
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("model key '{key}' not found in {}", path.display()))
+}
+
+/// Convenience for binaries: load the manifest at `path` and filter by `tag`.
+pub fn find_by_tag(path: &Path, tag: &str) -> Result<Vec<Model>> {
+    let manifest = load_manifest(path)?;
+    Ok(manifest.find_by_tag(tag).into_iter().cloned().collect())
+}

--- a/crates/higgs-bench/src/models.rs
+++ b/crates/higgs-bench/src/models.rs
@@ -9,20 +9,30 @@ use std::path::Path;
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
+/// One model entry from `benchmarks/models.toml`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Model {
+    /// Unique key passed to `--model` on bench CLIs.
     pub key: String,
+    /// Human-readable display name (used in summary tables).
     pub label: String,
+    /// Model path: `HuggingFace` repo ID or absolute local path.
     pub path: String,
+    /// Quantization format, e.g. `4bit`, `3bit`.
     pub quantization: String,
+    /// Approximate model size in gigabytes.
     pub approx_size_gb: f64,
+    /// Maximum context length in tokens.
     pub context: u32,
+    /// Optional tags for filtering, e.g. `small`, `dense`, `moe`, `h2h`.
     #[serde(default)]
     pub tags: Vec<String>,
 }
 
+/// Top-level structure of `benchmarks/models.toml`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Manifest {
+    /// All model entries declared in the manifest.
     #[serde(default)]
     pub models: Vec<Model>,
 }

--- a/crates/higgs-bench/src/server.rs
+++ b/crates/higgs-bench/src/server.rs
@@ -6,9 +6,11 @@ use anyhow::{Context, Result};
 
 /// Polls `GET /health` (and falls back to `/v1/models`) until the server
 /// responds with success or `timeout` elapses.
+///
+/// Each probe is bounded by `min(remaining_deadline, 2s)` so a small overall
+/// `timeout` is honored even when the server hangs mid-handshake.
 pub async fn wait_until_ready(base_url: &str, timeout: Duration) -> Result<()> {
     let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(2))
         .build()
         .context("build readiness probe client")?;
 
@@ -17,14 +19,23 @@ pub async fn wait_until_ready(base_url: &str, timeout: Duration) -> Result<()> {
         format!("{base_url}/health"),
         format!("{base_url}/v1/models"),
     ];
+    let max_probe = Duration::from_secs(2);
 
     let mut last_err: Option<String> = None;
     while Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
         for url in &probes {
-            match client.get(url).send().await {
-                Ok(resp) if resp.status().is_success() => return Ok(()),
-                Ok(resp) => last_err = Some(format!("{url} -> HTTP {}", resp.status())),
-                Err(e) => last_err = Some(format!("{url} -> {e}")),
+            let req_timeout = remaining.min(max_probe);
+            match tokio::time::timeout(req_timeout, client.get(url).send()).await {
+                Ok(Ok(resp)) if resp.status().is_success() => return Ok(()),
+                Ok(Ok(resp)) => last_err = Some(format!("{url} -> HTTP {}", resp.status())),
+                Ok(Err(e)) => last_err = Some(format!("{url} -> {e}")),
+                Err(_) => {
+                    last_err = Some(format!("{url} -> timed out after {req_timeout:?}"));
+                }
             }
         }
         tokio::time::sleep(Duration::from_millis(250)).await;

--- a/crates/higgs-bench/src/server.rs
+++ b/crates/higgs-bench/src/server.rs
@@ -1,0 +1,38 @@
+//! Helpers for waiting on a higgs server to become ready.
+
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+
+/// Polls `GET /health` (and falls back to `/v1/models`) until the server
+/// responds with success or `timeout` elapses.
+pub async fn wait_until_ready(base_url: &str, timeout: Duration) -> Result<()> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(2))
+        .build()
+        .context("build readiness probe client")?;
+
+    let deadline = Instant::now() + timeout;
+    let probes = [
+        format!("{base_url}/health"),
+        format!("{base_url}/v1/models"),
+    ];
+
+    let mut last_err: Option<String> = None;
+    while Instant::now() < deadline {
+        for url in &probes {
+            match client.get(url).send().await {
+                Ok(resp) if resp.status().is_success() => return Ok(()),
+                Ok(resp) => last_err = Some(format!("{url} -> HTTP {}", resp.status())),
+                Err(e) => last_err = Some(format!("{url} -> {e}")),
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+
+    Err(anyhow::anyhow!(
+        "server at {base_url} did not become ready within {:?}: {}",
+        timeout,
+        last_err.unwrap_or_else(|| "no probes attempted".into())
+    ))
+}

--- a/crates/higgs-bench/src/stats.rs
+++ b/crates/higgs-bench/src/stats.rs
@@ -1,0 +1,78 @@
+#![allow(
+    clippy::as_conversions,
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
+//! Tiny statistics helpers for bench result summaries.
+
+/// Returns the arithmetic mean, or `0.0` if the slice is empty.
+#[must_use]
+pub fn mean(xs: &[f64]) -> f64 {
+    if xs.is_empty() {
+        return 0.0;
+    }
+    let sum: f64 = xs.iter().sum();
+    sum / xs.len() as f64
+}
+
+/// Returns the median (p50). For even counts, averages the two midpoints.
+#[must_use]
+pub fn median(xs: &[f64]) -> f64 {
+    percentile(xs, 50.0)
+}
+
+/// Returns the p95.
+#[must_use]
+pub fn p95(xs: &[f64]) -> f64 {
+    percentile(xs, 95.0)
+}
+
+/// Returns the population standard deviation, or `0.0` if `xs.len() < 2`.
+#[must_use]
+pub fn stdev(xs: &[f64]) -> f64 {
+    if xs.len() < 2 {
+        return 0.0;
+    }
+    let m = mean(xs);
+    let var = xs.iter().map(|x| (x - m).powi(2)).sum::<f64>() / xs.len() as f64;
+    var.sqrt()
+}
+
+/// Linear-interpolated percentile in `[0, 100]`. Returns `0.0` on empty input.
+#[must_use]
+pub fn percentile(xs: &[f64], pct: f64) -> f64 {
+    if xs.is_empty() {
+        return 0.0;
+    }
+    let mut sorted: Vec<f64> = xs.to_vec();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let p = pct.clamp(0.0, 100.0);
+    let rank = p / 100.0 * (sorted.len() as f64 - 1.0);
+    let lo = rank.floor() as usize;
+    let hi = rank.ceil() as usize;
+    let lo_v = sorted.get(lo).copied().unwrap_or(0.0);
+    let hi_v = sorted.get(hi).copied().unwrap_or(lo_v);
+    let frac = rank - rank.floor();
+    frac.mul_add(hi_v - lo_v, lo_v)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_slice_returns_zero() {
+        assert!((mean(&[]) - 0.0).abs() < f64::EPSILON);
+        assert!((median(&[]) - 0.0).abs() < f64::EPSILON);
+        assert!((p95(&[]) - 0.0).abs() < f64::EPSILON);
+        assert!((stdev(&[]) - 0.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn small_sample() {
+        let xs = [1.0, 2.0, 3.0, 4.0, 5.0];
+        assert!((mean(&xs) - 3.0).abs() < 1e-9);
+        assert!((median(&xs) - 3.0).abs() < 1e-9);
+    }
+}

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -46,6 +46,115 @@ Current examples that informed the default:
 
 That is why `auto` resolves to `balanced` for small and medium models, and `throughput` for large and huge models.
 
+## Rust bench crate (`higgs-bench`)
+
+The `crates/higgs-bench/` crate hosts native-Rust end-to-end bench
+binaries. Each binary drives a running higgs server (or, for MLX-direct
+benches, the engine in-process) and produces output that satisfies the
+contract below.
+
+### Bench output contract
+
+Every bench binary in `higgs-bench` emits a JSON object with three
+top-level keys: `metadata`, `params`, `results`.
+
+```json
+{
+  "metadata": {
+    "bench_name": "bench_decode",
+    "bench_version": "1.0.0",
+    "higgs_version": "1.0.0",
+    "git_commit": "abcdef1234...",
+    "git_commit_short": "abcdef1",
+    "git_dirty": false,
+    "started_at": "2026-04-28T00:00:00Z",
+    "duration_ms": 12345,
+    "host": { "hostname": "...", "os": "...", "cpu": "...", "ram_gb": 128.0, "gpu": "Apple Silicon (MLX)" },
+    "mlx_version": null,
+    "model": { "key": "qwen3-1.7B-4bit", "path": "...", "quantization": "4bit", "approx_size_gb": 1.2 },
+    "args": ["bench_decode", "--port", "8899", "--model", "qwen3-1.7B-4bit"]
+  },
+  "params":  { /* bench-specific */ },
+  "results": { /* bench-specific */ }
+}
+```
+
+`metadata.git_commit` and `git_dirty` are captured at compile time via
+the `built` crate; you must rebuild the bench binary to refresh them.
+
+Every binary supports two output formats:
+
+- `--format json` (default) — single JSON object, machine-parseable.
+- `--format markdown` — pasteable into PR descriptions. Includes a
+  "How to reproduce" code fence with the exact command (re-quoted from
+  `args`), a results table, and an environment table.
+
+Every run also persists the JSON to
+`target/bench-results/<bench_name>/<git_commit_short>__<model_key>__<timestamp>.json`,
+regardless of `--format`. This directory is gitignored.
+
+### Model manifest
+
+`benchmarks/models.toml` is the source of truth for which models the
+benches can target. Bench binaries take `--model <key>` and look up the
+entry by key.
+
+```toml
+[[models]]
+key = "qwen3-1.7B-4bit"
+label = "Qwen3-1.7B-4bit (Dense)"
+path = "mlx-community/Qwen3-1.7B-4bit"
+quantization = "4bit"
+approx_size_gb = 1.2
+context = 32768
+tags = ["small", "dense"]
+```
+
+Adding a model is one entry. Tags should mark size (`small`, `medium`,
+`large`) and architecture (`dense`, `moe`); benches that filter by tag
+will pick the model up automatically.
+
+### `bench_decode`
+
+Drives a running higgs server over the OpenAI streaming chat-completions
+API and reports per-trial decode tok/s + TTFT.
+
+```bash
+./target/release/higgs serve --model mlx-community/Qwen3-1.7B-4bit --port 8899 &
+cargo run --release -p higgs-bench --bin bench_decode -- \
+  --port 8899 --model qwen3-1.7B-4bit \
+  --max-tokens 200 --warmup 1 --trials 5 \
+  --temperature 0.7
+```
+
+`results` is `{ trials: [...], ttft_ms_{mean,median,p95,stdev},
+decode_tokps_{mean,median,p95,stdev} }`.
+
+### `bench_summarize`
+
+Walks `target/bench-results/`, picks the latest result per
+`(bench_name, model_key)` pair, and emits a Markdown table grouped by
+model. This is what the README quotes for headline numbers.
+
+```bash
+cargo run --release -p higgs-bench --bin bench_summarize
+```
+
+### Adding a new bench
+
+1. Create `crates/higgs-bench/src/bin/<name>.rs`.
+2. Capture metadata at startup with
+   `let mut metadata = higgs_bench::RunMetadata::capture("<name>");`.
+3. Look up the model with `higgs_bench::models::find_by_key(...)` and
+   set `metadata.model`.
+4. Define `Params` and `Results` structs (must implement `Serialize`).
+5. Build `BenchOutput { metadata, params, results }` and call
+   `higgs_bench::persist_result(&output)` plus
+   `higgs_bench::format_json` / `format_markdown` based on
+   `--format`.
+6. Document the new binary in this file with a one-line description and
+   a sample command.
+
 ## Caveats
 
 - Benchmark numbers depend on hardware class, prompt mix, quantization, and model family.

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -130,6 +130,14 @@ cargo run --release -p higgs-bench --bin bench_decode -- \
 `results` is `{ trials: [...], ttft_ms_{mean,median,p95,stdev},
 decode_tokps_{mean,median,p95,stdev} }`.
 
+`ttft_ms` measures request start → first non-empty streamed content token.
+`decode_tokps` measures tokens/sec **after** that first token boundary; it
+uses the server-reported `completion_tokens` from the terminal `usage` chunk
+(higgs honors `stream_options.include_usage: true`) and only falls back to
+SSE chunk count for backends that don't emit usage. The bench also sends
+`reasoning: { effort: "none" }` so decode timing reflects time-to-generate,
+not time-to-visible-answer for thinking-mode models.
+
 ### `bench_summarize`
 
 Walks `target/bench-results/`, picks the latest result per


### PR DESCRIPTION
## Summary

Lands PR1b of the bench-migration plan: a new `crates/higgs-bench/` crate that establishes the standardized output contract for all future native-Rust end-to-end benches. PR5/PR6/PR7 will migrate the existing Python `benchmarks/*.py` scripts into this crate.

This is **infrastructure only**. No code outside `crates/higgs-bench/`, `Cargo.toml`/`Cargo.lock`, `benchmarks/models.toml`, `docs/benchmarking.md`, and `.gitignore` is touched. No other crate depends on `higgs-bench`.

## What's included

- `crates/higgs-bench/src/lib.rs` — `RunMetadata`, `BenchOutput<P, R>`, `format_json`, `format_markdown`, `persist_result`, `collect_results`, `OutputFormat`.
- `crates/higgs-bench/src/models.rs` — `Manifest`, `Model`, `find_by_key`, `find_by_tag`.
- `crates/higgs-bench/src/server.rs` — `wait_until_ready` HTTP readiness probe.
- `crates/higgs-bench/src/stats.rs` — `mean`, `median`, `p95`, `stdev`, `percentile`.
- `crates/higgs-bench/src/bin/bench_decode.rs` — drives a higgs server over `/v1/chat/completions` (streaming) and reports per-trial TTFT + decode tok/s with mean/median/p95/stdev.
- `crates/higgs-bench/src/bin/bench_summarize.rs` — walks `target/bench-results/` and emits a Markdown table grouped by model.
- `crates/higgs-bench/build.rs` — `built` crate captures git commit + dirty flag at compile time.
- `benchmarks/models.toml` — model manifest seeded with `qwen3-1.7B-4bit`, `deepseek-v2-lite-4bit`, `qwen3.5-27B-4bit`, `qwen3.5-35B-a3b-3bit`.
- `docs/benchmarking.md` — new sections: "Bench output contract", "Model manifest", "`bench_decode`", "`bench_summarize`", "Adding a new bench".
- `.gitignore` — excludes `target/bench-results/`.

## Model manifest excerpt

```toml
[[models]]
key = "qwen3-1.7B-4bit"
label = "Qwen3-1.7B-4bit (Dense)"
path = "mlx-community/Qwen3-1.7B-4bit"
quantization = "4bit"
approx_size_gb = 1.2
context = 32768
tags = ["small", "dense"]
```

## Sample `bench_summarize --format markdown` output

Generated against a hand-crafted result file (no live server run; that's PR5+).

```markdown
# Bench summary

## qwen3-1.7B-4bit

_path: `mlx-community/Qwen3-1.7B-4bit`_

| Bench | Headline | Commit | When |
|---|---|---|---|
| bench_decode | 345.7 tok/s decode, 339 ms TTFT | abcdef1 | 2026-04-28T00:00:00Z |
```

## What passes

- `cargo build -p higgs-bench --release`
- `cargo clippy -p higgs-bench --all-targets --release` (clean; nursery + pedantic warnings present only in generated `built.rs` which is `#[allow]`'d on the inner module).
- `cargo fmt -p higgs-bench -- --check`
- `cargo test -p higgs-bench --release` (2 stats unit tests pass)
- `bench_decode --help` and `bench_summarize --help` render cleanly.
- `bench_summarize` against an empty `target/bench-results/` exits 0 with a "no results yet" message.

## What's out of scope

- Running `bench_decode` against a real higgs server (requires Apple Silicon + a model; that's PR5/6/7's evidence step).
- Migrating any existing Python bench (PR5).
- Criterion microbenches (this crate is for end-to-end binaries).

## Test plan

- [ ] CI: `cargo build -p higgs-bench --release` on Linux + macOS.
- [ ] CI: `cargo clippy -p higgs-bench --all-targets`.
- [ ] CI: `cargo fmt -p higgs-bench -- --check`.
- [ ] CI: `cargo test -p higgs-bench`.
- [ ] Manual: run `cargo run --release -p higgs-bench --bin bench_decode -- --help` and confirm the help text matches the spec in `docs/benchmarking.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end benchmarking tools to measure first-token latency (TTFT) and decode throughput, plus a summarizer with JSON/Markdown output and model-targeted runs
  * Model manifest for selecting model variants and tag-based filtering of benchmark runs
  * Persistent storage of benchmark results for later analysis

* **Documentation**
  * Added a benchmarking guide with output schema, usage examples, and integration steps

* **Chores**
  * Ignore bench-results directory in version control
<!-- end of auto-generated comment: release notes by coderabbit.ai -->