### PR TITLE
Fix crates.io publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,55 +104,43 @@ jobs:
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
 
-      - name: Check crates.io publishability
-        id: publishability
-        run: |
-          if grep -Eq '^mlx-(rs|sys)\s*=\s*\{[^}]*git\s*=' Cargo.toml; then
-            echo "publishable=false" >> "$GITHUB_OUTPUT"
-            echo "Skipping crates.io publish: release artifacts depend on unreleased mlx-rs git revisions."
-            exit 0
-          fi
-
-          echo "publishable=true" >> "$GITHUB_OUTPUT"
-
       - name: Install Rust toolchain
-        if: ${{ steps.publishability.outputs.publishable == 'true' }}
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
 
       - name: Cache cargo registry and build
-        if: ${{ steps.publishability.outputs.publishable == 'true' }}
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Publish higgs-models
-        if: ${{ steps.publishability.outputs.publishable == 'true' }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
-          out=$(cargo publish -p higgs-models --token ${{ secrets.CARGO_REGISTRY_TOKEN }} 2>&1) && echo "$out" || {
+          out=$(cargo publish -p higgs-models 2>&1) && echo "$out" || {
             echo "$out"
             echo "$out" | grep -q "already exists" || exit 1
           }
 
       - name: Wait for crates.io to index higgs-models
-        if: ${{ steps.publishability.outputs.publishable == 'true' }}
         run: sleep 30
 
       - name: Publish higgs-engine
-        if: ${{ steps.publishability.outputs.publishable == 'true' }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
-          out=$(cargo publish -p higgs-engine --token ${{ secrets.CARGO_REGISTRY_TOKEN }} 2>&1) && echo "$out" || {
+          out=$(cargo publish -p higgs-engine 2>&1) && echo "$out" || {
             echo "$out"
             echo "$out" | grep -q "already exists" || exit 1
           }
 
       - name: Wait for crates.io to index higgs-engine
-        if: ${{ steps.publishability.outputs.publishable == 'true' }}
         run: sleep 30
 
       - name: Publish higgs
-        if: ${{ steps.publishability.outputs.publishable == 'true' }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
-          out=$(cargo publish -p higgs --token ${{ secrets.CARGO_REGISTRY_TOKEN }} 2>&1) && echo "$out" || {
+          out=$(cargo publish -p higgs 2>&1) && echo "$out" || {
             echo "$out"
             echo "$out" | grep -q "already exists" || exit 1
           }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,20 +281,20 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.72.1"
+version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
 dependencies = [
  "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.117",
 ]
@@ -2028,15 +2028,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -2395,7 +2386,8 @@ dependencies = [
 [[package]]
 name = "mlx-internal-macros"
 version = "0.25.3"
-source = "git+https://github.com/oxideai/mlx-rs.git?rev=f4aa309c79b6be35255ca7d34157dfc10d9ed4c9#f4aa309c79b6be35255ca7d34157dfc10d9ed4c9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a7c4444d624bf6b93db5cc22ebff4fdfa13593fd56154fe33b1f302a557c2c6"
 dependencies = [
  "darling 0.21.3",
  "itertools 0.14.0",
@@ -2407,7 +2399,8 @@ dependencies = [
 [[package]]
 name = "mlx-macros"
 version = "0.25.3"
-source = "git+https://github.com/oxideai/mlx-rs.git?rev=f4aa309c79b6be35255ca7d34157dfc10d9ed4c9#f4aa309c79b6be35255ca7d34157dfc10d9ed4c9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a819ee8b4434690572b6feb9c3ef0b6e90137e4190b340cf00150703b410aaf9"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
@@ -2418,7 +2411,8 @@ dependencies = [
 [[package]]
 name = "mlx-rs"
 version = "0.25.3"
-source = "git+https://github.com/oxideai/mlx-rs.git?rev=f4aa309c79b6be35255ca7d34157dfc10d9ed4c9#f4aa309c79b6be35255ca7d34157dfc10d9ed4c9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a0f592c5839b0237b3072530b1d3c503923579a2009ee0761df3edd1b1f27b"
 dependencies = [
  "dyn-clone",
  "half",
@@ -2441,7 +2435,8 @@ dependencies = [
 [[package]]
 name = "mlx-sys"
 version = "0.2.0"
-source = "git+https://github.com/oxideai/mlx-rs.git?rev=f4aa309c79b6be35255ca7d34157dfc10d9ed4c9#f4aa309c79b6be35255ca7d34157dfc10d9ed4c9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e3bc3880111918b2d5018f845d48fd995f9901f16efc81d1fcfd2f4210b8219"
 dependencies = [
  "bindgen",
  "cc",
@@ -2707,7 +2702,7 @@ dependencies = [
  "once_cell",
  "regex",
  "regex-automata",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -2995,7 +2990,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -3016,7 +3011,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.4",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -3352,6 +3347,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,12 +75,12 @@ wildcard_enum_match_arm = "deny"
 
 [workspace.dependencies]
 # Local crates
-higgs-engine = { path = "crates/higgs-engine" }
-higgs-models = { path = "crates/higgs-models" }
+higgs-engine = { version = "1.1.1", path = "crates/higgs-engine" }
+higgs-models = { version = "1.1.1", path = "crates/higgs-models" }
 
 # MLX
-mlx-rs = { git = "https://github.com/oxideai/mlx-rs.git", rev = "f4aa309c79b6be35255ca7d34157dfc10d9ed4c9" }
-mlx-sys = { git = "https://github.com/oxideai/mlx-rs.git", rev = "f4aa309c79b6be35255ca7d34157dfc10d9ed4c9" }
+mlx-rs = "0.25.3"
+mlx-sys = "0.2.0"
 
 # HTTP
 axum = { version = "0.8", features = ["macros"] }

--- a/crates/higgs-engine/src/mlx_tuning.rs
+++ b/crates/higgs-engine/src/mlx_tuning.rs
@@ -494,22 +494,13 @@ fn model_weight_bytes(model_dir: &Path) -> Option<u64> {
 #[allow(unsafe_code)]
 fn mlx_max_recommended_working_set_size() -> Option<usize> {
     unsafe {
-        let mut info = mlx_sys::mlx_device_info_new();
-        let mut dev = mlx_sys::mlx_device_new();
-        mlx_sys::mlx_get_default_device(&raw mut dev);
-        let mut max_rec = None;
-        if mlx_sys::mlx_device_info_get(&raw mut info, dev) == 0 {
-            let mut value: usize = 0;
-            let key = c"max_recommended_working_set_size";
-            if mlx_sys::mlx_device_info_get_size(&raw mut value, info, key.as_ptr()) == 0
-                && value > 0
-            {
-                max_rec = Some(value);
-            }
+        let mut available = false;
+        if mlx_sys::mlx_metal_is_available(&raw mut available) != 0 || !available {
+            return None;
         }
-        mlx_sys::mlx_device_info_free(info);
-        mlx_sys::mlx_device_free(dev);
-        max_rec
+
+        let info = mlx_sys::mlx_metal_device_info();
+        Some(info.max_recommended_working_set_size).filter(|value| *value > 0)
     }
 }
 

--- a/crates/higgs-engine/src/simple.rs
+++ b/crates/higgs-engine/src/simple.rs
@@ -107,65 +107,70 @@ pub(crate) fn set_wired_limit_to_max(enabled: bool) {
         tracing::info!("MLX wired-limit escalation disabled by config");
         return;
     }
+
+    let Some(max_rec) = mlx_max_recommended_working_set_size() else {
+        tracing::info!("MLX Metal max recommended working-set size unavailable");
+        return;
+    };
+
     unsafe {
-        let mut info = mlx_sys::mlx_device_info_new();
-        let mut dev = mlx_sys::mlx_device_new();
-        mlx_sys::mlx_get_default_device(&raw mut dev);
-        if mlx_sys::mlx_device_info_get(&raw mut info, dev) == 0 {
-            let mut max_rec: usize = 0;
-            let key = c"max_recommended_working_set_size";
-            if mlx_sys::mlx_device_info_get_size(&raw mut max_rec, info, key.as_ptr()) == 0
-                && max_rec > 0
-            {
-                let wired_mode = std::env::var("HIGGS_WIRED_LIMIT_MODE").ok();
-                let use_legacy_limits =
-                    matches!(wired_mode.as_deref(), Some("legacy" | "safe" | "caps"));
-                let mut prev_mem: usize = 0;
-                let mut prev_cache: usize = 0;
-                let mut prev_wired: usize = 0;
+        let wired_mode = std::env::var("HIGGS_WIRED_LIMIT_MODE").ok();
+        let use_legacy_limits = matches!(wired_mode.as_deref(), Some("legacy" | "safe" | "caps"));
+        let mut prev_mem: usize = 0;
+        let mut prev_cache: usize = 0;
+        let mut prev_wired: usize = 0;
 
-                let limits_enabled = std::env::var("HIGGS_NO_MEM_LIMIT").is_err();
+        let limits_enabled = std::env::var("HIGGS_NO_MEM_LIMIT").is_err();
 
-                if limits_enabled {
-                    if use_legacy_limits {
-                        let mem_limit = max_rec * 3 / 4;
-                        let cache_limit = max_rec / 2;
-                        mlx_sys::mlx_set_memory_limit(&raw mut prev_mem, mem_limit);
-                        mlx_sys::mlx_set_cache_limit(&raw mut prev_cache, cache_limit);
-                        tracing::info!(
-                            mode = "legacy",
-                            max_recommended_mb = max_rec / (1024 * 1024),
-                            memory_limit_mb = mem_limit / (1024 * 1024),
-                            cache_limit_mb = cache_limit / (1024 * 1024),
-                            prev_mem_mb = prev_mem / (1024 * 1024),
-                            prev_cache_mb = prev_cache / (1024 * 1024),
-                            "Configured MLX legacy memory/cache caps",
-                        );
-                    } else {
-                        mlx_sys::mlx_set_wired_limit(&raw mut prev_wired, max_rec);
-                        tracing::info!(
-                            mode = "mlx_wired_limit",
-                            max_recommended_mb = max_rec / (1024 * 1024),
-                            wired_limit_mb = max_rec / (1024 * 1024),
-                            prev_wired_mb = prev_wired / (1024 * 1024),
-                            "Configured MLX wired limit",
-                        );
-                    }
-                } else {
-                    tracing::info!(
-                        mode = if use_legacy_limits {
-                            "legacy"
-                        } else {
-                            "mlx_wired_limit"
-                        },
-                        max_recommended_mb = max_rec / (1024 * 1024),
-                        "Skipped MLX memory-limit configuration",
-                    );
-                }
+        if limits_enabled {
+            if use_legacy_limits {
+                let mem_limit = max_rec * 3 / 4;
+                let cache_limit = max_rec / 2;
+                mlx_sys::mlx_set_memory_limit(&raw mut prev_mem, mem_limit);
+                mlx_sys::mlx_set_cache_limit(&raw mut prev_cache, cache_limit);
+                tracing::info!(
+                    mode = "legacy",
+                    max_recommended_mb = max_rec / (1024 * 1024),
+                    memory_limit_mb = mem_limit / (1024 * 1024),
+                    cache_limit_mb = cache_limit / (1024 * 1024),
+                    prev_mem_mb = prev_mem / (1024 * 1024),
+                    prev_cache_mb = prev_cache / (1024 * 1024),
+                    "Configured MLX legacy memory/cache caps",
+                );
+            } else {
+                mlx_sys::mlx_set_wired_limit(&raw mut prev_wired, max_rec);
+                tracing::info!(
+                    mode = "mlx_wired_limit",
+                    max_recommended_mb = max_rec / (1024 * 1024),
+                    wired_limit_mb = max_rec / (1024 * 1024),
+                    prev_wired_mb = prev_wired / (1024 * 1024),
+                    "Configured MLX wired limit",
+                );
             }
+        } else {
+            tracing::info!(
+                mode = if use_legacy_limits {
+                    "legacy"
+                } else {
+                    "mlx_wired_limit"
+                },
+                max_recommended_mb = max_rec / (1024 * 1024),
+                "Skipped MLX memory-limit configuration",
+            );
         }
-        mlx_sys::mlx_device_info_free(info);
-        mlx_sys::mlx_device_free(dev);
+    }
+}
+
+#[allow(unsafe_code)]
+fn mlx_max_recommended_working_set_size() -> Option<usize> {
+    unsafe {
+        let mut available = false;
+        if mlx_sys::mlx_metal_is_available(&raw mut available) != 0 || !available {
+            return None;
+        }
+
+        let info = mlx_sys::mlx_metal_device_info();
+        Some(info.max_recommended_working_set_size).filter(|value| *value > 0)
     }
 }
 

--- a/crates/higgs-models/src/deepseek_v2.rs
+++ b/crates/higgs-models/src/deepseek_v2.rs
@@ -479,16 +479,10 @@ impl DeepSeekV2Attention {
         };
 
         let sdpa_mask = mask.map(fast::ScaledDotProductAttentionMask::from);
-        let output = fast::scaled_dot_product_attention(
-            queries,
-            keys,
-            values,
-            self.scale,
-            sdpa_mask,
-            None::<&Array>,
-        )?
-        .transpose_axes(&[0, 2, 1, 3])?
-        .reshape(&[B, L, -1])?;
+        let output =
+            fast::scaled_dot_product_attention(queries, keys, values, self.scale, sdpa_mask)?
+                .transpose_axes(&[0, 2, 1, 3])?
+                .reshape(&[B, L, -1])?;
 
         self.o_proj.forward(&output)
     }

--- a/crates/higgs-models/src/qwen3_moe.rs
+++ b/crates/higgs-models/src/qwen3_moe.rs
@@ -207,7 +207,6 @@ impl Qwen3MoeAttention {
                     cached_values,
                     self.scale,
                     Some(fast::ScaledDotProductAttentionMask::Causal),
-                    None::<&Array>,
                 )?
                 .transpose_axes(&[0, 2, 1, 3])?
                 .reshape(&[B, L, -1])?;
@@ -232,16 +231,10 @@ impl Qwen3MoeAttention {
         keys = apply_rope(&keys, &self.rope, 0)?;
 
         let sdpa_mask = mask.map(fast::ScaledDotProductAttentionMask::from);
-        let output = fast::scaled_dot_product_attention(
-            queries,
-            keys,
-            values,
-            self.scale,
-            sdpa_mask,
-            None::<&Array>,
-        )?
-        .transpose_axes(&[0, 2, 1, 3])?
-        .reshape(&[B, L, -1])?;
+        let output =
+            fast::scaled_dot_product_attention(queries, keys, values, self.scale, sdpa_mask)?
+                .transpose_axes(&[0, 2, 1, 3])?
+                .reshape(&[B, L, -1])?;
 
         self.o_proj.forward(&output)
     }

--- a/crates/higgs-models/src/qwen3_next.rs
+++ b/crates/higgs-models/src/qwen3_next.rs
@@ -541,15 +541,8 @@ pub(crate) fn gather_qmm(
             null_lhs,
             rhs_indices.as_ptr(),
             transpose,
-            mlx_sys::mlx_optional_int_ {
-                value: group_size,
-                has_value: true,
-            },
-            mlx_sys::mlx_optional_int_ {
-                value: bits,
-                has_value: true,
-            },
-            c"affine".as_ptr(),
+            group_size,
+            bits,
             sorted_indices,
             stream.as_ptr(),
         )
@@ -1473,7 +1466,6 @@ impl Qwen3NextAttention {
                     cached_values,
                     self.scale,
                     sdpa_mask,
-                    None::<&Array>,
                 )?
                 .transpose_axes(&[0, 2, 1, 3])?
                 .reshape(&[B, L, -1])?

--- a/crates/higgs-models/src/utils.rs
+++ b/crates/higgs-models/src/utils.rs
@@ -55,7 +55,6 @@ pub(crate) fn scaled_dot_product_attention(
         values,
         scale,
         mask.map(ScaledDotProductAttentionMask::Array),
-        None::<&Array>,
     )
 }
 
@@ -569,7 +568,6 @@ mod tests {
             &values,
             scale,
             Some(ScaledDotProductAttentionMask::Array(&mask_array)),
-            None::<&Array>,
         )
         .unwrap();
 
@@ -580,7 +578,6 @@ mod tests {
             &values,
             scale,
             Some(ScaledDotProductAttentionMask::Causal),
-            None::<&Array>,
         )
         .unwrap();
 
@@ -635,7 +632,6 @@ mod tests {
             &values,
             scale,
             Some(ScaledDotProductAttentionMask::Causal),
-            None::<&Array>,
         )
         .unwrap();
 
@@ -676,7 +672,6 @@ mod tests {
             &values,
             scale,
             Some(ScaledDotProductAttentionMask::Array(&mask_array)),
-            None::<&Array>,
         )
         .unwrap();
 
@@ -687,7 +682,6 @@ mod tests {
             &values,
             scale,
             Some(ScaledDotProductAttentionMask::Causal),
-            None::<&Array>,
         )
         .unwrap();
 


### PR DESCRIPTION
Updates the release workflow to use CARGO_REGISTRY_TOKEN instead of deprecated cargo publish --token. Switches workspace MLX dependencies to crates.io releases and adds version requirements for local crates so published manifests are valid. Aligns MLX API call sites with mlx-rs 0.25.3 / mlx-sys 0.2.0, including Metal device info usage. Verification: cargo publish -p higgs-models --dry-run --allow-dirty, cargo check -p higgs-engine, cargo check -p higgs, and cargo fmt --check.