### PR TITLE
feat(qwen3_next): mixed-bit Qwen3.5 GDN BA loading fallback

### DIFF
--- a/crates/higgs-models/src/qwen3_next.rs
+++ b/crates/higgs-models/src/qwen3_next.rs
@@ -3728,8 +3728,13 @@ fn load_qwen3_5_moe_text_config_args<P: AsRef<Path>>(
     // projection fields so the direct weight loader can match them. Otherwise,
     // construct with fused fields (weights are rearranged at load time).
     let mixed_ba_layers = qwen3_5_mixed_ba_quantization_layers(&config, text_config);
-    let use_separate =
-        std::env::var("HIGGS_SEPARATE_GDN_PROJ").is_ok() || !mixed_ba_layers.is_empty();
+    let config_requests_separate = map
+        .get("use_separate_gdn_projections")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    let use_separate = config_requests_separate
+        || std::env::var("HIGGS_SEPARATE_GDN_PROJ").is_ok()
+        || !mixed_ba_layers.is_empty();
     map.insert(
         "use_separate_gdn_projections".to_owned(),
         serde_json::Value::from(use_separate),
@@ -3781,15 +3786,22 @@ fn qwen3_5_mixed_ba_quantization_layers(
 
     (0..num_hidden_layers)
         .filter(|layer_idx| {
-            let prefix = format!("language_model.model.layers.{layer_idx}.linear_attn");
-            let a_quant = quant
-                .get(format!("{prefix}.in_proj_a"))
-                .and_then(qwen3_5_quantization_config)
-                .unwrap_or_else(|| default_quant.clone());
-            let b_quant = quant
-                .get(format!("{prefix}.in_proj_b"))
-                .and_then(qwen3_5_quantization_config)
-                .unwrap_or_else(|| default_quant.clone());
+            let prefixes = [
+                format!("language_model.model.layers.{layer_idx}.linear_attn"),
+                format!("model.layers.{layer_idx}.linear_attn"),
+            ];
+            let projection_quantization = |projection: &str| {
+                prefixes
+                    .iter()
+                    .find_map(|prefix| {
+                        quant
+                            .get(format!("{prefix}.{projection}"))
+                            .and_then(qwen3_5_quantization_config)
+                    })
+                    .unwrap_or_else(|| default_quant.clone())
+            };
+            let a_quant = projection_quantization("in_proj_a");
+            let b_quant = projection_quantization("in_proj_b");
             a_quant.bits != b_quant.bits || a_quant.group_size != b_quant.group_size
         })
         .collect()
@@ -4018,15 +4030,19 @@ fn concat_and_permute(a: &Array, b: &Array, perm: &[i32]) -> Result<Array, Excep
 /// matches and every non-axis-0 dimension is identical. Quantized weights pack
 /// different bit-widths into different inner shapes, so this guards the BA
 /// fusion path from silently producing a malformed `in_proj_ba` matrix.
-fn can_concatenate_axis0(a: &Array, b: &Array) -> bool {
-    let a_shape = a.shape();
-    let b_shape = b.shape();
+fn can_concatenate_axis0_shapes(a_shape: &[i32], b_shape: &[i32]) -> bool {
     a_shape.len() == b_shape.len()
         && a_shape
             .iter()
             .zip(b_shape.iter())
             .enumerate()
             .all(|(axis, (lhs, rhs))| axis == 0 || lhs == rhs)
+}
+
+fn can_concatenate_axis0(a: &Array, b: &Array) -> bool {
+    let a_shape = a.shape();
+    let b_shape = b.shape();
+    can_concatenate_axis0_shapes(a_shape, b_shape)
 }
 
 /// Load Qwen3.5-MoE weights with GDN projection fusion.
@@ -12974,6 +12990,36 @@ mod tests {
     }
 
     #[test]
+    fn test_load_qwen35_mixed_ba_quantization_supports_unprefixed_layer_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = format!(
+            r#"{{
+                "text_config": {},
+                "tie_word_embeddings": false,
+                "quantization": {{
+                    "group_size": 64,
+                    "bits": 2,
+                    "mode": "affine",
+                    "model.layers.1.linear_attn.in_proj_a": {{
+                        "group_size": 64,
+                        "bits": 5,
+                        "mode": "affine"
+                    }}
+                }}
+            }}"#,
+            qwen35_dense_text_config()
+        );
+        std::fs::write(dir.path().join("config.json"), config).unwrap();
+
+        let args = load_qwen3_5_moe_text_config_args(dir.path()).unwrap();
+
+        assert!(
+            args.use_separate_gdn_projections,
+            "unprefixed mixed-bit in_proj_a/in_proj_b must force separate GDN projections"
+        );
+    }
+
+    #[test]
     fn test_load_qwen35_matching_ba_quantization_keeps_fused_gdn() {
         let dir = tempfile::tempdir().unwrap();
         let config = format!(
@@ -13009,17 +13055,32 @@ mod tests {
     }
 
     #[test]
-    fn test_can_concatenate_axis0_detects_quantized_inner_shape_mismatch() {
-        let a = Array::zeros::<f32>(&[48, 320]).unwrap();
-        let b = Array::zeros::<f32>(&[48, 800]).unwrap();
-        let c = Array::zeros::<f32>(&[96, 320]).unwrap();
+    fn test_load_qwen35_explicit_separate_gdn_config_is_preserved() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut text_config = qwen35_dense_text_config().trim_end_matches('}').to_owned();
+        text_config.push_str(
+            r#",
+            "use_separate_gdn_projections": true
+        }"#,
+        );
+        write_qwen35_config(dir.path(), &text_config);
+
+        let args = load_qwen3_5_moe_text_config_args(dir.path()).unwrap();
 
         assert!(
-            !can_concatenate_axis0(&a, &b),
+            args.use_separate_gdn_projections,
+            "explicit use_separate_gdn_projections=true must not be overwritten"
+        );
+    }
+
+    #[test]
+    fn test_can_concatenate_axis0_detects_quantized_inner_shape_mismatch() {
+        assert!(
+            !can_concatenate_axis0_shapes(&[48, 320], &[48, 800]),
             "different packed inner dims must block BA fusion"
         );
         assert!(
-            can_concatenate_axis0(&a, &c),
+            can_concatenate_axis0_shapes(&[48, 320], &[96, 320]),
             "axis-0 size may differ because fusion concatenates rows"
         );
     }

--- a/crates/higgs-models/src/qwen3_next.rs
+++ b/crates/higgs-models/src/qwen3_next.rs
@@ -3722,14 +3722,24 @@ fn load_qwen3_5_moe_text_config_args<P: AsRef<Path>>(
             .or_insert(serde_json::Value::from(0));
     }
 
-    // When HIGGS_SEPARATE_GDN_PROJ is set, construct the model with separate
-    // GDN projection fields so the direct weight loader can match them.
-    // Otherwise, construct with fused fields (weights are rearranged at load time).
-    let use_separate = std::env::var("HIGGS_SEPARATE_GDN_PROJ").is_ok();
+    // When HIGGS_SEPARATE_GDN_PROJ is set, or when per-layer GDN BA quantization
+    // disagrees on bit-width / group_size between in_proj_a and in_proj_b (common
+    // in Unsloth dynamic quants), construct the model with separate GDN
+    // projection fields so the direct weight loader can match them. Otherwise,
+    // construct with fused fields (weights are rearranged at load time).
+    let mixed_ba_layers = qwen3_5_mixed_ba_quantization_layers(&config, text_config);
+    let use_separate =
+        std::env::var("HIGGS_SEPARATE_GDN_PROJ").is_ok() || !mixed_ba_layers.is_empty();
     map.insert(
         "use_separate_gdn_projections".to_owned(),
         serde_json::Value::from(use_separate),
     );
+    if !mixed_ba_layers.is_empty() {
+        tracing::info!(
+            layers = ?mixed_ba_layers,
+            "Detected mixed-bit GDN BA projections; using separate GDN projections"
+        );
+    }
 
     // Detect per-layer gate quantization override from top-level quantization config
     if let Some(gate_q) = gate_quantization_override(&config) {
@@ -3737,6 +3747,52 @@ fn load_qwen3_5_moe_text_config_args<P: AsRef<Path>>(
     }
 
     Ok(serde_json::from_value(obj)?)
+}
+
+/// Parse a `{group_size, bits}` quantization spec from a JSON node.
+fn qwen3_5_quantization_config(value: &serde_json::Value) -> Option<QuantizationConfig> {
+    Some(QuantizationConfig {
+        group_size: i32::try_from(value.get("group_size")?.as_i64()?).ok()?,
+        bits: i32::try_from(value.get("bits")?.as_i64()?).ok()?,
+    })
+}
+
+/// Scan the per-layer `quantization` map and return layer indices where the GDN
+/// `in_proj_a` and `in_proj_b` projections disagree on bit-width or group size.
+/// Such layers cannot be fused into a single `in_proj_ba` matrix without
+/// dequantizing, so the loader must fall back to separate GDN projections.
+fn qwen3_5_mixed_ba_quantization_layers(
+    config: &serde_json::Value,
+    text_config: &serde_json::Value,
+) -> Vec<i32> {
+    let Some(quant) = config.get("quantization") else {
+        return Vec::new();
+    };
+    let Some(default_quant) = qwen3_5_quantization_config(quant) else {
+        return Vec::new();
+    };
+    let Some(num_hidden_layers) = text_config
+        .get("num_hidden_layers")
+        .and_then(serde_json::Value::as_i64)
+        .and_then(|n| i32::try_from(n).ok())
+    else {
+        return Vec::new();
+    };
+
+    (0..num_hidden_layers)
+        .filter(|layer_idx| {
+            let prefix = format!("language_model.model.layers.{layer_idx}.linear_attn");
+            let a_quant = quant
+                .get(format!("{prefix}.in_proj_a"))
+                .and_then(qwen3_5_quantization_config)
+                .unwrap_or_else(|| default_quant.clone());
+            let b_quant = quant
+                .get(format!("{prefix}.in_proj_b"))
+                .and_then(qwen3_5_quantization_config)
+                .unwrap_or_else(|| default_quant.clone());
+            a_quant.bits != b_quant.bits || a_quant.group_size != b_quant.group_size
+        })
+        .collect()
 }
 
 /// Load a Qwen3.5 dense model (VLM wrapper around `Qwen3Next` architecture).
@@ -3766,15 +3822,7 @@ pub fn load_qwen3_5_model<P: AsRef<Path>>(model_dir: P) -> Result<Qwen3NextCausa
         head_v_dim: args.linear_value_head_dim,
     };
     gdn_dims.validate()?;
-    let use_separate_gdn = std::env::var("HIGGS_SEPARATE_GDN_PROJ").is_ok();
-    let mut model = Qwen3NextCausalLM::new(args)?;
-
-    if use_separate_gdn {
-        load_qwen3_5_moe_weights_direct(&mut model, model_path)?;
-        tracing::info!("Using SEPARATE GDN projections (4 dispatches per layer)");
-    } else {
-        load_qwen3_5_moe_weights_fused(&mut model, model_path, &gdn_dims)?;
-    }
+    let model = load_qwen3_5_model_with_gdn_fallback(model_path, args, &gdn_dims)?;
 
     tracing::info!("Qwen3.5 dense model loaded successfully");
     Ok(model)
@@ -3810,23 +3858,71 @@ pub fn load_qwen3_5_moe_model<P: AsRef<Path>>(
         head_v_dim: args.linear_value_head_dim,
     };
     gdn_dims.validate()?;
-    let mut model = Qwen3NextCausalLM::new(args.clone())?;
-
     // Load weights with GDN projection rearrangement: flat (qkv,z,b,a)
     // → per-head-grouped (qkvz,ba) for fused 2-dispatch forward path.
-    // Respect use_separate_gdn_projections config flag or HIGGS_SEPARATE_GDN_PROJ env var.
-    let use_separate =
-        args.use_separate_gdn_projections || std::env::var("HIGGS_SEPARATE_GDN_PROJ").is_ok();
-    if use_separate {
-        load_qwen3_5_moe_weights_direct(&mut model, model_path)?;
-        tracing::info!("Using SEPARATE GDN projections (4 dispatches per layer)");
-    } else {
-        load_qwen3_5_moe_weights_fused(&mut model, model_path, &gdn_dims)?;
-        tracing::info!("Using FUSED GDN projections (2 dispatches per layer)");
-    }
+    // Respects use_separate_gdn_projections (set by HIGGS_SEPARATE_GDN_PROJ env
+    // var or mixed-bit BA detection in load_qwen3_5_moe_text_config_args), and
+    // falls back to separate projections at runtime if fusion finds a
+    // shape-incompatible BA pair.
+    let model = load_qwen3_5_model_with_gdn_fallback(model_path, args, &gdn_dims)?;
 
     tracing::info!("Qwen3.5-MoE model loaded successfully");
     Ok(model)
+}
+
+/// Build a `Qwen3NextCausalLM` and load weights, choosing fused or separate GDN
+/// projections. When the config (or env var) requests separate projections, use
+/// the direct loader. Otherwise try the fused loader; if it reports a mixed-bit
+/// `in_proj_ba` shape mismatch, rebuild the model with separate projections and
+/// retry via the direct loader.
+fn load_qwen3_5_model_with_gdn_fallback(
+    model_path: &Path,
+    mut args: Qwen3NextModelArgs,
+    gdn_dims: &GdnDims,
+) -> Result<Qwen3NextCausalLM, ModelError> {
+    let force_separate =
+        args.use_separate_gdn_projections || std::env::var("HIGGS_SEPARATE_GDN_PROJ").is_ok();
+    if force_separate {
+        args.use_separate_gdn_projections = true;
+        let mut model = Qwen3NextCausalLM::new(args)?;
+        load_qwen3_5_moe_weights_direct(&mut model, model_path)?;
+        tracing::info!("Using SEPARATE GDN projections (4 dispatches per layer)");
+        return Ok(model);
+    }
+
+    let mut fused_model = Qwen3NextCausalLM::new(args.clone())?;
+    match load_qwen3_5_moe_weights_fused(&mut fused_model, model_path, gdn_dims) {
+        Ok(()) => {
+            tracing::info!("Using FUSED GDN projections (2 dispatches per layer)");
+            Ok(fused_model)
+        }
+        Err(err) if is_mixed_bit_gdn_ba_fusion_error(&err) => {
+            tracing::warn!(
+                error = %err,
+                "Detected mixed-bit GDN BA projection shapes; retrying with separate GDN projections"
+            );
+            args.use_separate_gdn_projections = true;
+            let mut separate_model = Qwen3NextCausalLM::new(args)?;
+            load_qwen3_5_moe_weights_direct(&mut separate_model, model_path)?;
+            tracing::info!(
+                "Using SEPARATE GDN projections (4 dispatches per layer, mixed-bit fallback)"
+            );
+            Ok(separate_model)
+        }
+        Err(err) => Err(err),
+    }
+}
+
+/// Returns true when the supplied error is the mixed-bit BA fusion error raised
+/// by [`load_qwen3_5_moe_weights_fused`] when `in_proj_a` and `in_proj_b` have
+/// incompatible packed inner shapes.
+fn is_mixed_bit_gdn_ba_fusion_error(err: &ModelError) -> bool {
+    matches!(
+        err,
+        ModelError::ShapeMismatch(message)
+            if message.contains("in_proj_ba")
+                && message.contains("requires separate GDN projections")
+    )
 }
 
 /// GDN dimension info extracted from model args before move.
@@ -3916,6 +4012,21 @@ fn concat_and_permute(a: &Array, b: &Array, perm: &[i32]) -> Result<Array, Excep
         &[i32::try_from(perm.len()).map_err(|_| Exception::custom("perm len overflow"))?],
     );
     cat.take_axis(&perm_arr, 0)
+}
+
+/// Return true when `a` and `b` can be concatenated along axis 0: the rank
+/// matches and every non-axis-0 dimension is identical. Quantized weights pack
+/// different bit-widths into different inner shapes, so this guards the BA
+/// fusion path from silently producing a malformed `in_proj_ba` matrix.
+fn can_concatenate_axis0(a: &Array, b: &Array) -> bool {
+    let a_shape = a.shape();
+    let b_shape = b.shape();
+    a_shape.len() == b_shape.len()
+        && a_shape
+            .iter()
+            .zip(b_shape.iter())
+            .enumerate()
+            .all(|(axis, (lhs, rhs))| axis == 0 || lhs == rhs)
 }
 
 /// Load Qwen3.5-MoE weights with GDN projection fusion.
@@ -4052,6 +4163,13 @@ fn load_qwen3_5_moe_weights_fused<M: mlx_rs::module::ModuleParametersExt>(
                 format!("Incomplete GDN projection pair for key: {combined_key}"),
             )));
         };
+        if combined_key.contains("in_proj_ba") && !can_concatenate_axis0(a, b) {
+            return Err(crate::error::ModelError::ShapeMismatch(format!(
+                "Mixed-bit BA fusion requires separate GDN projections for key {combined_key}: {:?} vs {:?}",
+                a.shape(),
+                b.shape()
+            )));
+        }
         let Some(param) = params.get_mut(combined_key.as_str()) else {
             return Err(crate::error::ModelError::Io(std::io::Error::other(
                 format!("Fused target key not found in model params: {combined_key}"),
@@ -12823,6 +12941,87 @@ mod tests {
         args.mtp_num_hidden_layers = 1;
         maybe_disable_mtp_without_checkpoint_weights(&mut args, dir.path()).unwrap();
         assert_eq!(args.mtp_num_hidden_layers, 1);
+    }
+
+    #[test]
+    fn test_load_qwen35_mixed_ba_quantization_forces_separate_gdn() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = format!(
+            r#"{{
+                "text_config": {},
+                "tie_word_embeddings": false,
+                "quantization": {{
+                    "group_size": 64,
+                    "bits": 2,
+                    "mode": "affine",
+                    "language_model.model.layers.1.linear_attn.in_proj_a": {{
+                        "group_size": 64,
+                        "bits": 5,
+                        "mode": "affine"
+                    }}
+                }}
+            }}"#,
+            qwen35_dense_text_config()
+        );
+        std::fs::write(dir.path().join("config.json"), config).unwrap();
+
+        let args = load_qwen3_5_moe_text_config_args(dir.path()).unwrap();
+
+        assert!(
+            args.use_separate_gdn_projections,
+            "mixed-bit in_proj_a/in_proj_b must force separate GDN projections"
+        );
+    }
+
+    #[test]
+    fn test_load_qwen35_matching_ba_quantization_keeps_fused_gdn() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = format!(
+            r#"{{
+                "text_config": {},
+                "tie_word_embeddings": false,
+                "quantization": {{
+                    "group_size": 64,
+                    "bits": 2,
+                    "mode": "affine",
+                    "language_model.model.layers.1.linear_attn.in_proj_a": {{
+                        "group_size": 64,
+                        "bits": 5,
+                        "mode": "affine"
+                    }},
+                    "language_model.model.layers.1.linear_attn.in_proj_b": {{
+                        "group_size": 64,
+                        "bits": 5,
+                        "mode": "affine"
+                    }}
+                }}
+            }}"#,
+            qwen35_dense_text_config()
+        );
+        std::fs::write(dir.path().join("config.json"), config).unwrap();
+
+        let args = load_qwen3_5_moe_text_config_args(dir.path()).unwrap();
+
+        assert!(
+            !args.use_separate_gdn_projections,
+            "matching BA overrides should keep the fused GDN loader path"
+        );
+    }
+
+    #[test]
+    fn test_can_concatenate_axis0_detects_quantized_inner_shape_mismatch() {
+        let a = Array::zeros::<f32>(&[48, 320]).unwrap();
+        let b = Array::zeros::<f32>(&[48, 800]).unwrap();
+        let c = Array::zeros::<f32>(&[96, 320]).unwrap();
+
+        assert!(
+            !can_concatenate_axis0(&a, &b),
+            "different packed inner dims must block BA fusion"
+        );
+        assert!(
+            can_concatenate_axis0(&a, &c),
+            "axis-0 size may differ because fusion concatenates rows"
+        );
     }
 
     /// GQA ratio: `num_v_heads` must be divisible by `num_k_heads`.


### PR DESCRIPTION
## Summary

Adds a load-time fallback for Qwen3.5 models with **mixed-bit GDN BA projections** (some layers q4, some q8 — common in unsloth's dynamic-quant variants). The default fused loader concatenates `in_proj_a` + `in_proj_b` into a single matmul; mixed-bit weights have incompatible shapes and fusion fails. This PR detects that specific failure and retries with separate (4-dispatch) GDN projections.

PR-1c of the `feat/magic-canvas` split — a deferred follow-up from #141's audit (source commit `061e500c`).

### Behaviour

1. Default fused path: try `load_qwen3_5_moe_weights_fused` (2 GDN dispatches per layer).
2. On `ModelError::ShapeMismatch` containing both `"in_proj_ba"` and `"requires separate GDN projections"`, retry with `args.use_separate_gdn_projections = true` and `load_qwen3_5_moe_weights_direct` (4 dispatches per layer).
3. Forced separate (`HIGGS_SEPARATE_GDN_PROJ` env or `args.use_separate_gdn_projections`) skips the fused attempt entirely.
4. Any other error propagates.

### What's added

- `is_mixed_bit_gdn_ba_fusion_error` — matches the diagnostic shape-mismatch error
- `qwen3_5_quantization_config` — parses `{group_size, bits}` from the per-layer `quantization` map
- `qwen3_5_mixed_ba_quantization_layers` — finds layers where `in_proj_a` and `in_proj_b` differ
- `can_concatenate_axis0` — guard inside `load_qwen3_5_moe_weights_fused` to emit the diagnostic error rather than panic
- `load_qwen3_5_model_with_gdn_fallback` — private helper called by both dense and MoE load paths

### Adaptations to origin/main

- The dense `load_qwen3_5_model` on origin/main only honoured the env var; now also honours `args.use_separate_gdn_projections` (matching MoE behaviour). Strict improvement — flag is set only by env or by mixed-bit detection.
- Direct cherry-pick of `061e500c` produced 5 conflict regions because origin/main has evolved the load functions independently. This is a manual surgical port preserving origin/main's structure.

### Hygiene

- No `unwrap()` on `Result`/`Option`
- No `as` casts in shape-arithmetic paths (`i32::try_from`)
- Match arms enumerate variants explicitly
- No file-level blanket allows added

## Test plan

- [x] `cargo check -p higgs-models` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean (rustc 1.95.0, matches CI)
- [x] `cargo fmt --check` — clean
- [x] `cargo test -p higgs-models --lib` — 333/333 pass (3 new)
- [ ] End-to-end load test against an unsloth dynamic-quant Qwen3.5 model (e.g. `Brooooooklyn/Qwen3.5-27B-unsloth-mlx`) — confirm the warn-then-retry path triggers and the model loads.

## Context

Part of the `feat/magic-canvas` PR split. Prior PRs in the chain: #141 (fused MoE), #142 (Bonsai-Q1 fp16 +2.83×), #143 (AnyCache::trim_by), #144 (DraftModel trait), #145 (PLD drafter), #147 (DFlash drafter foundation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Qwen3.5 model loading to detect per-layer mixed-bit quantization and automatically fall back to a compatible loading path when fusion is invalid, reducing load failures and shape-mismatch errors.
  * Added safeguards to prevent incorrect tensor fusion during model import and clearer logging of fused vs. separate projection outcomes.

* **Tests**
  * Added tests covering mixed-bit quantization, forced separate-projection scenarios, fusion-preservation, and shape-mismatch detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->