### PR TITLE
ci: simplify required check names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,7 @@ jobs:
         uses: panbanda/omen@omen-v4.24.0
         id: omen
         with:
+          version: "4.24.0"
           comment: false
           label: false
           check: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run Omen
-        uses: panbanda/omen@omen-v4.21.2
+        uses: panbanda/omen@omen-v4.24.1
         id: omen
         with:
           comment: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run Omen
-        uses: panbanda/omen@omen-v4.24.1
+        uses: panbanda/omen@omen-v4.24.0
         id: omen
         with:
           comment: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,10 +170,10 @@ jobs:
           fetch-depth: 0
 
       - name: Run Omen
-        uses: panbanda/omen@omen-v4.24.0
+        uses: panbanda/omen@omen-v4.24.1
         id: omen
         with:
-          version: "4.24.0"
+          version: "4.24.1"
           comment: false
           label: false
           check: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         run: cargo clippy --all-targets --all-features
 
   msrv:
-    name: MSRV (1.88.0)
+    name: MSRV
     runs-on: macos-latest
     permissions:
       contents: read
@@ -105,7 +105,7 @@ jobs:
         run: cargo check --all-features
 
   coverage:
-    name: Coverage (70%)
+    name: Coverage
     runs-on: macos-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- rename MSRV and coverage CI jobs to stable version-neutral check names
- keep the Rust 1.88.0 toolchain pin and 70% coverage threshold unchanged
- align required repo ruleset checks to Coverage and MSRV

## Verification
- git diff --check
- gh api repos/panbanda/higgs/rulesets/13352234 --jq '.rules[] | select(.type=="required_status_checks").parameters.required_status_checks'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined CI workflow job display names for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->