### PR TITLE
bench: port bench_h2h.py and bench_mlx_tuning.py to higgs-bench

### DIFF
--- a/benchmarks/models.toml
+++ b/benchmarks/models.toml
@@ -26,6 +26,8 @@ quantization = "4bit"
 approx_size_gb = 9.5
 context = 32768
 tags = ["medium", "moe", "h2h"]
+# oMLX requires a local cache path (matches LMS prefix in bench_h2h.py).
+omlx_model_dir = "~/.cache/lm-studio/models"
 
 [[models]]
 key = "qwen3.5-27B-4bit"
@@ -35,6 +37,7 @@ quantization = "4bit"
 approx_size_gb = 16.0
 context = 32768
 tags = ["large", "dense", "h2h"]
+omlx_model_dir = "~/.cache/lm-studio/models"
 
 [[models]]
 key = "qwen3.5-35B-a3b-3bit"
@@ -44,6 +47,7 @@ quantization = "3bit"
 approx_size_gb = 14.0
 context = 32768
 tags = ["large", "moe", "h2h"]
+omlx_model_dir = "~/.cache/lm-studio/models"
 
 [[models]]
 key = "qwen3-0.6B-4bit"

--- a/benchmarks/models.toml
+++ b/benchmarks/models.toml
@@ -25,7 +25,7 @@ path = "mlx-community/DeepSeek-Coder-V2-Lite-Instruct-4bit-mlx"
 quantization = "4bit"
 approx_size_gb = 9.5
 context = 32768
-tags = ["medium", "moe"]
+tags = ["medium", "moe", "h2h"]
 
 [[models]]
 key = "qwen3.5-27B-4bit"
@@ -34,7 +34,7 @@ path = "mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit"
 quantization = "4bit"
 approx_size_gb = 16.0
 context = 32768
-tags = ["large", "dense"]
+tags = ["large", "dense", "h2h"]
 
 [[models]]
 key = "qwen3.5-35B-a3b-3bit"
@@ -43,7 +43,7 @@ path = "NexVeridian/Qwen3.5-35B-A3B-3bit"
 quantization = "3bit"
 approx_size_gb = 14.0
 context = 32768
-tags = ["large", "moe"]
+tags = ["large", "moe", "h2h"]
 
 [[models]]
 key = "qwen3-0.6B-4bit"

--- a/crates/higgs-bench/Cargo.toml
+++ b/crates/higgs-bench/Cargo.toml
@@ -53,3 +53,11 @@ path = "src/bin/bench_tq_configs.rs"
 [[bin]]
 name = "bench_all"
 path = "src/bin/bench_all.rs"
+
+[[bin]]
+name = "bench_h2h"
+path = "src/bin/bench_h2h.rs"
+
+[[bin]]
+name = "bench_mlx_tuning"
+path = "src/bin/bench_mlx_tuning.rs"

--- a/crates/higgs-bench/src/bin/bench_h2h.rs
+++ b/crates/higgs-bench/src/bin/bench_h2h.rs
@@ -1,0 +1,533 @@
+#![allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::print_stderr,
+    clippy::as_conversions,
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::indexing_slicing,
+    clippy::shadow_unrelated,
+    clippy::shadow_reuse,
+    clippy::shadow_same,
+    clippy::too_many_lines,
+    clippy::similar_names,
+    clippy::option_if_let_else,
+    clippy::map_unwrap_or,
+    clippy::needless_range_loop
+)]
+//! `bench_h2h` — Higgs vs oMLX head-to-head TTFT and decode tok/s.
+//!
+//! Port of `benchmarks/bench_h2h.py`. Spins up a higgs server then an
+//! oMLX subprocess (path: `/Applications/oMLX.app/Contents/MacOS/omlx-cli`,
+//! overridable via `OMLX_CLI`) for each model, sends the same set of
+//! prompts to both, and prints a side-by-side comparison.
+//!
+//! Models are selected by key. Defaults to all models tagged `h2h` in
+//! `benchmarks/models.toml`; the original Python uses `--models 35B|27B|DSV2`.
+//! Pass `--models qwen3.5-35B-a3b-3bit` etc. to mirror that behavior.
+
+use std::path::Path;
+use std::process::ExitCode;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use higgs_bench::http::{StreamChatOptions, StreamMetrics};
+use higgs_bench::{
+    BenchOutput, ModelInfo, OutputFormat, RunMetadata, default_manifest_path, format_json,
+    format_markdown, http, models, persist_result, process,
+};
+use serde::Serialize;
+use tokio::process::Child;
+
+const HIGGS_PORT: u16 = 8899;
+const OMLX_PORT: u16 = 8000;
+
+const MAX_TOKENS: u32 = 100;
+const COOLDOWN_S: u64 = 5;
+const WARMUP_TOKENS: u32 = 10;
+
+const SHORT_PROMPT: &str = "What is 2+2? Answer in one word.";
+const MEDIUM_PROMPT: &str = "Write a detailed technical explanation of how transformer architectures work, covering attention mechanisms, positional encoding, layer normalization, feed-forward networks, and the differences between encoder and decoder architectures. Include discussion of multi-head attention, scaled dot-product attention, and how these components work together.";
+const LONG_PROMPT: &str = "Write an extremely comprehensive and detailed technical guide covering the following topics in depth:\n\n1. COMPILER DESIGN: Explain lexical analysis, parsing (LL, LR, LALR), abstract syntax trees, semantic analysis, intermediate representations (SSA form, three-address code), optimization passes (constant folding, dead code elimination, loop unrolling, register allocation via graph coloring), and code generation for modern CPU architectures.\n\n2. OPERATING SYSTEMS: Cover process scheduling algorithms (CFS, MLFQ, lottery scheduling), virtual memory management (page tables, TLB, huge pages, NUMA), file systems (ext4, btrfs, ZFS internals), I/O scheduling, interrupt handling, system calls.\n\n3. DISTRIBUTED SYSTEMS: Explain consensus protocols (Paxos, Raft, PBFT), distributed hash tables, vector clocks, CRDTs, the CAP theorem, leader election algorithms, distributed transactions (2PC, 3PC, saga pattern).\n\n4. CRYPTOGRAPHY: Cover symmetric encryption (AES internals, modes of operation), asymmetric encryption (RSA, elliptic curves, key exchange), hash functions (SHA-256 internals), digital signatures, zero-knowledge proofs.\n\n5. DATABASE INTERNALS: Explain B-tree and LSM-tree storage engines, write-ahead logging, MVCC, query optimization, join algorithms, buffer pool management.\n\nBe thorough and technical throughout.";
+
+const SYSTEM_PROMPT: &str = "You are a highly skilled software architect with deep expertise in distributed systems, database design, and cloud-native applications. You provide thorough, well-reasoned technical advice with step-by-step reasoning and concrete examples.";
+
+const TURN_QUESTIONS: &[&str] = &[
+    "Explain the CAP theorem and its practical implications for system design.",
+    "How would you design a rate limiter for a distributed API gateway?",
+    "Compare event sourcing with traditional CRUD. When would you pick each?",
+    "What are the key differences between Raft and Paxos consensus protocols?",
+    "Design a notification system that handles 1M users with real-time delivery.",
+    "How does MVCC work in PostgreSQL? Walk me through a concurrent update scenario.",
+    "What strategies would you use to migrate a monolith to microservices safely?",
+];
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "bench_h2h",
+    about = "Head-to-head benchmark: Higgs vs oMLX (port of bench_h2h.py)",
+    version
+)]
+struct Args {
+    /// Comma-separated list of model keys from `benchmarks/models.toml`.
+    /// Defaults to all models tagged `h2h`.
+    #[arg(long)]
+    models: Option<String>,
+
+    /// Number of multi-turn conversation turns.
+    #[arg(long, default_value_t = 5)]
+    turns: usize,
+
+    /// Skip multi-turn tests.
+    #[arg(long)]
+    skip_multiturn: bool,
+
+    /// Run only the higgs side.
+    #[arg(long)]
+    higgs_only: bool,
+
+    /// Run only the oMLX side.
+    #[arg(long)]
+    omlx_only: bool,
+
+    /// Override the manifest path.
+    #[arg(long)]
+    manifest: Option<std::path::PathBuf>,
+
+    /// Server startup timeout (seconds).
+    #[arg(long, default_value_t = 180)]
+    server_timeout_s: u64,
+
+    /// Output format.
+    #[arg(long, value_enum, default_value_t = OutputFormat::Json)]
+    format: OutputFormat,
+}
+
+#[derive(Debug, Serialize)]
+struct Params {
+    max_tokens: u32,
+    turns: usize,
+    cooldown_s: u64,
+    skip_multiturn: bool,
+    higgs_only: bool,
+    omlx_only: bool,
+    model_keys: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct PromptResult {
+    label: String,
+    ttft_ms: f64,
+    decode_tps: f64,
+    prompt_tokens: u32,
+    completion_tokens: u32,
+    completion_tokens_estimated: bool,
+    total_ms: f64,
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct TurnResult {
+    turn: usize,
+    ttft_ms: f64,
+    decode_tps: f64,
+    prompt_tokens: u32,
+    completion_tokens: u32,
+    total_ms: f64,
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct BackendResults {
+    backend: String,
+    model: String,
+    single_turn: Vec<PromptResult>,
+    multi_turn: Vec<TurnResult>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct ModelComparison {
+    model_key: String,
+    label: String,
+    higgs: Option<BackendResults>,
+    omlx: Option<BackendResults>,
+}
+
+#[derive(Debug, Serialize)]
+struct Results {
+    comparisons: Vec<ModelComparison>,
+}
+
+fn main() -> ExitCode {
+    let args = Args::parse();
+    let runtime = match tokio::runtime::Runtime::new() {
+        Ok(rt) => rt,
+        Err(e) => {
+            eprintln!("error: failed to start tokio runtime: {e}");
+            return ExitCode::from(2);
+        }
+    };
+    match runtime.block_on(run(args)) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("error: {e:#}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+async fn run(args: Args) -> Result<()> {
+    let mut metadata = RunMetadata::capture("bench_h2h");
+    let started = Instant::now();
+
+    let manifest_path = args.manifest.clone().unwrap_or_else(default_manifest_path);
+    let manifest = models::load_manifest(&manifest_path)?;
+    let selected = select_models(&manifest, &args)?;
+    if selected.is_empty() {
+        anyhow::bail!("no models selected; pass --models <key,...> or tag a model with `h2h`");
+    }
+    eprintln!("{}", "=".repeat(80));
+    eprintln!("HEAD-TO-HEAD: Higgs vs oMLX");
+    eprintln!(
+        "Max tokens: {MAX_TOKENS}  Turns: {}  Cooldown: {}s",
+        args.turns, COOLDOWN_S
+    );
+    eprintln!(
+        "Models: {}",
+        selected
+            .iter()
+            .map(|m| m.key.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    eprintln!("{}", "=".repeat(80));
+
+    if let Some(first) = selected.first() {
+        metadata.model = Some(ModelInfo {
+            key: first.key.clone(),
+            path: first.path.clone(),
+            quantization: first.quantization.clone(),
+            approx_size_gb: first.approx_size_gb,
+        });
+    }
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(600))
+        .build()?;
+
+    let mut comparisons: Vec<ModelComparison> = Vec::new();
+    for model in &selected {
+        eprintln!("\n{}", "#".repeat(80));
+        eprintln!("# MODEL: {}", model.label);
+        eprintln!("# Path:  {}", model.path);
+        eprintln!("{}", "#".repeat(80));
+
+        let mut comparison = ModelComparison {
+            model_key: model.key.clone(),
+            label: model.label.clone(),
+            higgs: None,
+            omlx: None,
+        };
+
+        if !args.omlx_only {
+            match run_for_higgs(&client, model, &args).await {
+                Ok(r) => comparison.higgs = Some(r),
+                Err(e) => eprintln!("  Higgs error: {e:#}"),
+            }
+            tokio::time::sleep(Duration::from_secs(COOLDOWN_S)).await;
+        }
+        if !args.higgs_only {
+            match run_for_omlx(&client, model, &args).await {
+                Ok(r) => comparison.omlx = Some(r),
+                Err(e) => eprintln!("  oMLX error: {e:#}"),
+            }
+            tokio::time::sleep(Duration::from_secs(COOLDOWN_S)).await;
+        }
+
+        if let (Some(h), Some(o)) = (&comparison.higgs, &comparison.omlx) {
+            print_comparison(&model.label, h, o);
+        }
+        comparisons.push(comparison);
+    }
+
+    metadata.duration_ms = started.elapsed().as_millis() as u64;
+    let params = Params {
+        max_tokens: MAX_TOKENS,
+        turns: args.turns,
+        cooldown_s: COOLDOWN_S,
+        skip_multiturn: args.skip_multiturn,
+        higgs_only: args.higgs_only,
+        omlx_only: args.omlx_only,
+        model_keys: selected.iter().map(|m| m.key.clone()).collect(),
+    };
+    let results = Results { comparisons };
+    let output = BenchOutput {
+        metadata,
+        params,
+        results,
+    };
+    let path = persist_result(&output)?;
+    eprintln!("[persisted] {}", path.display());
+    let rendered = match args.format {
+        OutputFormat::Json => format_json(&output)?,
+        OutputFormat::Markdown => format_markdown(&output)?,
+    };
+    println!("{rendered}");
+    Ok(())
+}
+
+fn select_models(manifest: &models::Manifest, args: &Args) -> Result<Vec<models::Model>> {
+    if let Some(list) = &args.models {
+        list.split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(|key| {
+                manifest
+                    .find_by_key(key)
+                    .cloned()
+                    .ok_or_else(|| anyhow::anyhow!("model key '{key}' not in manifest"))
+            })
+            .collect()
+    } else {
+        Ok(manifest.find_by_tag("h2h").into_iter().cloned().collect())
+    }
+}
+
+async fn run_for_higgs(
+    client: &reqwest::Client,
+    model: &models::Model,
+    args: &Args,
+) -> Result<BackendResults> {
+    eprintln!("\n  --- higgs ---");
+    eprintln!("  Starting Higgs on :{HIGGS_PORT} ...");
+    let child = process::start_higgs_server(
+        &model.path,
+        HIGGS_PORT,
+        &[],
+        Duration::from_secs(args.server_timeout_s),
+    )
+    .await?;
+    let base_url = format!("http://127.0.0.1:{HIGGS_PORT}");
+    let result = run_backend(client, &base_url, "higgs", model, None, args).await;
+    if let Err(e) = process::stop_server(child).await {
+        eprintln!("warning: stop_server: {e:#}");
+    }
+    result
+}
+
+async fn run_for_omlx(
+    client: &reqwest::Client,
+    model: &models::Model,
+    args: &Args,
+) -> Result<BackendResults> {
+    eprintln!("\n  --- omlx ---");
+    eprintln!("  Starting oMLX on :{OMLX_PORT} (--no-cache) ...");
+    // oMLX walks one level deep from --model-dir; pass the parent directory.
+    let parent = Path::new(&model.path)
+        .parent()
+        .map(|p| p.to_string_lossy().into_owned())
+        .ok_or_else(|| anyhow::anyhow!("can't resolve parent dir of {}", model.path))?;
+    let child: Child = process::start_omlx_server(
+        &parent,
+        OMLX_PORT,
+        Duration::from_secs(args.server_timeout_s),
+    )
+    .await?;
+    let base_url = format!("http://127.0.0.1:{OMLX_PORT}");
+    // oMLX discovers models by directory basename — use that as the model id.
+    let basename = Path::new(&model.path)
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| model.path.clone());
+    let result = run_backend(
+        client,
+        &base_url,
+        "omlx",
+        model,
+        Some(("omlx", basename.as_str())),
+        args,
+    )
+    .await;
+    if let Err(e) = process::stop_server(child).await {
+        eprintln!("warning: stop_server: {e:#}");
+    }
+    result
+}
+
+async fn run_backend(
+    client: &reqwest::Client,
+    base_url: &str,
+    backend: &str,
+    model: &models::Model,
+    omlx_auth: Option<(&str, &str)>,
+    args: &Args,
+) -> Result<BackendResults> {
+    let model_id = if let Some((api_key, override_id)) = omlx_auth {
+        // Verify oMLX is responding, then use the override (basename) as id.
+        let _ = http::first_model_id_with_auth(client, base_url, Some(api_key)).await?;
+        override_id.to_owned()
+    } else {
+        http::first_model_id(client, base_url).await?
+    };
+    let api_key = omlx_auth.map(|(k, _)| k);
+
+    eprintln!("  Server ready: model={model_id}");
+    eprintln!("  Warmup...");
+    let warmup_msgs = serde_json::json!([{"role": "user", "content": "Say hi."}]);
+    let _ = stream(
+        client,
+        base_url,
+        &model_id,
+        &warmup_msgs,
+        WARMUP_TOKENS,
+        api_key,
+    )
+    .await?;
+    eprintln!("  Warmup done.");
+
+    eprintln!("\n  [Single-turn]");
+    let mut single_turn = Vec::new();
+    for (label, prompt) in [
+        ("short", SHORT_PROMPT),
+        ("medium", MEDIUM_PROMPT),
+        ("long", LONG_PROMPT),
+    ] {
+        let msgs = serde_json::json!([{"role": "user", "content": prompt}]);
+        let r = stream(client, base_url, &model_id, &msgs, MAX_TOKENS, api_key).await?;
+        eprintln!(
+            "    {label:8}: TTFT={:>7.0}ms  decode={:>5.1}tok/s  prompt={:>4}tok  gen={:>3}tok  total={:>5.1}s",
+            r.ttft_ms,
+            r.decode_tps,
+            r.prompt_tokens,
+            r.completion_tokens,
+            r.total_ms / 1000.0
+        );
+        single_turn.push(PromptResult {
+            label: label.to_owned(),
+            ttft_ms: r.ttft_ms,
+            decode_tps: r.decode_tps,
+            prompt_tokens: r.prompt_tokens,
+            completion_tokens: r.completion_tokens,
+            completion_tokens_estimated: r.completion_tokens_estimated,
+            total_ms: r.total_ms,
+        });
+    }
+
+    let mut multi_turn = Vec::new();
+    if !args.skip_multiturn {
+        eprintln!("\n  [Multi-turn, {} turns]", args.turns);
+        let mut messages: Vec<serde_json::Value> =
+            vec![serde_json::json!({"role": "system", "content": SYSTEM_PROMPT})];
+        let n = args.turns.min(TURN_QUESTIONS.len());
+        for i in 0..n {
+            messages.push(serde_json::json!({"role": "user", "content": TURN_QUESTIONS[i]}));
+            let value = serde_json::Value::Array(messages.clone());
+            let r = stream(client, base_url, &model_id, &value, 80, api_key).await?;
+            eprintln!(
+                "    turn {}: TTFT={:>7.0}ms  decode={:>5.1}tok/s  ctx~{}",
+                i + 1,
+                r.ttft_ms,
+                r.decode_tps,
+                r.prompt_tokens
+            );
+            multi_turn.push(TurnResult {
+                turn: i + 1,
+                ttft_ms: r.ttft_ms,
+                decode_tps: r.decode_tps,
+                prompt_tokens: r.prompt_tokens,
+                completion_tokens: r.completion_tokens,
+                total_ms: r.total_ms,
+            });
+            messages.push(serde_json::json!({"role": "assistant", "content": r.output}));
+        }
+    }
+
+    Ok(BackendResults {
+        backend: backend.to_owned(),
+        model: model.label.clone(),
+        single_turn,
+        multi_turn,
+    })
+}
+
+async fn stream(
+    client: &reqwest::Client,
+    base_url: &str,
+    model: &str,
+    messages: &serde_json::Value,
+    max_tokens: u32,
+    api_key: Option<&str>,
+) -> Result<StreamMetrics> {
+    let opts = StreamChatOptions {
+        max_tokens,
+        temperature: 0.0,
+        api_key,
+        response_format: None,
+        // oMLX doesn't report prompt tokens in SSE; estimate.
+        estimate_prompt_tokens: api_key.is_some(),
+    };
+    http::stream_chat_metrics(client, base_url, model, messages, &opts)
+        .await
+        .with_context(|| format!("stream {base_url}/v1/chat/completions"))
+}
+
+fn print_comparison(label: &str, higgs: &BackendResults, omlx: &BackendResults) {
+    eprintln!("\n{}", "=".repeat(80));
+    eprintln!("COMPARISON: {label}");
+    eprintln!("{}", "=".repeat(80));
+
+    eprintln!(
+        "\n  {:12} {:>20}   {:>20}",
+        "", "TTFT (ms)", "Decode (tok/s)"
+    );
+    eprintln!(
+        "  {:12} {:>9} {:>9}   {:>9} {:>9}  {:>7} {:>7}",
+        "Prompt", "Higgs", "oMLX", "Higgs", "oMLX", "TTFT", "Decode"
+    );
+    eprintln!("  {}", "-".repeat(74));
+
+    for label in ["short", "medium", "long"] {
+        let h = higgs.single_turn.iter().find(|r| r.label == label);
+        let o = omlx.single_turn.iter().find(|r| r.label == label);
+        let (Some(h), Some(o)) = (h, o) else {
+            continue;
+        };
+        let ttft_ratio = if h.ttft_ms > 0.0 {
+            format!("{:.2}x", o.ttft_ms / h.ttft_ms)
+        } else {
+            "—".to_owned()
+        };
+        let dec_ratio = if o.decode_tps > 0.0 {
+            format!("{:.2}x", h.decode_tps / o.decode_tps)
+        } else {
+            "—".to_owned()
+        };
+        eprintln!(
+            "  {label:12} {:>8.0}  {:>8.0}   {:>8.1}  {:>8.1}  {ttft_ratio:>7} {dec_ratio:>7}",
+            h.ttft_ms, o.ttft_ms, h.decode_tps, o.decode_tps,
+        );
+    }
+
+    if !higgs.multi_turn.is_empty() && !omlx.multi_turn.is_empty() {
+        eprintln!("\n  Multi-turn TTFT progression:");
+        eprintln!(
+            "  {:>5}  {:>11}  {:>11}  {:>10}  {:>10}",
+            "Turn", "Higgs TTFT", "oMLX TTFT", "Higgs dec", "oMLX dec"
+        );
+        eprintln!("  {}", "-".repeat(55));
+        let n = higgs.multi_turn.len().min(omlx.multi_turn.len());
+        for i in 0..n {
+            let h = &higgs.multi_turn[i];
+            let o = &omlx.multi_turn[i];
+            eprintln!(
+                "  {:>5}  {:>9.0}ms  {:>9.0}ms  {:>8.1}/s  {:>8.1}/s",
+                i + 1,
+                h.ttft_ms,
+                o.ttft_ms,
+                h.decode_tps,
+                o.decode_tps,
+            );
+        }
+    }
+}

--- a/crates/higgs-bench/src/bin/bench_h2h.rs
+++ b/crates/higgs-bench/src/bin/bench_h2h.rs
@@ -361,15 +361,13 @@ async fn run_for_omlx(
     // `model.path` strings so that Higgs can resolve them via its own
     // cache; here we require an explicit `omlx_model_dir` cache prefix
     // (typically `~/.cache/lm-studio/models`) and fail loudly if missing.
-    let cache_prefix = model
-        .resolved_omlx_model_dir()
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "model '{}' has no `omlx_model_dir`; H2H requires a local cache path. \
+    let cache_prefix = model.resolved_omlx_model_dir().ok_or_else(|| {
+        anyhow::anyhow!(
+            "model '{}' has no `omlx_model_dir`; H2H requires a local cache path. \
                  Add `omlx_model_dir = \"~/.cache/lm-studio/models/...\"` to its manifest entry.",
-                model.key
-            )
-        })?;
+            model.key
+        )
+    })?;
     // oMLX walks one level deep from --model-dir, so `omlx_model_dir`
     // must be the parent of the model's own directory. The model's
     // directory name is the trailing path component of `model.path`.

--- a/crates/higgs-bench/src/bin/bench_h2h.rs
+++ b/crates/higgs-bench/src/bin/bench_h2h.rs
@@ -459,13 +459,18 @@ async fn stream(
     max_tokens: u32,
     api_key: Option<&str>,
 ) -> Result<StreamMetrics> {
+    let is_omlx = api_key.is_some();
     let opts = StreamChatOptions {
         max_tokens,
         temperature: 0.0,
         api_key,
         response_format: None,
         // oMLX doesn't report prompt tokens in SSE; estimate.
-        estimate_prompt_tokens: api_key.is_some(),
+        estimate_prompt_tokens: is_omlx,
+        // Higgs honors stream_options.include_usage; oMLX rejects unknown
+        // body keys, so only request it on the Higgs side. The oMLX path
+        // falls back to the character-count completion-token estimate.
+        include_usage: !is_omlx,
     };
     http::stream_chat_metrics(client, base_url, model, messages, &opts)
         .await

--- a/crates/higgs-bench/src/bin/bench_h2h.rs
+++ b/crates/higgs-bench/src/bin/bench_h2h.rs
@@ -203,20 +203,16 @@ async fn run(args: Args) -> Result<()> {
     );
     eprintln!("{}", "=".repeat(80));
 
-    if let Some(first) = selected.first() {
-        metadata.model = Some(ModelInfo {
-            key: first.key.clone(),
-            path: first.path.clone(),
-            quantization: first.quantization.clone(),
-            approx_size_gb: first.approx_size_gb,
-        });
-    }
-
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(600))
         .build()?;
 
-    let mut comparisons: Vec<ModelComparison> = Vec::new();
+    // Persist one BenchOutput per model. `persist_result` derives the
+    // filename from `metadata.model.key` and `bench_summarize` groups by
+    // it; a single combined record would only record the first model's
+    // key, hiding every other model's data inside `results.comparisons`.
+    // Splitting per-model keeps each model independently summarizable.
+    let mut all_comparisons: Vec<ModelComparison> = Vec::new();
     for model in &selected {
         eprintln!("\n{}", "#".repeat(80));
         eprintln!("# MODEL: {}", model.label);
@@ -248,10 +244,47 @@ async fn run(args: Args) -> Result<()> {
         if let (Some(h), Some(o)) = (&comparison.higgs, &comparison.omlx) {
             print_comparison(&model.label, h, o);
         }
-        comparisons.push(comparison);
+
+        let mut per_model_meta = metadata.clone();
+        per_model_meta.model = Some(ModelInfo {
+            key: model.key.clone(),
+            path: model.path.clone(),
+            quantization: model.quantization.clone(),
+            approx_size_gb: model.approx_size_gb,
+        });
+        per_model_meta.duration_ms = started.elapsed().as_millis() as u64;
+        let per_params = Params {
+            max_tokens: MAX_TOKENS,
+            turns: args.turns,
+            cooldown_s: COOLDOWN_S,
+            skip_multiturn: args.skip_multiturn,
+            higgs_only: args.higgs_only,
+            omlx_only: args.omlx_only,
+            model_keys: vec![model.key.clone()],
+        };
+        let per_results = Results {
+            comparisons: vec![comparison.clone()],
+        };
+        let per_model_output = BenchOutput {
+            metadata: per_model_meta,
+            params: per_params,
+            results: per_results,
+        };
+        let path = persist_result(&per_model_output)?;
+        eprintln!("[persisted] {}", path.display());
+        all_comparisons.push(comparison);
     }
 
+    // Render a combined view to stdout for the human watching the run.
     metadata.duration_ms = started.elapsed().as_millis() as u64;
+    if let Some(first) = selected.first() {
+        metadata.model = Some(ModelInfo {
+            key: first.key.clone(),
+            path: first.path.clone(),
+            quantization: first.quantization.clone(),
+            approx_size_gb: first.approx_size_gb,
+        });
+    }
     let params = Params {
         max_tokens: MAX_TOKENS,
         turns: args.turns,
@@ -261,17 +294,16 @@ async fn run(args: Args) -> Result<()> {
         omlx_only: args.omlx_only,
         model_keys: selected.iter().map(|m| m.key.clone()).collect(),
     };
-    let results = Results { comparisons };
-    let output = BenchOutput {
+    let combined = BenchOutput {
         metadata,
         params,
-        results,
+        results: Results {
+            comparisons: all_comparisons,
+        },
     };
-    let path = persist_result(&output)?;
-    eprintln!("[persisted] {}", path.display());
     let rendered = match args.format {
-        OutputFormat::Json => format_json(&output)?,
-        OutputFormat::Markdown => format_markdown(&output)?,
+        OutputFormat::Json => format_json(&combined)?,
+        OutputFormat::Markdown => format_markdown(&combined)?,
     };
     println!("{rendered}");
     Ok(())
@@ -323,11 +355,32 @@ async fn run_for_omlx(
 ) -> Result<BackendResults> {
     eprintln!("\n  --- omlx ---");
     eprintln!("  Starting oMLX on :{OMLX_PORT} (--no-cache) ...");
-    // oMLX walks one level deep from --model-dir; pass the parent directory.
-    let parent = Path::new(&model.path)
+    // oMLX's `--model-dir` expects a local parent directory containing
+    // the model one level below — not a HuggingFace repo id like
+    // `mlx-community/Foo`. The default manifest uses HF-style
+    // `model.path` strings so that Higgs can resolve them via its own
+    // cache; here we require an explicit `omlx_model_dir` cache prefix
+    // (typically `~/.cache/lm-studio/models`) and fail loudly if missing.
+    let cache_prefix = model
+        .resolved_omlx_model_dir()
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "model '{}' has no `omlx_model_dir`; H2H requires a local cache path. \
+                 Add `omlx_model_dir = \"~/.cache/lm-studio/models/...\"` to its manifest entry.",
+                model.key
+            )
+        })?;
+    // oMLX walks one level deep from --model-dir, so `omlx_model_dir`
+    // must be the parent of the model's own directory. The model's
+    // directory name is the trailing path component of `model.path`.
+    let model_subdir = Path::new(&model.path);
+    let model_full_path = cache_prefix.join(model_subdir);
+    let parent = model_full_path
         .parent()
         .map(|p| p.to_string_lossy().into_owned())
-        .ok_or_else(|| anyhow::anyhow!("can't resolve parent dir of {}", model.path))?;
+        .ok_or_else(|| {
+            anyhow::anyhow!("can't resolve parent dir of {}", model_full_path.display())
+        })?;
     let child: Child = process::start_omlx_server(
         &parent,
         OMLX_PORT,
@@ -336,7 +389,7 @@ async fn run_for_omlx(
     .await?;
     let base_url = format!("http://127.0.0.1:{OMLX_PORT}");
     // oMLX discovers models by directory basename — use that as the model id.
-    let basename = Path::new(&model.path)
+    let basename = model_full_path
         .file_name()
         .map(|n| n.to_string_lossy().into_owned())
         .unwrap_or_else(|| model.path.clone());

--- a/crates/higgs-bench/src/bin/bench_mlx_tuning.rs
+++ b/crates/higgs-bench/src/bin/bench_mlx_tuning.rs
@@ -524,6 +524,8 @@ async fn stream(
         api_key: None,
         response_format,
         estimate_prompt_tokens: false,
+        // bench_mlx_tuning only targets a local Higgs server.
+        include_usage: true,
     };
     http::stream_chat_metrics(client, base_url, model, messages, &opts).await
 }

--- a/crates/higgs-bench/src/bin/bench_mlx_tuning.rs
+++ b/crates/higgs-bench/src/bin/bench_mlx_tuning.rs
@@ -1,0 +1,1011 @@
+#![allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::print_stderr,
+    clippy::as_conversions,
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::indexing_slicing,
+    clippy::shadow_unrelated,
+    clippy::shadow_reuse,
+    clippy::shadow_same,
+    clippy::too_many_lines,
+    clippy::similar_names,
+    clippy::suboptimal_flops,
+    clippy::useless_vec
+)]
+//! `bench_mlx_tuning` — port of `benchmarks/bench_mlx_tuning.py`.
+//!
+//! Sweeps five MLX tuning profiles (baseline / latency / balanced /
+//! throughput / throughput+TQ) and reports a composite score combining
+//! TTFT, decode tok/s, short-QA accuracy, long-context retrieval,
+//! structured-output correctness, and prefix-cache speedup. The composite
+//! formula is implemented in `higgs_bench::score` and exercised by the
+//! unit tests at the bottom of this file (ports of
+//! `benchmarks/test_bench_mlx_tuning.py`).
+
+use std::process::ExitCode;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use higgs_bench::http::{StreamChatOptions, StreamMetrics};
+use higgs_bench::score::{
+    AccuracyInputs, CacheInputs, SpeedInputs, compute_bests, compute_iteration_score,
+    normalize_text,
+};
+use higgs_bench::stats::median;
+use higgs_bench::{
+    BenchOutput, ModelInfo, OutputFormat, RunMetadata, format_json, format_markdown, http,
+    persist_result, process,
+};
+use serde::Serialize;
+
+const PORT: u16 = 8099;
+
+const SHORT_PROMPT: &str = "What is 17 + 25? Reply with digits only.";
+const MEDIUM_PROMPT: &str = "Explain how KV cache reuse affects time-to-first-token and decode throughput for autoregressive transformer inference on Apple Silicon. Keep the answer technical and concise.";
+
+const LONG_CONTEXT_NEEDLE: &str = "CAPE-TOWN-7419";
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "bench_mlx_tuning",
+    about = "Sweep MLX tuning profiles and emit a composite score (port of bench_mlx_tuning.py)",
+    version
+)]
+struct Args {
+    /// Model path (local directory or HF cache directory) — same shape as
+    /// the Python script.
+    model_path: String,
+
+    /// Repeats per prompt in the prompt sweep.
+    #[arg(long, default_value_t = 2)]
+    repeats: u32,
+
+    /// Port the spawned higgs server should listen on.
+    #[arg(long, default_value_t = PORT)]
+    port: u16,
+
+    /// Skip spawning a server; assume one is already running on `--port`.
+    /// In this mode only the first iteration runs (no profile sweep).
+    #[arg(long)]
+    no_spawn: bool,
+
+    /// Server startup timeout (seconds).
+    #[arg(long, default_value_t = 120)]
+    server_timeout_s: u64,
+
+    /// Output format (json, markdown).
+    #[arg(long, value_enum, default_value_t = OutputFormat::Json)]
+    format: OutputFormat,
+}
+
+#[derive(Debug, Clone)]
+struct Iteration {
+    slug: &'static str,
+    label: &'static str,
+    profile: &'static str,
+    args: &'static [&'static str],
+    notes: &'static str,
+}
+
+const ITERATIONS: &[Iteration] = &[
+    Iteration {
+        slug: "baseline",
+        label: "1. Baseline",
+        profile: "baseline",
+        args: &[],
+        notes: "Current conservative defaults",
+    },
+    Iteration {
+        slug: "latency",
+        label: "2. Latency Profile",
+        profile: "latency",
+        args: &[],
+        notes: "Favor single-pass prefill and speculative decode",
+    },
+    Iteration {
+        slug: "balanced",
+        label: "3. Balanced Profile",
+        profile: "balanced",
+        args: &[],
+        notes: "Model-aware chunking plus larger paged KV budget",
+    },
+    Iteration {
+        slug: "throughput",
+        label: "4. Throughput Profile",
+        profile: "throughput",
+        args: &[],
+        notes: "Bigger decode-oriented chunks and paged KV budget",
+    },
+    Iteration {
+        slug: "throughput_turboquant",
+        label: "5. Throughput + Safe TurboQuant",
+        profile: "throughput",
+        args: &[
+            "--kv-cache",
+            "turboquant",
+            "--kv-bits",
+            "3",
+            "--kv-key-bits",
+            "2",
+            "--kv-value-bits",
+            "3",
+            "--kv-adaptive-dense-layers",
+            "8",
+        ],
+        notes: "Adds quality-preserving KV quantization after MLX runtime tuning",
+    },
+];
+
+const QA_CASES: &[(&str, &str)] = &[
+    ("Reply with digits only. What is 37 * 19?", "703"),
+    (
+        "Reply with one lowercase word only. Which word appears twice in 'alpha beta gamma beta delta'?",
+        "beta",
+    ),
+    (
+        "Reply with digits only. How many vowels are in the word instrumentation?",
+        "6",
+    ),
+    (
+        "Reply with lowercase letters only. Reverse the string stressed.",
+        "desserts",
+    ),
+    (
+        "Reply with comma-separated digits only. Sort 7,1,9,1 ascending.",
+        "1,1,7,9",
+    ),
+];
+
+fn long_prompt() -> String {
+    use std::fmt::Write as _;
+    let mut s = String::from(
+        "Write a technical note about optimizing LLM inference on unified-memory Apple Silicon systems. Cover TTFT, decode throughput, prompt length sensitivity, prefix cache reuse, chunked prefill, speculative decode, and quantized KV caches. Include concrete engineering tradeoffs and failure modes.\n\n",
+    );
+    for idx in 1..=90 {
+        let _ = writeln!(
+            s,
+            "Section {idx}: Repeated background detail about scheduler fairness, prompt staging, and kernel launch overhead on MLX devices."
+        );
+    }
+    s
+}
+
+fn long_context_filler() -> String {
+    use std::fmt::Write as _;
+    let mut s = String::new();
+    for idx in 1..=180 {
+        let _ = writeln!(
+            s,
+            "Paragraph {idx}: Cape Town cluster notes about unified memory pressure, prefill staging, and context reuse across serving workloads."
+        );
+    }
+    s.pop();
+    s
+}
+
+fn prefix_cache_doc() -> String {
+    use std::fmt::Write as _;
+    let mut s = String::new();
+    for idx in 1..=160 {
+        let _ = writeln!(
+            s,
+            "Policy {idx}: Route latency data through the prefill pipeline, keep the region failover target as cape town, and retain prefix blocks for reuse."
+        );
+    }
+    s.pop();
+    s
+}
+
+fn structured_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "json_schema",
+        "json_schema": {
+            "name": "mlx_report",
+            "strict": true,
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "model_family": {"type": "string"},
+                    "iteration": {"type": "integer"},
+                    "prefill_focus": {"type": "boolean"},
+                    "kv_bits": {"type": "integer"},
+                    "primary_goal": {"type": "string"},
+                },
+                "required": [
+                    "model_family",
+                    "iteration",
+                    "prefill_focus",
+                    "kv_bits",
+                    "primary_goal",
+                ],
+                "additionalProperties": false,
+            },
+        },
+    })
+}
+
+#[derive(Debug, Serialize)]
+struct Params {
+    model_path: String,
+    port: u16,
+    repeats: u32,
+    iterations: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct PromptMetric {
+    ttft_ms: f64,
+    decode_tps: f64,
+    prompt_tokens: f64,
+    completion_tokens: f64,
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct PromptSweep {
+    short: PromptMetric,
+    medium: PromptMetric,
+    long: PromptMetric,
+    weighted_ttft_ms: f64,
+    weighted_decode_tps: f64,
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct QaCaseResult {
+    prompt: String,
+    expected: String,
+    output: String,
+    passed: bool,
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct QaResults {
+    passed: u32,
+    total: u32,
+    accuracy: f64,
+    cases: Vec<QaCaseResult>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct LongContextResult {
+    expected: String,
+    output: String,
+    passed: bool,
+    accuracy: f64,
+    prompt_tokens: u32,
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct StructuredResult {
+    passed: bool,
+    accuracy: f64,
+    raw: Option<String>,
+    parsed: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct PrefixCacheResult {
+    cold_ttft_ms: f64,
+    warm_ttft_ms: f64,
+    speedup: f64,
+    answer: String,
+    passed: bool,
+    accuracy: f64,
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct ScoreOut {
+    accuracy: f64,
+    speed: f64,
+    cache: f64,
+    composite: f64,
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct IterationResult {
+    iteration: String,
+    label: String,
+    notes: String,
+    args: Vec<String>,
+    prompt_sweep: PromptSweep,
+    qa: QaResults,
+    long_context: LongContextResult,
+    structured_output: StructuredResult,
+    prefix_cache: PrefixCacheResult,
+    score: Option<ScoreOut>,
+}
+
+#[derive(Debug, Serialize)]
+struct Results {
+    model_path: String,
+    iterations: Vec<IterationResult>,
+    winner: Option<String>,
+}
+
+fn main() -> ExitCode {
+    let args = Args::parse();
+    let runtime = match tokio::runtime::Runtime::new() {
+        Ok(rt) => rt,
+        Err(e) => {
+            eprintln!("error: failed to start tokio runtime: {e}");
+            return ExitCode::from(2);
+        }
+    };
+    match runtime.block_on(run(args)) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("error: {e:#}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+async fn run(args: Args) -> Result<()> {
+    let mut metadata = RunMetadata::capture("bench_mlx_tuning");
+    let started = Instant::now();
+    metadata.model = Some(ModelInfo {
+        key: args.model_path.clone(),
+        path: args.model_path.clone(),
+        quantization: "unknown".into(),
+        approx_size_gb: 0.0,
+    });
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(600))
+        .build()?;
+    let base_url = format!("http://127.0.0.1:{}", args.port);
+
+    let iterations: Vec<Iteration> = if args.no_spawn {
+        ITERATIONS.iter().take(1).cloned().collect()
+    } else {
+        ITERATIONS.to_vec()
+    };
+
+    let mut iter_results = Vec::new();
+    for (idx, iteration) in iterations.iter().enumerate() {
+        let result = benchmark_iteration(&client, &base_url, &args, idx + 1, iteration)
+            .await
+            .with_context(|| format!("iteration '{}'", iteration.slug))?;
+        iter_results.push(result);
+    }
+
+    score_results(&mut iter_results);
+
+    let winner = iter_results
+        .iter()
+        .max_by(|a, b| {
+            let aa = a.score.as_ref().map_or(0.0, |s| s.composite);
+            let bb = b.score.as_ref().map_or(0.0, |s| s.composite);
+            aa.partial_cmp(&bb).unwrap_or(std::cmp::Ordering::Equal)
+        })
+        .map(|r| r.label.clone());
+
+    print_summary(&iter_results, winner.as_deref());
+
+    metadata.duration_ms = started.elapsed().as_millis() as u64;
+    let params = Params {
+        model_path: args.model_path.clone(),
+        port: args.port,
+        repeats: args.repeats,
+        iterations: iterations.iter().map(|i| i.slug.to_owned()).collect(),
+    };
+    let results = Results {
+        model_path: args.model_path.clone(),
+        iterations: iter_results,
+        winner,
+    };
+    let output = BenchOutput {
+        metadata,
+        params,
+        results,
+    };
+    let path = persist_result(&output)?;
+    eprintln!("[persisted] {}", path.display());
+    let rendered = match args.format {
+        OutputFormat::Json => format_json(&output)?,
+        OutputFormat::Markdown => format_markdown(&output)?,
+    };
+    println!("{rendered}");
+    Ok(())
+}
+
+async fn benchmark_iteration(
+    client: &reqwest::Client,
+    base_url: &str,
+    args: &Args,
+    iteration_index: usize,
+    iteration: &Iteration,
+) -> Result<IterationResult> {
+    eprintln!("\n{}", "=".repeat(80));
+    eprintln!("{}", iteration.label);
+    eprintln!("Notes: {}", iteration.notes);
+    if !iteration.args.is_empty() {
+        eprintln!("Args: {}", iteration.args.join(" "));
+    }
+    eprintln!("{}", "=".repeat(80));
+
+    let child = if args.no_spawn {
+        None
+    } else {
+        let extra_args: Vec<String> = iteration.args.iter().map(|s| (*s).to_owned()).collect();
+        let extra_env = vec![("HIGGS_MLX_PROFILE".to_owned(), iteration.profile.to_owned())];
+        Some(
+            process::start_higgs_server_with_env(
+                &args.model_path,
+                args.port,
+                &extra_args,
+                &extra_env,
+                Duration::from_secs(args.server_timeout_s),
+            )
+            .await?,
+        )
+    };
+
+    let body = run_iteration_body(client, base_url, args, iteration_index, iteration).await;
+
+    if let Some(c) = child {
+        if let Err(e) = process::stop_server(c).await {
+            eprintln!("warning: stop_server: {e:#}");
+        }
+        // 2s settle time, mirror the Python `time.sleep(2)` after kill.
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+    body
+}
+
+async fn run_iteration_body(
+    client: &reqwest::Client,
+    base_url: &str,
+    args: &Args,
+    iteration_index: usize,
+    iteration: &Iteration,
+) -> Result<IterationResult> {
+    let model = http::first_model_id(client, base_url).await?;
+    eprintln!("Model: {model}");
+
+    eprintln!("Warmup...");
+    let warmup_msgs = serde_json::json!([
+        {"role": "user", "content": "Say ready."},
+    ]);
+    let _ = stream(client, base_url, &model, &warmup_msgs, 4, None).await?;
+
+    let sweep = prompt_sweep(client, base_url, &model, args.repeats).await?;
+    let qa = run_qa(client, base_url, &model).await?;
+    let long_ctx = run_long_context(client, base_url, &model).await?;
+    let structured = run_structured(client, base_url, &model, iteration_index).await?;
+    let prefix_cache = run_prefix_cache(client, base_url, &model).await?;
+
+    eprintln!(
+        "Weighted prompt metrics: TTFT={:.0} ms  decode={:.1} tok/s",
+        sweep.weighted_ttft_ms, sweep.weighted_decode_tps
+    );
+    eprintln!(
+        "Accuracy checks: qa={}/{}  needle={}  json={}  cache={}",
+        qa.passed,
+        qa.total,
+        if long_ctx.passed { "pass" } else { "fail" },
+        if structured.passed { "pass" } else { "fail" },
+        if prefix_cache.passed { "pass" } else { "fail" },
+    );
+    eprintln!(
+        "Prefix cache: cold={:.0} ms  warm={:.0} ms  speedup={:.2}x",
+        prefix_cache.cold_ttft_ms, prefix_cache.warm_ttft_ms, prefix_cache.speedup
+    );
+
+    Ok(IterationResult {
+        iteration: iteration.slug.to_owned(),
+        label: iteration.label.to_owned(),
+        notes: iteration.notes.to_owned(),
+        args: iteration.args.iter().map(|s| (*s).to_owned()).collect(),
+        prompt_sweep: sweep,
+        qa,
+        long_context: long_ctx,
+        structured_output: structured,
+        prefix_cache,
+        score: None,
+    })
+}
+
+async fn stream(
+    client: &reqwest::Client,
+    base_url: &str,
+    model: &str,
+    messages: &serde_json::Value,
+    max_tokens: u32,
+    response_format: Option<serde_json::Value>,
+) -> Result<StreamMetrics> {
+    let opts = StreamChatOptions {
+        max_tokens,
+        temperature: 0.0,
+        api_key: None,
+        response_format,
+        estimate_prompt_tokens: false,
+    };
+    http::stream_chat_metrics(client, base_url, model, messages, &opts).await
+}
+
+async fn prompt_sweep(
+    client: &reqwest::Client,
+    base_url: &str,
+    model: &str,
+    repeats: u32,
+) -> Result<PromptSweep> {
+    let long = long_prompt();
+    let prompts: [(&str, &str); 3] = [
+        ("short", SHORT_PROMPT),
+        ("medium", MEDIUM_PROMPT),
+        ("long", &long),
+    ];
+    let weights: [(&str, f64); 3] = [("short", 0.2), ("medium", 0.3), ("long", 0.5)];
+    let mut metrics: Vec<(&str, PromptMetric)> = Vec::new();
+
+    for (label, prompt) in prompts {
+        let mut runs: Vec<StreamMetrics> = Vec::new();
+        for attempt in 0..repeats {
+            if attempt == 0 {
+                let warmup = serde_json::json!([
+                    {"role": "user", "content": format!("[warmup {label}] {prompt}")},
+                ]);
+                let _ = stream(client, base_url, model, &warmup, 8, None).await?;
+            }
+            let msgs = serde_json::json!([{"role": "user", "content": prompt}]);
+            let r = stream(client, base_url, model, &msgs, 64, None).await?;
+            runs.push(r);
+        }
+        let m = PromptMetric {
+            ttft_ms: median(&runs.iter().map(|r| r.ttft_ms).collect::<Vec<_>>()),
+            decode_tps: median(&runs.iter().map(|r| r.decode_tps).collect::<Vec<_>>()),
+            prompt_tokens: median(
+                &runs
+                    .iter()
+                    .map(|r| f64::from(r.prompt_tokens))
+                    .collect::<Vec<_>>(),
+            ),
+            completion_tokens: median(
+                &runs
+                    .iter()
+                    .map(|r| f64::from(r.completion_tokens))
+                    .collect::<Vec<_>>(),
+            ),
+        };
+        metrics.push((label, m));
+    }
+
+    let mut weighted_ttft = 0.0;
+    let mut weighted_decode = 0.0;
+    for (label, weight) in weights {
+        let m = metrics
+            .iter()
+            .find(|(l, _)| *l == label)
+            .map(|(_, m)| m)
+            .expect("prompt label present in metrics");
+        weighted_ttft += m.ttft_ms * weight;
+        weighted_decode += m.decode_tps * weight;
+    }
+
+    let pick = |name: &str| -> PromptMetric {
+        metrics
+            .iter()
+            .find(|(l, _)| *l == name)
+            .map(|(_, m)| m.clone())
+            .expect("prompt label present")
+    };
+
+    Ok(PromptSweep {
+        short: pick("short"),
+        medium: pick("medium"),
+        long: pick("long"),
+        weighted_ttft_ms: weighted_ttft,
+        weighted_decode_tps: weighted_decode,
+    })
+}
+
+async fn run_qa(client: &reqwest::Client, base_url: &str, model: &str) -> Result<QaResults> {
+    let mut cases = Vec::new();
+    let mut passed = 0_u32;
+    for (prompt, expected) in QA_CASES {
+        let msgs = serde_json::json!([{"role": "user", "content": prompt}]);
+        let resp = http::chat_with_options(client, base_url, model, &msgs, 16, 0.0, None).await?;
+        let normalized = normalize_text(&resp.content);
+        let success = normalized == *expected;
+        if success {
+            passed += 1;
+        }
+        cases.push(QaCaseResult {
+            prompt: (*prompt).to_owned(),
+            expected: (*expected).to_owned(),
+            output: normalized,
+            passed: success,
+        });
+    }
+    let total = QA_CASES.len() as u32;
+    Ok(QaResults {
+        passed,
+        total,
+        accuracy: f64::from(passed) / f64::from(total),
+        cases,
+    })
+}
+
+async fn run_long_context(
+    client: &reqwest::Client,
+    base_url: &str,
+    model: &str,
+) -> Result<LongContextResult> {
+    let filler = long_context_filler();
+    let prompt = format!(
+        "Read the following deployment notes carefully.\n\n{filler}\n\nImportant hidden code: {LONG_CONTEXT_NEEDLE}\n\n{filler}\n\nQuestion: reply with the deployment code only."
+    );
+    let msgs = serde_json::json!([{"role": "user", "content": prompt}]);
+    let resp = http::chat_with_options(client, base_url, model, &msgs, 8, 0.0, None).await?;
+    let output = normalize_text(&resp.content).replace(' ', "");
+    let expected = LONG_CONTEXT_NEEDLE.to_lowercase();
+    let passed = output.contains(&expected);
+    Ok(LongContextResult {
+        expected,
+        output,
+        passed,
+        accuracy: if passed { 1.0 } else { 0.0 },
+        prompt_tokens: resp.prompt_tokens,
+    })
+}
+
+async fn run_structured(
+    client: &reqwest::Client,
+    base_url: &str,
+    model: &str,
+    iteration_index: usize,
+) -> Result<StructuredResult> {
+    let prompt = format!(
+        "Return structured JSON only. Facts: model_family=qwen, iteration={iteration_index}, prefill_focus=true, kv_bits=3, primary_goal=latency."
+    );
+    let schema = structured_schema();
+    let msgs = serde_json::json!([{"role": "user", "content": prompt}]);
+    let resp =
+        http::chat_with_options(client, base_url, model, &msgs, 64, 0.0, Some(&schema)).await?;
+    let parsed: serde_json::Value = match serde_json::from_str(&resp.content) {
+        Ok(v) => v,
+        Err(_) => {
+            return Ok(StructuredResult {
+                passed: false,
+                accuracy: 0.0,
+                raw: Some(resp.content),
+                parsed: None,
+            });
+        }
+    };
+    let expected = serde_json::json!({
+        "model_family": "qwen",
+        "iteration": iteration_index,
+        "prefill_focus": true,
+        "kv_bits": 3,
+        "primary_goal": "latency",
+    });
+    let passed = parsed == expected;
+    Ok(StructuredResult {
+        passed,
+        accuracy: if passed { 1.0 } else { 0.0 },
+        raw: None,
+        parsed: Some(parsed),
+    })
+}
+
+async fn run_prefix_cache(
+    client: &reqwest::Client,
+    base_url: &str,
+    model: &str,
+) -> Result<PrefixCacheResult> {
+    let doc = prefix_cache_doc();
+    let prefix = serde_json::json!([
+        {"role": "system", "content": format!(
+            "You are reviewing an operations handbook. Study the material and reply READY only.\n\n{doc}",
+        )},
+        {"role": "user", "content": "Read the handbook and reply READY only."},
+    ]);
+    let followup = serde_json::json!([
+        prefix[0],
+        prefix[1],
+        {"role": "assistant", "content": "READY"},
+        {"role": "user", "content": "What is the failover region? Reply with two words only."},
+    ]);
+
+    let cold = stream(client, base_url, model, &followup, 8, None).await?;
+    let _ = stream(client, base_url, model, &prefix, 4, None).await?;
+    let warm = stream(client, base_url, model, &followup, 8, None).await?;
+
+    let warm_output = normalize_text(&warm.output);
+    let passed = warm_output.contains("cape town");
+    let speedup = if warm.ttft_ms > 0.0 {
+        cold.ttft_ms / warm.ttft_ms
+    } else {
+        0.0
+    };
+    Ok(PrefixCacheResult {
+        cold_ttft_ms: cold.ttft_ms,
+        warm_ttft_ms: warm.ttft_ms,
+        speedup,
+        answer: warm.output,
+        passed,
+        accuracy: if passed { 1.0 } else { 0.0 },
+    })
+}
+
+fn score_results(results: &mut [IterationResult]) {
+    let speeds: Vec<SpeedInputs> = results
+        .iter()
+        .map(|r| SpeedInputs {
+            weighted_ttft_ms: r.prompt_sweep.weighted_ttft_ms,
+            weighted_decode_tps: r.prompt_sweep.weighted_decode_tps,
+        })
+        .collect();
+    let caches: Vec<CacheInputs> = results
+        .iter()
+        .map(|r| CacheInputs {
+            passed: r.prefix_cache.passed,
+            speedup: r.prefix_cache.speedup,
+        })
+        .collect();
+    let (best_ttft, best_decode, best_cache) = compute_bests(&speeds, &caches);
+
+    for r in results.iter_mut() {
+        let acc = AccuracyInputs {
+            qa: r.qa.accuracy,
+            long_context: r.long_context.accuracy,
+            structured_output: r.structured_output.accuracy,
+            prefix_cache: r.prefix_cache.accuracy,
+        };
+        let speed = SpeedInputs {
+            weighted_ttft_ms: r.prompt_sweep.weighted_ttft_ms,
+            weighted_decode_tps: r.prompt_sweep.weighted_decode_tps,
+        };
+        let cache = CacheInputs {
+            passed: r.prefix_cache.passed,
+            speedup: r.prefix_cache.speedup,
+        };
+        let s = compute_iteration_score(acc, speed, cache, best_ttft, best_decode, best_cache);
+        r.score = Some(ScoreOut {
+            accuracy: s.accuracy,
+            speed: s.speed,
+            cache: s.cache,
+            composite: s.composite,
+        });
+    }
+}
+
+fn print_summary(results: &[IterationResult], winner: Option<&str>) {
+    let mut ordered: Vec<&IterationResult> = results.iter().collect();
+    ordered.sort_by(|a, b| {
+        let aa = a.score.as_ref().map_or(0.0, |s| s.composite);
+        let bb = b.score.as_ref().map_or(0.0, |s| s.composite);
+        bb.partial_cmp(&aa).unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    eprintln!("\n{}", "#".repeat(80));
+    eprintln!("FINAL SUMMARY");
+    eprintln!("{}", "#".repeat(80));
+    eprintln!(
+        "{:32} {:>8} {:>10} {:>10} {:>6} {:>8} {:>6} {:>8}",
+        "Iteration", "Score", "TTFT", "Decode", "QA", "Needle", "JSON", "Cache"
+    );
+    eprintln!("{}", "-".repeat(96));
+    for r in &ordered {
+        let label = if r.label.len() > 32 {
+            &r.label[..32]
+        } else {
+            &r.label
+        };
+        let composite = r.score.as_ref().map_or(0.0, |s| s.composite);
+        eprintln!(
+            "{:32} {:>7.1} {:>9.0} {:>9.1} {:>2}/{:<3} {:>8} {:>6} {:>7.2}x",
+            label,
+            composite,
+            r.prompt_sweep.weighted_ttft_ms,
+            r.prompt_sweep.weighted_decode_tps,
+            r.qa.passed,
+            r.qa.total,
+            if r.long_context.passed {
+                "pass"
+            } else {
+                "fail"
+            },
+            if r.structured_output.passed {
+                "pass"
+            } else {
+                "fail"
+            },
+            r.prefix_cache.speedup,
+        );
+    }
+    if let Some(w) = winner {
+        eprintln!("\nWinner: {w}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Ports of `benchmarks/test_bench_mlx_tuning.py`.
+    use super::*;
+    use higgs_bench::score::{
+        AccuracyInputs, CacheInputs, SpeedInputs, clamp_cache_speedup, compute_iteration_score,
+        normalize_text,
+    };
+
+    fn approx(a: f64, b: f64) {
+        assert!((a - b).abs() < 1e-9, "lhs={a} rhs={b}");
+    }
+
+    #[test]
+    fn test_normalize_text() {
+        let normalized = normalize_text("  Leading\tand\ntrailing  MIXED  Case ");
+        assert_eq!(normalized, "leading and trailing mixed case");
+    }
+
+    #[test]
+    fn test_cache_speedup_is_capped() {
+        approx(clamp_cache_speedup(96.0), 32.0);
+        approx(clamp_cache_speedup(12.0), 12.0);
+    }
+
+    #[test]
+    fn test_compute_iteration_score_applies_formula() {
+        let acc = AccuracyInputs {
+            qa: 1.0,
+            long_context: 0.5,
+            structured_output: 0.0,
+            prefix_cache: 1.0,
+        };
+        let speed = SpeedInputs {
+            weighted_ttft_ms: 100.0,
+            weighted_decode_tps: 100.0,
+        };
+        let cache = CacheInputs {
+            passed: true,
+            speedup: 96.0,
+        };
+        let s = compute_iteration_score(acc, speed, cache, 100.0, 50.0, 16.0);
+
+        let expected_accuracy = (1.0_f64 * 0.45) + (0.5 * 0.25) + (0.0 * 0.15) + (1.0 * 0.15);
+        let expected_speed = (100.0_f64 / 100.0) * 0.55 + (100.0 / 50.0) * 0.45;
+        let expected_cache = 32.0_f64 / 16.0;
+        let expected_composite = 100.0
+            * ((expected_accuracy * 0.45) + (expected_speed * 0.45) + (expected_cache * 0.10));
+
+        approx(s.accuracy, expected_accuracy);
+        approx(s.speed, expected_speed);
+        approx(s.cache, expected_cache);
+        approx(s.composite, expected_composite);
+    }
+
+    fn dummy_iteration_result(
+        weighted_ttft_ms: f64,
+        weighted_decode_tps: f64,
+        qa_accuracy: f64,
+        long_accuracy: f64,
+        structured_accuracy: f64,
+        cache_passed: bool,
+        cache_speedup: f64,
+    ) -> IterationResult {
+        IterationResult {
+            iteration: "dummy".into(),
+            label: "dummy".into(),
+            notes: String::new(),
+            args: vec![],
+            prompt_sweep: PromptSweep {
+                short: PromptMetric {
+                    ttft_ms: 0.0,
+                    decode_tps: 0.0,
+                    prompt_tokens: 0.0,
+                    completion_tokens: 0.0,
+                },
+                medium: PromptMetric {
+                    ttft_ms: 0.0,
+                    decode_tps: 0.0,
+                    prompt_tokens: 0.0,
+                    completion_tokens: 0.0,
+                },
+                long: PromptMetric {
+                    ttft_ms: 0.0,
+                    decode_tps: 0.0,
+                    prompt_tokens: 0.0,
+                    completion_tokens: 0.0,
+                },
+                weighted_ttft_ms,
+                weighted_decode_tps,
+            },
+            qa: QaResults {
+                passed: 0,
+                total: 5,
+                accuracy: qa_accuracy,
+                cases: vec![],
+            },
+            long_context: LongContextResult {
+                expected: String::new(),
+                output: String::new(),
+                passed: long_accuracy >= 1.0,
+                accuracy: long_accuracy,
+                prompt_tokens: 0,
+            },
+            structured_output: StructuredResult {
+                passed: structured_accuracy >= 1.0,
+                accuracy: structured_accuracy,
+                raw: None,
+                parsed: None,
+            },
+            prefix_cache: PrefixCacheResult {
+                cold_ttft_ms: 0.0,
+                warm_ttft_ms: 0.0,
+                speedup: cache_speedup,
+                answer: String::new(),
+                passed: cache_passed,
+                accuracy: if cache_passed { 1.0 } else { 0.0 },
+            },
+            score: None,
+        }
+    }
+
+    #[test]
+    fn test_score_results_marks_all_results() {
+        let mut results = vec![
+            dummy_iteration_result(200.0, 80.0, 0.4, 0.0, 1.0, false, 12.0),
+            dummy_iteration_result(100.0, 160.0, 0.8, 1.0, 1.0, true, 96.0),
+        ];
+        score_results(&mut results);
+        assert!(results[0].score.is_some());
+        assert!(results[1].score.is_some());
+        assert!(
+            (results[0].score.as_ref().unwrap().composite
+                - results[1].score.as_ref().unwrap().composite)
+                .abs()
+                > 1e-9
+        );
+    }
+
+    #[test]
+    fn test_rank_results_by_score() {
+        let mut results = vec![
+            {
+                let mut r = dummy_iteration_result(0.0, 0.0, 0.0, 0.0, 0.0, false, 0.0);
+                r.score = Some(ScoreOut {
+                    accuracy: 0.0,
+                    speed: 0.0,
+                    cache: 0.0,
+                    composite: 33.0,
+                });
+                r
+            },
+            {
+                let mut r = dummy_iteration_result(0.0, 0.0, 0.0, 0.0, 0.0, false, 0.0);
+                r.score = Some(ScoreOut {
+                    accuracy: 0.0,
+                    speed: 0.0,
+                    cache: 0.0,
+                    composite: 72.0,
+                });
+                r
+            },
+            {
+                let mut r = dummy_iteration_result(0.0, 0.0, 0.0, 0.0, 0.0, false, 0.0);
+                r.score = Some(ScoreOut {
+                    accuracy: 0.0,
+                    speed: 0.0,
+                    cache: 0.0,
+                    composite: 51.0,
+                });
+                r
+            },
+        ];
+        results.sort_by(|a, b| {
+            b.score
+                .as_ref()
+                .unwrap()
+                .composite
+                .partial_cmp(&a.score.as_ref().unwrap().composite)
+                .unwrap()
+        });
+        approx(results[0].score.as_ref().unwrap().composite, 72.0);
+    }
+}

--- a/crates/higgs-bench/src/http.rs
+++ b/crates/higgs-bench/src/http.rs
@@ -220,13 +220,22 @@ pub async fn chat(
 
 /// Returns the first model id reported by `GET /v1/models`.
 pub async fn first_model_id(client: &reqwest::Client, base_url: &str) -> Result<String> {
+    first_model_id_with_auth(client, base_url, None).await
+}
+
+/// Like `first_model_id`, but optionally sends an `Authorization: Bearer`
+/// header. Used by the oMLX backend in `bench_h2h`.
+pub async fn first_model_id_with_auth(
+    client: &reqwest::Client,
+    base_url: &str,
+    api_key: Option<&str>,
+) -> Result<String> {
     let url = format!("{base_url}/v1/models");
-    let resp = client
-        .get(&url)
-        .timeout(Duration::from_secs(5))
-        .send()
-        .await
-        .with_context(|| format!("GET {url}"))?;
+    let mut req = client.get(&url).timeout(Duration::from_secs(5));
+    if let Some(key) = api_key {
+        req = req.bearer_auth(key);
+    }
+    let resp = req.send().await.with_context(|| format!("GET {url}"))?;
     if !resp.status().is_success() {
         anyhow::bail!("{url} returned HTTP {}", resp.status());
     }
@@ -238,4 +247,233 @@ pub async fn first_model_id(client: &reqwest::Client, base_url: &str) -> Result<
         .and_then(|s| s.as_str())
         .map(std::string::ToString::to_string)
         .ok_or_else(|| anyhow::anyhow!("no models reported by {url}"))
+}
+
+/// One streamed chat completion result with TTFT, decode tok/s, and the
+/// flag tracking whether the server reported `usage.completion_tokens` or
+/// we estimated it from the streamed character count.
+///
+/// Mirrors `bench_mlx_tuning.py::stream_chat` and `bench_h2h.py::stream_chat`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StreamMetrics {
+    pub ttft_ms: f64,
+    pub decode_tps: f64,
+    pub total_ms: f64,
+    pub prompt_tokens: u32,
+    pub completion_tokens: u32,
+    pub completion_tokens_estimated: bool,
+    pub output: String,
+}
+
+/// Optional knobs for `stream_chat_metrics`.
+#[derive(Debug, Default, Clone)]
+pub struct StreamChatOptions<'a> {
+    pub max_tokens: u32,
+    pub temperature: f32,
+    pub api_key: Option<&'a str>,
+    pub response_format: Option<serde_json::Value>,
+    pub estimate_prompt_tokens: bool,
+}
+
+/// Drives a streaming chat completion and returns ttft + decode-tok/s.
+///
+/// Same shape as the Python `stream_chat` helpers used by `bench_h2h`
+/// and `bench_mlx_tuning`. If `usage.completion_tokens` is absent the
+/// completion-token count is estimated from the streamed character count
+/// (`max(1, output_chars / 3.5)`); the flag is preserved on the result.
+#[allow(clippy::too_many_lines)]
+pub async fn stream_chat_metrics(
+    client: &reqwest::Client,
+    base_url: &str,
+    model: &str,
+    messages: &serde_json::Value,
+    opts: &StreamChatOptions<'_>,
+) -> Result<StreamMetrics> {
+    let mut body = serde_json::json!({
+        "model": model,
+        "messages": messages,
+        "max_tokens": opts.max_tokens,
+        "temperature": opts.temperature,
+        "stream": true,
+    });
+    if let Some(rf) = &opts.response_format {
+        if let Some(map) = body.as_object_mut() {
+            map.insert("response_format".to_owned(), rf.clone());
+        }
+    }
+
+    let url = format!("{base_url}/v1/chat/completions");
+    let mut req = client.post(&url).json(&body);
+    if let Some(key) = opts.api_key {
+        req = req.bearer_auth(key);
+    }
+    let started = Instant::now();
+    let resp = req.send().await.with_context(|| format!("POST {url}"))?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        anyhow::bail!("{url} returned HTTP {status}: {text}");
+    }
+
+    let mut stream = resp.bytes_stream();
+    let mut first_token_at: Option<Instant> = None;
+    let mut tokens: Vec<String> = Vec::new();
+    let mut prompt_tokens: u32 = 0;
+    let mut completion_tokens: u32 = 0;
+    let mut buf = String::new();
+
+    while let Some(chunk_res) = stream.next().await {
+        let bytes = chunk_res.context("read SSE chunk")?;
+        buf.push_str(&String::from_utf8_lossy(&bytes));
+        while let Some(idx) = buf.find('\n') {
+            let raw: String = buf.drain(..=idx).collect();
+            let line = raw.trim();
+            if line.is_empty() || !line.starts_with("data:") {
+                continue;
+            }
+            let data = line.trim_start_matches("data:").trim();
+            if data == "[DONE]" {
+                continue;
+            }
+            let value: serde_json::Value = match serde_json::from_str(data) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+            if let Some(content) = value
+                .get("choices")
+                .and_then(|c| c.get(0))
+                .and_then(|c| c.get("delta"))
+                .and_then(|d| d.get("content"))
+                .and_then(|s| s.as_str())
+            {
+                if !content.is_empty() {
+                    if first_token_at.is_none() {
+                        first_token_at = Some(Instant::now());
+                    }
+                    tokens.push(content.to_owned());
+                }
+            }
+            if let Some(usage) = value.get("usage") {
+                if let Some(p) = usage
+                    .get("prompt_tokens")
+                    .and_then(serde_json::Value::as_u64)
+                {
+                    prompt_tokens = p as u32;
+                }
+                if let Some(c) = usage
+                    .get("completion_tokens")
+                    .and_then(serde_json::Value::as_u64)
+                {
+                    completion_tokens = c as u32;
+                }
+            }
+        }
+    }
+
+    let ended = Instant::now();
+    let first_token = first_token_at.unwrap_or(ended);
+    let ttft_ms = first_token.duration_since(started).as_secs_f64() * 1000.0;
+    let decode_s = ended.duration_since(first_token).as_secs_f64().max(0.001);
+
+    let mut completion_tokens_estimated = false;
+    if completion_tokens == 0 {
+        let output_chars: usize = tokens.iter().map(String::len).sum();
+        if output_chars > 0 {
+            completion_tokens = (output_chars as f64 / 3.5).max(1.0) as u32;
+            completion_tokens_estimated = true;
+        }
+    }
+
+    if opts.estimate_prompt_tokens && prompt_tokens == 0 {
+        let prompt_chars = messages
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|m| m.get("content").and_then(|c| c.as_str()))
+                    .map(str::len)
+                    .sum::<usize>()
+            })
+            .unwrap_or_default();
+        if prompt_chars > 0 {
+            prompt_tokens = (prompt_chars as f64 / 3.5).max(1.0) as u32;
+        }
+    }
+
+    let decode_tps = if completion_tokens > 0 {
+        f64::from(completion_tokens.saturating_sub(1)) / decode_s
+    } else {
+        0.0
+    };
+    let total_ms = ended.duration_since(started).as_secs_f64() * 1000.0;
+
+    Ok(StreamMetrics {
+        ttft_ms,
+        decode_tps,
+        total_ms,
+        prompt_tokens,
+        completion_tokens,
+        completion_tokens_estimated,
+        output: tokens.join(""),
+    })
+}
+
+/// Non-streaming chat with optional `response_format` and `api_key`.
+pub async fn chat_with_options(
+    client: &reqwest::Client,
+    base_url: &str,
+    model: &str,
+    messages: &serde_json::Value,
+    max_tokens: u32,
+    temperature: f32,
+    response_format: Option<&serde_json::Value>,
+) -> Result<ChatResult> {
+    let mut body = serde_json::json!({
+        "model": model,
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+    });
+    if let Some(rf) = response_format {
+        if let Some(map) = body.as_object_mut() {
+            map.insert("response_format".to_owned(), rf.clone());
+        }
+    }
+    let url = format!("{base_url}/v1/chat/completions");
+    let started = Instant::now();
+    let resp = client
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .with_context(|| format!("POST {url}"))?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        anyhow::bail!("{url} returned HTTP {status}: {text}");
+    }
+    let elapsed_ms = started.elapsed().as_secs_f64() * 1000.0;
+    let value: serde_json::Value = resp.json().await.context("decode chat response JSON")?;
+    let content = value
+        .get("choices")
+        .and_then(|c| c.get(0))
+        .and_then(|c| c.get("message"))
+        .and_then(|m| m.get("content"))
+        .and_then(|s| s.as_str())
+        .unwrap_or_default()
+        .to_owned();
+    let usage = value.get("usage");
+    let prompt_tokens = usage
+        .and_then(|u| u.get("prompt_tokens"))
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0) as u32;
+    let completion_tokens = usage
+        .and_then(|u| u.get("completion_tokens"))
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0) as u32;
+    Ok(ChatResult {
+        content,
+        elapsed_ms,
+        prompt_tokens,
+        completion_tokens,
+    })
 }

--- a/crates/higgs-bench/src/http.rs
+++ b/crates/higgs-bench/src/http.rs
@@ -273,6 +273,11 @@ pub struct StreamChatOptions<'a> {
     pub api_key: Option<&'a str>,
     pub response_format: Option<serde_json::Value>,
     pub estimate_prompt_tokens: bool,
+    /// Ask the server to emit a terminal `usage` chunk by sending
+    /// `stream_options.include_usage = true`. Higgs honors this; some
+    /// other backends (oMLX, in particular) reject unknown keys, so leave
+    /// disabled for those and rely on the character-count estimate.
+    pub include_usage: bool,
 }
 
 /// Drives a streaming chat completion and returns ttft + decode-tok/s.
@@ -299,6 +304,14 @@ pub async fn stream_chat_metrics(
     if let Some(rf) = &opts.response_format {
         if let Some(map) = body.as_object_mut() {
             map.insert("response_format".to_owned(), rf.clone());
+        }
+    }
+    if opts.include_usage {
+        if let Some(map) = body.as_object_mut() {
+            map.insert(
+                "stream_options".to_owned(),
+                serde_json::json!({"include_usage": true}),
+            );
         }
     }
 

--- a/crates/higgs-bench/src/lib.rs
+++ b/crates/higgs-bench/src/lib.rs
@@ -14,6 +14,7 @@
 pub mod http;
 pub mod models;
 pub mod process;
+pub mod score;
 pub mod server;
 pub mod stats;
 

--- a/crates/higgs-bench/src/models.rs
+++ b/crates/higgs-bench/src/models.rs
@@ -29,7 +29,7 @@ pub struct Model {
     pub tags: Vec<String>,
     /// Local directory containing this model in oMLX's expected layout
     /// (parent of the model directory). oMLX's `--model-dir` walks one
-    /// level deep and rejects HuggingFace repo IDs, so `bench_h2h`
+    /// level deep and rejects `HuggingFace` repo IDs, so `bench_h2h`
     /// requires this for any model tagged `h2h`. Leading `~` is expanded
     /// against `$HOME` at load time.
     #[serde(default)]

--- a/crates/higgs-bench/src/models.rs
+++ b/crates/higgs-bench/src/models.rs
@@ -4,7 +4,7 @@
 //! Adding a new model is one TOML entry; benches can filter by tag.
 
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -27,6 +27,35 @@ pub struct Model {
     /// Optional tags for filtering, e.g. `small`, `dense`, `moe`, `h2h`.
     #[serde(default)]
     pub tags: Vec<String>,
+    /// Local directory containing this model in oMLX's expected layout
+    /// (parent of the model directory). oMLX's `--model-dir` walks one
+    /// level deep and rejects HuggingFace repo IDs, so `bench_h2h`
+    /// requires this for any model tagged `h2h`. Leading `~` is expanded
+    /// against `$HOME` at load time.
+    #[serde(default)]
+    pub omlx_model_dir: Option<PathBuf>,
+}
+
+impl Model {
+    /// Returns `omlx_model_dir` with a leading `~` expanded to `$HOME`.
+    #[must_use]
+    pub fn resolved_omlx_model_dir(&self) -> Option<PathBuf> {
+        self.omlx_model_dir.as_ref().map(|p| expand_tilde(p))
+    }
+}
+
+fn expand_tilde(p: &Path) -> PathBuf {
+    let s = p.to_string_lossy();
+    if let Some(rest) = s.strip_prefix("~/") {
+        if let Some(home) = std::env::var_os("HOME") {
+            return PathBuf::from(home).join(rest);
+        }
+    } else if s == "~" {
+        if let Some(home) = std::env::var_os("HOME") {
+            return PathBuf::from(home);
+        }
+    }
+    p.to_path_buf()
 }
 
 /// Top-level structure of `benchmarks/models.toml`.

--- a/crates/higgs-bench/src/process.rs
+++ b/crates/higgs-bench/src/process.rs
@@ -54,6 +54,18 @@ pub async fn start_higgs_server(
     extra_args: &[String],
     timeout: Duration,
 ) -> Result<Child> {
+    start_higgs_server_with_env(model, port, extra_args, &[], timeout).await
+}
+
+/// Like `start_higgs_server`, but injects extra environment variables —
+/// e.g. `HIGGS_MLX_PROFILE` for `bench_mlx_tuning`.
+pub async fn start_higgs_server_with_env(
+    model: &str,
+    port: u16,
+    extra_args: &[String],
+    extra_env: &[(String, String)],
+    timeout: Duration,
+) -> Result<Child> {
     let bin = higgs_bin();
     ensure_higgs_bin(&bin)?;
     let mut cmd = Command::new(&bin);
@@ -68,6 +80,9 @@ pub async fn start_higgs_server(
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .kill_on_drop(true);
+    for (k, v) in extra_env {
+        cmd.env(k, v);
+    }
 
     let mut child = cmd
         .spawn()
@@ -92,6 +107,83 @@ pub async fn start_higgs_server(
         }
     }
     Ok(child)
+}
+
+/// Path to the oMLX CLI on macOS. Honors `OMLX_CLI` if set.
+#[must_use]
+pub fn omlx_cli() -> PathBuf {
+    if let Ok(p) = std::env::var("OMLX_CLI") {
+        return PathBuf::from(p);
+    }
+    PathBuf::from("/Applications/oMLX.app/Contents/MacOS/omlx-cli")
+}
+
+/// Spawns `omlx-cli serve --model-dir <dir> --port <port>` as a child
+/// process with stdio captured, then waits up to `timeout` for the server
+/// to respond on `/v1/models` (oMLX requires a bearer token; we send
+/// `omlx`).
+///
+/// `model_parent_dir` is the *parent* of the model dir — oMLX walks one
+/// level deep. The Python helper does `os.path.dirname(model_path)`.
+pub async fn start_omlx_server(
+    model_parent_dir: &str,
+    port: u16,
+    timeout: Duration,
+) -> Result<Child> {
+    let bin = omlx_cli();
+    let mut cmd = Command::new(&bin);
+    cmd.arg("serve")
+        .arg("--model-dir")
+        .arg(model_parent_dir)
+        .arg("--port")
+        .arg(port.to_string())
+        .arg("--no-cache")
+        .arg("--max-num-seqs")
+        .arg("1")
+        .arg("--log-level")
+        .arg("warning")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .kill_on_drop(true);
+
+    let child = cmd.spawn().with_context(|| {
+        format!(
+            "spawn {} serve --model-dir {model_parent_dir}",
+            bin.display()
+        )
+    })?;
+
+    // oMLX requires bearer auth on /v1/models; the readiness probe
+    // doesn't send one, but oMLX reports HTTP 200 on /v1/models when
+    // bearer is present and 401 otherwise — both indicate a live server.
+    // Wait for either status by treating 401 as "alive".
+    let base_url = format!("http://127.0.0.1:{port}");
+    wait_until_responding(&base_url, timeout).await?;
+    Ok(child)
+}
+
+async fn wait_until_responding(base_url: &str, timeout: Duration) -> Result<()> {
+    use std::time::Instant;
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(2))
+        .build()
+        .context("build readiness probe client")?;
+    let deadline = Instant::now() + timeout;
+    let url = format!("{base_url}/v1/models");
+    let mut last_err = String::new();
+    while Instant::now() < deadline {
+        match client.get(&url).bearer_auth("omlx").send().await {
+            Ok(resp) if resp.status().is_success() || resp.status().as_u16() == 401 => {
+                return Ok(());
+            }
+            Ok(resp) => last_err = format!("HTTP {}", resp.status()),
+            Err(e) => last_err = format!("{e}"),
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    Err(anyhow::anyhow!(
+        "server at {base_url} did not become ready within {timeout:?}: {last_err}"
+    ))
 }
 
 /// Forcefully terminates the higgs child and waits for it to exit.

--- a/crates/higgs-bench/src/score.rs
+++ b/crates/higgs-bench/src/score.rs
@@ -1,0 +1,156 @@
+// `clippy::suboptimal_flops` would rewrite `a*b + c*d` as `c.mul_add(d,
+// a*b)`, which fuses to a single rounding step and produces results
+// numerically distinct from the Python reference. The acceptance
+// criterion requires exact equivalence with Python, so the literal
+// add/multiply form is the correct one.
+#![allow(
+    clippy::module_name_repetitions,
+    clippy::suboptimal_flops,
+    clippy::if_not_else
+)]
+//! Composite-score math for `bench_mlx_tuning`.
+//!
+//! Pulled into the library crate (rather than the bin file) so the unit
+//! tests ported from `benchmarks/test_bench_mlx_tuning.py` can exercise
+//! the formulas directly. The formulas mirror the Python verbatim —
+//! `bench_mlx_tuning.py`'s acceptance criterion is "composite score
+//! matches Python given the same inputs", so any drift here is a bug.
+
+/// Cap on the prefix-cache speedup factored into the composite score.
+/// Mirrors `CACHE_SPEEDUP_CAP = 32.0` in `bench_mlx_tuning.py`.
+pub const CACHE_SPEEDUP_CAP: f64 = 32.0;
+
+/// Trims, lowercases, and collapses runs of whitespace.
+///
+/// Matches `bench_mlx_tuning.py::normalize_text`.
+#[must_use]
+pub fn normalize_text(text: &str) -> String {
+    text.split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
+}
+
+/// Caps `speedup` at `CACHE_SPEEDUP_CAP`.
+#[must_use]
+pub const fn clamp_cache_speedup(speedup: f64) -> f64 {
+    if speedup < CACHE_SPEEDUP_CAP {
+        speedup
+    } else {
+        CACHE_SPEEDUP_CAP
+    }
+}
+
+/// Sub-bench accuracy inputs (one per iteration).
+#[derive(Debug, Clone, Copy)]
+pub struct AccuracyInputs {
+    pub qa: f64,
+    pub long_context: f64,
+    pub structured_output: f64,
+    pub prefix_cache: f64,
+}
+
+/// Speed inputs: weighted TTFT (ms) and weighted decode tok/s.
+#[derive(Debug, Clone, Copy)]
+pub struct SpeedInputs {
+    pub weighted_ttft_ms: f64,
+    pub weighted_decode_tps: f64,
+}
+
+/// Prefix cache inputs.
+#[derive(Debug, Clone, Copy)]
+pub struct CacheInputs {
+    pub passed: bool,
+    pub speedup: f64,
+}
+
+/// Composite components: each in `[0, 1+]`, weighted into `composite`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Score {
+    pub accuracy: f64,
+    pub speed: f64,
+    pub cache: f64,
+    pub composite: f64,
+}
+
+/// Mirrors `compute_accuracy_score` in `bench_mlx_tuning.py`.
+#[must_use]
+pub fn compute_accuracy_score(acc: AccuracyInputs) -> f64 {
+    (acc.qa * 0.45)
+        + (acc.long_context * 0.25)
+        + (acc.structured_output * 0.15)
+        + (acc.prefix_cache * 0.15)
+}
+
+/// Mirrors `compute_speed_score` in `bench_mlx_tuning.py`.
+#[must_use]
+pub fn compute_speed_score(speed: SpeedInputs, best_ttft: f64, best_decode: f64) -> f64 {
+    let ttft_score = if best_ttft != 0.0 && speed.weighted_ttft_ms != 0.0 {
+        best_ttft / speed.weighted_ttft_ms
+    } else {
+        0.0
+    };
+    let decode_score = if best_decode != 0.0 {
+        speed.weighted_decode_tps / best_decode
+    } else {
+        0.0
+    };
+    (ttft_score * 0.55) + (decode_score * 0.45)
+}
+
+/// Mirrors `compute_iteration_score` in `bench_mlx_tuning.py`.
+#[must_use]
+pub fn compute_iteration_score(
+    acc: AccuracyInputs,
+    speed: SpeedInputs,
+    cache: CacheInputs,
+    best_ttft: f64,
+    best_decode: f64,
+    best_cache: f64,
+) -> Score {
+    let accuracy = compute_accuracy_score(acc);
+    let speed_score = compute_speed_score(speed, best_ttft, best_decode);
+    let cache_speedup = if cache.passed {
+        clamp_cache_speedup(cache.speedup)
+    } else {
+        0.0
+    };
+    let cache_score = if best_cache != 0.0 {
+        cache_speedup / best_cache
+    } else {
+        0.0
+    };
+    let composite = 100.0 * ((accuracy * 0.45) + (speed_score * 0.45) + (cache_score * 0.10));
+    Score {
+        accuracy,
+        speed: speed_score,
+        cache: cache_score,
+        composite,
+    }
+}
+
+/// Computes per-iteration `best_*` aggregates from a slice of (speed,
+/// cache) inputs. Mirrors the `score_results` body in
+/// `bench_mlx_tuning.py`.
+#[must_use]
+pub fn compute_bests(speeds: &[SpeedInputs], caches: &[CacheInputs]) -> (f64, f64, f64) {
+    let best_ttft = speeds
+        .iter()
+        .map(|s| s.weighted_ttft_ms)
+        .fold(f64::INFINITY, f64::min);
+    let best_decode = speeds
+        .iter()
+        .map(|s| s.weighted_decode_tps)
+        .fold(f64::NEG_INFINITY, f64::max);
+    let best_cache = caches
+        .iter()
+        .filter(|c| c.passed)
+        .map(|c| clamp_cache_speedup(c.speedup))
+        .fold(f64::NEG_INFINITY, f64::max);
+    let best_cache_finalized = if best_cache.is_finite() && best_cache > 0.0 {
+        best_cache
+    } else {
+        1.0
+    };
+    (best_ttft, best_decode, best_cache_finalized)
+}

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -13,7 +13,8 @@ This document collects the benchmark methodology and the benchmark-driven defaul
 Use the benchmark harness below to compare five serving iterations on the same local model:
 
 ```bash
-python3 benchmarks/bench_mlx_tuning.py ~/.cache/lm-studio/models/mlx-community/Qwen3.6-35B-A3B-4bit
+cargo run --release -p higgs-bench --bin bench_mlx_tuning -- \
+  ~/.cache/lm-studio/models/mlx-community/Qwen3.6-35B-A3B-4bit
 ```
 
 The harness evaluates:
@@ -223,6 +224,44 @@ model.
 ```bash
 cargo run --release -p higgs-bench --bin bench_all -- --tag all
 ```
+
+### `bench_mlx_tuning`
+
+Spins up five higgs server profiles (baseline / latency / balanced /
+throughput / throughput+TurboQuant), runs a TTFT sweep across short,
+medium, and long prompts, scores short QA accuracy, long-context needle
+retrieval, structured-output correctness, and prefix-cache speedup, and
+emits a composite score that mirrors the Python `bench_mlx_tuning.py`
+formula exactly. Use this to pick the right MLX profile for a model.
+
+```bash
+cargo run --release -p higgs-bench --bin bench_mlx_tuning -- \
+  ~/.cache/lm-studio/models/mlx-community/Qwen3-1.7B-4bit
+```
+
+Each profile sweep starts a fresh higgs server with the relevant
+`HIGGS_MLX_PROFILE` env var (and TurboQuant flags for the fifth pass);
+the bench tears the server down with a 2-second cooldown between passes.
+
+### `bench_h2h`
+
+Head-to-head comparison of higgs vs oMLX on the same models. Spins up a
+higgs server, runs short / medium / long single-turn prompts plus an
+optional multi-turn conversation, then repeats the suite against an
+oMLX subprocess (path: `/Applications/oMLX.app/Contents/MacOS/omlx-cli`,
+override via `OMLX_CLI`).
+
+Models are selected by key from `benchmarks/models.toml`; defaults to
+all entries tagged `h2h`. Pass `--models qwen3.5-35B-a3b-3bit` etc. to
+match the Python `--models 35B|27B|DSV2` shape.
+
+```bash
+cargo run --release -p higgs-bench --bin bench_h2h -- \
+  --models qwen3.5-35B-a3b-3bit --turns 5
+```
+
+Pass `--skip-multiturn` to skip the multi-turn phase, `--higgs-only` /
+`--omlx-only` to limit the comparison to one backend.
 
 ### Adding a new bench
 


### PR DESCRIPTION
## Summary

PR6 of the bench migration plan: port the two largest HTTP-driven Python bench scripts (`bench_h2h.py`, `bench_mlx_tuning.py`) to native Rust binaries in `higgs-bench`, plus port the `test_bench_mlx_tuning.py` unit tests.

**Stacks on:** PR5 (#127, base branch `panbanda/bench-http-rs`), which itself stacks on PR1b (#124). This PR will need its base retargeted to `main` once PR5 lands.

## What changed

New bins:

- `bench_h2h` — Higgs vs oMLX head-to-head TTFT + decode tok/s. Spawns oMLX as a subprocess (path `/Applications/oMLX.app/Contents/MacOS/omlx-cli`, override via `OMLX_CLI`). Models selected by key from `benchmarks/models.toml`; defaults to all entries tagged `h2h`. Preserves the Python CLI shape (`--models`, `--turns`, `--skip-multiturn`).
- `bench_mlx_tuning` — composite-score sweep across five MLX profiles. Composite math lives in `higgs_bench::score` so it's directly unit-testable; the five tests from `benchmarks/test_bench_mlx_tuning.py` are ported as `#[test]` blocks.

Shared library helpers:

- `http::stream_chat_metrics` + `StreamChatOptions` — streaming chat helper matching the Python `stream_chat` semantics (TTFT, decode tok/s using `(completion - 1) / decode_s`, `output_chars / 3.5` fallback estimation when `usage` is absent, optional bearer auth, optional `response_format`).
- `http::chat_with_options`, `http::first_model_id_with_auth`.
- `process::start_higgs_server_with_env` (env-var injection for `HIGGS_MLX_PROFILE`).
- `process::start_omlx_server` (treats HTTP 401 on `/v1/models` as alive).
- `score::*` — composite-score math with `clippy::suboptimal_flops` and `clippy::if_not_else` suppressed and a comment explaining that exact Python equivalence is the acceptance criterion (so `mul_add` rewrites would be wrong).

`benchmarks/models.toml` gets the `h2h` tag on the three models the Python script targeted (35B / 27B / DSV2). `docs/benchmarking.md` swaps the Python tuning command for the Rust equivalent and adds sections for both new bins. The README has no references to either Python script, so nothing to update there.

## What did NOT translate cleanly

- The Python `--models 35B|27B|DSV2` shorthand keys are not preserved verbatim; users now pass the full `benchmarks/models.toml` keys. This keeps a single source of truth for model paths.
- oMLX readiness probing: oMLX returns 401 on `/v1/models` without a bearer token, so the readiness loop treats both 200 and 401 as alive. A hardened version would do a positive `/v1/models` GET with the `omlx` bearer token.
- The Python `--higgs-only` / `--omlx-only` flags are ported.

## Sample --help

bench_h2h:

```
Head-to-head benchmark: Higgs vs oMLX (port of bench_h2h.py)

Usage: bench_h2h [OPTIONS]

Options:
      --models <MODELS>                       Comma-separated list of model keys [...]
      --turns <TURNS>                         Number of multi-turn conversation turns [default: 5]
      --skip-multiturn                        Skip multi-turn tests
      --higgs-only
      --omlx-only
      --manifest <MANIFEST>
      --server-timeout-s <SERVER_TIMEOUT_S>   [default: 180]
      --format <FORMAT>                       [default: json] [possible values: json, markdown]
```

bench_mlx_tuning:

```
Sweep MLX tuning profiles and emit a composite score (port of bench_mlx_tuning.py)

Usage: bench_mlx_tuning [OPTIONS] <MODEL_PATH>

Arguments:
  <MODEL_PATH>  Model path (local directory or HF cache directory)

Options:
      --repeats <REPEATS>                     [default: 2]
      --port <PORT>                           [default: 8099]
      --no-spawn                              Skip spawning a server [...]
      --server-timeout-s <SERVER_TIMEOUT_S>   [default: 120]
      --format <FORMAT>                       [default: json] [possible values: json, markdown]
```

## Verification done

- `cargo build -p higgs-bench --release` clean
- `cargo clippy -p higgs-bench --all-targets --release` no errors (only warnings already present from PR5 bins)
- `cargo fmt -p higgs-bench -- --check` clean
- `cargo test -p higgs-bench --bin bench_mlx_tuning` — 5/5 tests pass (the ports of `test_bench_mlx_tuning.py`)
- `cargo test -p higgs-bench` — all suites pass
- `cargo run --release -p higgs-bench --bin bench_h2h -- --help` and `--bin bench_mlx_tuning -- --help` — both clean

## Manual side-by-side equivalence

**Not run as part of this PR.** Side-by-side equivalence vs Python requires Apple Silicon + cached models + ~30 minutes per script. The composite-score math is locked in by the unit tests; the per-sub-bench raw numbers will need a manual user verification pass.

Suggested next step (for a reviewer with a 35B model on disk):

```bash
# Python baseline
python3 benchmarks/bench_mlx_tuning.py ~/.cache/lm-studio/models/.../Qwen3-1.7B-4bit > /tmp/py.json

# Rust port
cargo run --release -p higgs-bench --bin bench_mlx_tuning -- \
  ~/.cache/lm-studio/models/.../Qwen3-1.7B-4bit > /tmp/rs.json

# Compare composite scores per iteration
jq '.results[] | {iteration, composite: .score.composite}' /tmp/py.json
jq '.results.iterations[] | {iteration, composite: .score.composite}' /tmp/rs.json
```

Composite scores must match exactly given identical generation outputs; raw sub-bench numbers can drift within 5% due to system noise.

## Test plan

- [x] cargo test -p higgs-bench (all suites)
- [x] cargo clippy + fmt clean
- [x] --help output for both bins
- [ ] Manual: run both bins on a real model and compare against the Python equivalents

🤖 Generated with [Claude Code](https://claude.com/claude-code)