### PR TITLE
feat(cache): AnyCache::trim_by dispatcher for spec-decode rollback

### DIFF
--- a/crates/higgs-models/src/lib.rs
+++ b/crates/higgs-models/src/lib.rs
@@ -91,6 +91,29 @@ pub enum AnyCache {
     Hybrid(Vec<Option<LayerCache>>),
 }
 
+impl AnyCache {
+    /// Trim every layer cache by `count` tokens, discarding the most recent
+    /// entries. Used after speculative-decode verify to roll back rejected
+    /// draft tokens. Hybrid SSM (recurrent) layers are intentionally left
+    /// untouched — their state cannot be trimmed by offset alone.
+    pub fn trim_by(&mut self, count: usize) {
+        match self {
+            Self::KV(layers) => {
+                for layer in layers.iter_mut().flatten() {
+                    layer.trim_by(count);
+                }
+            }
+            Self::Hybrid(layers) => {
+                for layer in layers.iter_mut().flatten() {
+                    if let LayerCache::KV(kv) = layer {
+                        kv.trim_by(count);
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Unified model wrapper dispatching to the correct architecture.
 pub enum AnyModel {
     /// Standard transformer architectures: Llama, Mistral, Qwen2/2.5, Qwen3.
@@ -1189,6 +1212,7 @@ fn remap_quantized_key(key: &str) -> Option<String> {
 #[allow(clippy::panic, clippy::unwrap_used, clippy::indexing_slicing)]
 mod tests {
     use super::*;
+    use crate::cache::KeyValueCache;
 
     fn params(temp: f32, top_p: f32) -> SamplingParams {
         SamplingParams {
@@ -1694,5 +1718,59 @@ mod tests {
         assert!((vals[0] - 2.5).abs() < 1e-5);
         assert!((vals[1] - 2.0).abs() < 1e-5);
         assert!((vals[2] - 4.5).abs() < 1e-5);
+    }
+
+    // --- AnyCache::trim_by tests ---
+
+    #[test]
+    fn any_cache_trim_by_kv_dispatches_to_each_layer() {
+        // Two KV layers, both at offset 0; trim_by saturates to 0.
+        // Verifies the dispatcher iterates None and Some(_) layers without panic.
+        let mut cache = AnyCache::KV(vec![
+            Some(cache::SteppingKeyValueCache::new()),
+            None,
+            Some(cache::SteppingKeyValueCache::new()),
+        ]);
+        cache.trim_by(5);
+        if let AnyCache::KV(layers) = &cache {
+            assert_eq!(layers.len(), 3);
+            for layer in layers.iter().flatten() {
+                assert_eq!(layer.offset(), 0);
+            }
+        } else {
+            panic!("expected KV variant");
+        }
+    }
+
+    #[test]
+    fn any_cache_trim_by_hybrid_skips_arrays_layers() {
+        // Hybrid mixes LayerCache::KV (trimmable) and LayerCache::Arrays (recurrent,
+        // intentionally untouched). Verifies the dispatcher reaches into KV layers
+        // and leaves Arrays alone.
+        let mut arrays = qwen3_next::ArraysCache::new();
+        arrays.offset = 7;
+        let mut cache = AnyCache::Hybrid(vec![
+            Some(LayerCache::KV(cache::SteppingKeyValueCache::new())),
+            Some(LayerCache::Arrays(arrays)),
+            None,
+        ]);
+        cache.trim_by(3);
+        if let AnyCache::Hybrid(layers) = &cache {
+            assert_eq!(layers.len(), 3);
+            // KV layer trimmed (saturated at 0 since starting offset was 0)
+            if let Some(LayerCache::KV(kv)) = layers.first().and_then(|l| l.as_ref()) {
+                assert_eq!(kv.offset(), 0);
+            } else {
+                panic!("expected first layer to be KV variant");
+            }
+            // Arrays layer offset unchanged (recurrent state, can't trim by offset)
+            if let Some(LayerCache::Arrays(a)) = layers.get(1).and_then(|l| l.as_ref()) {
+                assert_eq!(a.offset, 7, "Arrays layer offset must NOT be trimmed");
+            } else {
+                panic!("expected second layer to be Arrays variant");
+            }
+        } else {
+            panic!("expected Hybrid variant");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds an `AnyCache::trim_by(count: usize)` helper that walks every layer in either `KV` or `Hybrid` variant and trims the underlying `SteppingKeyValueCache`, while intentionally leaving `LayerCache::Arrays` (recurrent SSM state) untouched.

Required by upcoming spec-decode verify-rollback paths: after a draft batch's verify rejects the last N tokens, the dispatcher rolls back the KV portion of the cache without reaching into per-layer types.

## Why a separate PR

This is the second of a series rebased from a 5-week feature branch (`feat/magic-canvas`). After auditing the originally-planned 3-commit bundle (paged prefix cache, chunked prefill, trim_by) against current `main`, only the `AnyCache`-level dispatcher is genuinely new — the underlying `SteppingKeyValueCache::trim_by(usize)` already lives in `cache.rs:457` from `1514737d`, and `paged_prefix_cache.rs` is a superset of the branch's version on `main`.

| Original commit | State on main |
|---|---|
| `feat/magic-canvas@826794b0` paged_prefix_cache.rs | SUPERSET on main (1072 lines vs branch's 855 — TqBlock + slice_axis1 + conv_pos additions) |
| `feat/magic-canvas@d24e4a92` chunked_prefill | SUPERSET on main (wired into 2453-line simple.rs) |
| `feat/magic-canvas@fb48230c` trim_by | PARTIAL — `SteppingKeyValueCache::trim_by` already on main; `AnyCache::trim_by` dispatcher not yet |

So the PR is intentionally small — single function + 2 tests, +78 lines.

## Behaviour

```rust
impl AnyCache {
    pub fn trim_by(&mut self, count: usize) {
        match self {
            Self::KV(layers) => {
                for layer in layers.iter_mut().flatten() {
                    layer.trim_by(count);
                }
            }
            Self::Hybrid(layers) => {
                for layer in layers.iter_mut().flatten() {
                    if let LayerCache::KV(kv) = layer {
                        kv.trim_by(count);
                    }
                }
            }
        }
    }
}
```

`Hybrid`'s `LayerCache::Arrays` variant (qwen3-next SSM recurrent state) is intentionally skipped — its state cannot be trimmed by offset alone. Documented inline.

## Test plan

- [x] `cargo clippy --all-targets --all-features` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test -p higgs-models --lib -- --test-threads=1` — **332 passed, 0 failed, 24 ignored** (+2 new)

New tests:
- `tests::any_cache_trim_by_kv_dispatches_to_each_layer` — KV variant with mixed `Some`/`None` layers, no panic, all saturate to 0.
- `tests::any_cache_trim_by_hybrid_skips_arrays_layers` — Hybrid with `LayerCache::KV` + `LayerCache::Arrays`, asserts `Arrays.offset` stays unchanged.

## Notes

- Single-file change: `crates/higgs-models/src/lib.rs` (+78 lines, all in `impl AnyCache` + test module).
- Foundation for an upcoming DraftModel-trait / spec-decode-wiring PR.
- Validated on the dusterbloom/higgs fork: https://github.com/dusterbloom/higgs/pull/14
- Co-authored with Claude Opus 4.7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cache memory optimization with intelligent trimming that selectively removes entries from certain cache types while preserving critical cache state in other layers.

* **Tests**
  * Added unit tests validating cache trimming functionality across different cache architectures and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->