### PR TITLE
fix: default Qwen3.6 to non-thinking mode

### DIFF
--- a/crates/higgs/src/lib.rs
+++ b/crates/higgs/src/lib.rs
@@ -11,6 +11,7 @@ pub mod metrics_log;
 pub mod model_download;
 pub mod model_resolver;
 pub mod proxy;
+pub(crate) mod reasoning;
 pub mod router;
 pub mod routes;
 #[doc(hidden)]

--- a/crates/higgs/src/reasoning.rs
+++ b/crates/higgs/src/reasoning.rs
@@ -1,12 +1,26 @@
 use crate::types::openai::ReasoningConfig;
 
 fn model_defaults_to_non_thinking(model_names: &[&str]) -> bool {
-    model_names
-        .iter()
-        .any(|name| name.to_ascii_lowercase().contains("qwen3.6"))
+    model_names.iter().any(|model_name| {
+        let normalized = model_name.to_ascii_lowercase();
+        normalized.match_indices("qwen3.6").any(|(idx, _)| {
+            let after = idx + "qwen3.6".len();
+            let before_is_boundary = idx == 0
+                || normalized
+                    .as_bytes()
+                    .get(idx - 1)
+                    .is_some_and(|b| !b.is_ascii_alphanumeric());
+            let after_is_boundary = after == normalized.len()
+                || normalized
+                    .as_bytes()
+                    .get(after)
+                    .is_some_and(|b| !b.is_ascii_digit());
+            before_is_boundary && after_is_boundary
+        })
+    })
 }
 
-pub(crate) fn effective_thinking_enabled(
+pub fn effective_thinking_enabled(
     engine_default: bool,
     model_names: &[&str],
     reasoning: Option<&ReasoningConfig>,
@@ -16,7 +30,7 @@ pub(crate) fn effective_thinking_enabled(
     }
 
     match reasoning.and_then(|r| r.effort.as_deref()) {
-        Some(effort) if effort.eq_ignore_ascii_case("none") => false,
+        Some(effort) if effort.is_empty() || effort.eq_ignore_ascii_case("none") => false,
         Some(_) => true,
         None => !model_defaults_to_non_thinking(model_names),
     }
@@ -55,6 +69,15 @@ mod tests {
     }
 
     #[test]
+    fn qwen365_does_not_use_qwen36_default() {
+        assert!(effective_thinking_enabled(
+            true,
+            &["mlx-community/Qwen3.65-35B-A3B-4bit"],
+            None,
+        ));
+    }
+
+    #[test]
     fn honors_reasoning_none() {
         assert!(!effective_thinking_enabled(
             true,
@@ -66,10 +89,32 @@ mod tests {
     }
 
     #[test]
+    fn honors_empty_reasoning_as_not_explicit() {
+        assert!(!effective_thinking_enabled(
+            true,
+            &["mlx-community/Qwen3.5-foo"],
+            Some(&ReasoningConfig {
+                effort: Some(String::new()),
+            }),
+        ));
+    }
+
+    #[test]
     fn honors_explicit_reasoning_request() {
         assert!(effective_thinking_enabled(
             true,
             &["mlx-community/Qwen3.6-35B-A3B-4bit"],
+            Some(&ReasoningConfig {
+                effort: Some("low".to_owned()),
+            }),
+        ));
+    }
+
+    #[test]
+    fn engine_default_off_overrides_explicit_request() {
+        assert!(!effective_thinking_enabled(
+            false,
+            &["mlx-community/Qwen3.5-foo"],
             Some(&ReasoningConfig {
                 effort: Some("low".to_owned()),
             }),

--- a/crates/higgs/src/reasoning.rs
+++ b/crates/higgs/src/reasoning.rs
@@ -1,0 +1,78 @@
+use crate::types::openai::ReasoningConfig;
+
+fn model_defaults_to_non_thinking(model_names: &[&str]) -> bool {
+    model_names
+        .iter()
+        .any(|name| name.to_ascii_lowercase().contains("qwen3.6"))
+}
+
+pub(crate) fn effective_thinking_enabled(
+    engine_default: bool,
+    model_names: &[&str],
+    reasoning: Option<&ReasoningConfig>,
+) -> bool {
+    if !engine_default {
+        return false;
+    }
+
+    match reasoning.and_then(|r| r.effort.as_deref()) {
+        Some(effort) if effort.eq_ignore_ascii_case("none") => false,
+        Some(_) => true,
+        None => !model_defaults_to_non_thinking(model_names),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_qwen35_on() {
+        assert!(effective_thinking_enabled(
+            true,
+            &["mlx-community/Qwen3.5-foo"],
+            None,
+        ));
+    }
+
+    #[test]
+    fn defaults_qwen36_off_from_route_name() {
+        assert!(!effective_thinking_enabled(
+            true,
+            &["mlx-community/Qwen3.6-35B-A3B-4bit"],
+            None,
+        ));
+    }
+
+    #[test]
+    fn defaults_qwen36_off_from_engine_name_even_when_aliased() {
+        assert!(!effective_thinking_enabled(
+            true,
+            &["qwen", "mlx-community/Qwen3.6-35B-A3B-4bit"],
+            None,
+        ));
+    }
+
+    #[test]
+    fn honors_reasoning_none() {
+        assert!(!effective_thinking_enabled(
+            true,
+            &["mlx-community/Qwen3.5-foo"],
+            Some(&ReasoningConfig {
+                effort: Some("none".to_owned()),
+            }),
+        ));
+    }
+
+    #[test]
+    fn honors_explicit_reasoning_request() {
+        assert!(effective_thinking_enabled(
+            true,
+            &["mlx-community/Qwen3.6-35B-A3B-4bit"],
+            Some(&ReasoningConfig {
+                effort: Some("low".to_owned()),
+            }),
+        ));
+    }
+}

--- a/crates/higgs/src/routes/anthropic.rs
+++ b/crates/higgs/src/routes/anthropic.rs
@@ -234,20 +234,25 @@ async fn create_message_non_streaming(
 
     let engine_messages = anthropic_messages_to_engine(&req.messages, req.system.as_ref());
     let tools = req.tools.as_deref();
+    let thinking_enabled = crate::reasoning::effective_thinking_enabled(
+        engine.enable_thinking(),
+        &[engine.model_name(), req.model.as_str()],
+        None,
+    );
 
     let prompt_tokens = engine
-        .prepare_chat_prompt(&engine_messages, tools)
+        .prepare_chat_prompt_with_thinking(&engine_messages, tools, thinking_enabled)
         .map_err(ServerError::Engine)?;
 
-    let thinking_enabled = engine.enable_thinking();
     let output = tokio::task::spawn_blocking(move || {
-        engine.generate(
+        engine.generate_with_thinking(
             &prompt_tokens,
             max_tokens,
             &sampling,
             &stop_sequences,
             false,
             None,
+            thinking_enabled,
             None,
             None,
         )
@@ -315,9 +320,14 @@ fn create_message_stream(
 
     let engine_messages = anthropic_messages_to_engine(&req.messages, req.system.as_ref());
     let tools = req.tools.as_deref();
+    let thinking_enabled = crate::reasoning::effective_thinking_enabled(
+        engine.enable_thinking(),
+        &[engine.model_name(), req.model.as_str()],
+        None,
+    );
 
     let prompt_tokens = engine
-        .prepare_chat_prompt(&engine_messages, tools)
+        .prepare_chat_prompt_with_thinking(&engine_messages, tools, thinking_enabled)
         .map_err(ServerError::Engine)?;
 
     let msg_id = format!("msg_{}", uuid::Uuid::new_v4().simple());
@@ -325,13 +335,11 @@ fn create_message_stream(
     let prompt_token_count = u32::try_from(prompt_tokens.len())
         .map_err(|_| ServerError::BadRequest("Token count overflow".to_owned()))?;
 
-    let thinking_enabled = engine.enable_thinking();
-
     // Spawn generation before creating the stream so prefill starts immediately
     let (tx, mut rx) = tokio::sync::mpsc::channel(32);
 
     tokio::task::spawn_blocking(move || {
-        let result = engine.generate_streaming(
+        let result = engine.generate_streaming_with_thinking(
             &prompt_tokens,
             max_tokens,
             &sampling,
@@ -339,6 +347,7 @@ fn create_message_stream(
             false,
             None,
             &tx,
+            thinking_enabled,
             None,
             None,
         );
@@ -509,12 +518,19 @@ pub async fn count_tokens(
         .map_err(ServerError::ModelNotFound)?;
 
     match resolved {
-        ResolvedRoute::Higgs { engine, .. } => {
+        ResolvedRoute::Higgs {
+            engine, model_name, ..
+        } => {
             let engine_messages = anthropic_messages_to_engine(&req.messages, req.system.as_ref());
             let tools = req.tools.as_deref();
+            let thinking_enabled = crate::reasoning::effective_thinking_enabled(
+                engine.enable_thinking(),
+                &[engine.model_name(), model_name.as_str()],
+                None,
+            );
 
             let tokens = engine
-                .prepare_chat_prompt(&engine_messages, tools)
+                .prepare_chat_prompt_with_thinking(&engine_messages, tools, thinking_enabled)
                 .map_err(ServerError::Engine)?;
 
             let count = u32::try_from(tokens.len())

--- a/crates/higgs/src/routes/chat.rs
+++ b/crates/higgs/src/routes/chat.rs
@@ -22,31 +22,11 @@ use crate::{
     state::{Engine, SharedState},
     types::openai::{
         ChatCompletionChoice, ChatCompletionDelta, ChatCompletionMessage, ChatCompletionRequest,
-        ChatCompletionResponse, ChoiceLogprobs, CompletionUsage, MessageContent, ReasoningConfig,
-        StopSequence, TokenLogprob, ToolCall, ToolCallFunction, TopLogprob,
+        ChatCompletionResponse, ChoiceLogprobs, CompletionUsage, MessageContent, StopSequence,
+        TokenLogprob, ToolCall, ToolCallFunction, TopLogprob,
     },
 };
 use higgs_models::SamplingParams;
-
-fn model_defaults_to_non_thinking(model_name: &str) -> bool {
-    model_name.to_ascii_lowercase().contains("qwen3.6")
-}
-
-fn effective_thinking_enabled(
-    engine_default: bool,
-    model_name: &str,
-    reasoning: Option<&ReasoningConfig>,
-) -> bool {
-    if !engine_default {
-        return false;
-    }
-
-    match reasoning.and_then(|r| r.effort.as_deref()) {
-        Some(effort) if effort.eq_ignore_ascii_case("none") => false,
-        Some(_) => true,
-        None => !model_defaults_to_non_thinking(model_name),
-    }
-}
 
 #[allow(clippy::too_many_lines)]
 pub async fn chat_completions(
@@ -288,9 +268,9 @@ async fn chat_completions_non_streaming(
 
     let messages = convert_messages(&effective_messages);
     let tools = req.tools.as_deref();
-    let thinking_enabled = effective_thinking_enabled(
+    let thinking_enabled = crate::reasoning::effective_thinking_enabled(
         engine.enable_thinking(),
-        engine.model_name(),
+        &[engine.model_name(), req.model.as_str()],
         req.reasoning.as_ref(),
     );
 
@@ -469,9 +449,9 @@ fn chat_completions_stream(
     };
 
     let messages = convert_messages(&effective_messages);
-    let thinking_enabled_stream = effective_thinking_enabled(
+    let thinking_enabled_stream = crate::reasoning::effective_thinking_enabled(
         engine.enable_thinking(),
-        engine.model_name(),
+        &[engine.model_name(), req.model.as_str()],
         req.reasoning.as_ref(),
     );
 
@@ -852,7 +832,6 @@ fn current_unix_timestamp() -> i64 {
 #[allow(clippy::panic, clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use crate::types::openai::ReasoningConfig;
 
     fn simple_message(role: &str, content: Option<&str>) -> ChatCompletionMessage {
         ChatCompletionMessage {
@@ -970,45 +949,5 @@ mod tests {
     fn test_current_unix_timestamp_reasonable_value() {
         let ts = current_unix_timestamp();
         assert!(ts > 1_700_000_000, "timestamp too old: {ts}");
-    }
-
-    #[test]
-    fn test_effective_thinking_enabled_defaults_qwen35_on() {
-        assert!(effective_thinking_enabled(
-            true,
-            "mlx-community/Qwen3.5-foo",
-            None
-        ));
-    }
-
-    #[test]
-    fn test_effective_thinking_enabled_defaults_qwen36_off() {
-        assert!(!effective_thinking_enabled(
-            true,
-            "mlx-community/Qwen3.6-35B-A3B-4bit",
-            None,
-        ));
-    }
-
-    #[test]
-    fn test_effective_thinking_enabled_honors_reasoning_none() {
-        assert!(!effective_thinking_enabled(
-            true,
-            "mlx-community/Qwen3.5-foo",
-            Some(&ReasoningConfig {
-                effort: Some("none".to_owned()),
-            }),
-        ));
-    }
-
-    #[test]
-    fn test_effective_thinking_enabled_honors_explicit_reasoning_request() {
-        assert!(effective_thinking_enabled(
-            true,
-            "mlx-community/Qwen3.6-35B-A3B-4bit",
-            Some(&ReasoningConfig {
-                effort: Some("low".to_owned()),
-            }),
-        ));
     }
 }

--- a/crates/higgs/src/routes/chat.rs
+++ b/crates/higgs/src/routes/chat.rs
@@ -328,18 +328,14 @@ async fn chat_completions_non_streaming(
     // When thinking mode is enabled, the template already opened `<think>` in the prompt,
     // so the generated text starts inside the think block. Prepend `<think>` so the parser
     // can find the matching `</think>` and split reasoning from visible content.
-    let parse_input = if thinking_enabled {
-        if output_text.contains("</think>") {
+    let (raw_text, reasoning_content) = if thinking_enabled {
+        let parse_input = if output_text.contains("</think>") {
             format!("<think>{output_text}")
         } else {
             // Model was length-stopped mid-thinking — close the tag so the
             // parser can extract reasoning instead of leaking raw `<think>`.
             format!("<think>{output_text}</think>")
-        }
-    } else {
-        output_text.clone()
-    };
-    let (raw_text, reasoning_content) = if thinking_enabled {
+        };
         let reasoning_result = higgs_engine::reasoning_parser::parse_reasoning(&parse_input);
         let raw_text = if reasoning_result.reasoning.is_some() {
             reasoning_result.text
@@ -348,7 +344,7 @@ async fn chat_completions_non_streaming(
         };
         (raw_text, reasoning_result.reasoning)
     } else {
-        (parse_input, None)
+        (output_text, None)
     };
 
     let (content, tool_calls, finish_reason) = if has_tools {

--- a/crates/higgs/src/types/openai.rs
+++ b/crates/higgs/src/types/openai.rs
@@ -5,6 +5,9 @@ use serde::{Deserialize, Serialize};
 pub struct ChatCompletionRequest {
     pub model: String,
     pub messages: Vec<ChatCompletionMessage>,
+    /// Maximum number of tokens to generate.
+    ///
+    /// Accepts `max_completion_tokens` and `max_output_tokens` aliases.
     #[serde(default, alias = "max_completion_tokens", alias = "max_output_tokens")]
     pub max_tokens: Option<u32>,
     #[serde(default)]
@@ -284,6 +287,9 @@ pub struct ToolCallFunctionDelta {
 pub struct CompletionRequest {
     pub model: String,
     pub prompt: String,
+    /// Maximum number of tokens to generate.
+    ///
+    /// Accepts `max_completion_tokens` and `max_output_tokens` aliases.
     #[serde(default, alias = "max_completion_tokens", alias = "max_output_tokens")]
     pub max_tokens: Option<u32>,
     #[serde(default)]
@@ -824,6 +830,17 @@ mod tests {
             "model": "m",
             "prompt": "test",
             "max_completion_tokens": 100
+        }"#;
+        let req: CompletionRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.max_tokens, Some(100));
+    }
+
+    #[test]
+    fn test_completion_request_accepts_max_output_tokens_alias() {
+        let json = r#"{
+            "model": "m",
+            "prompt": "test",
+            "max_output_tokens": 100
         }"#;
         let req: CompletionRequest = serde_json::from_str(json).unwrap();
         assert_eq!(req.max_tokens, Some(100));

--- a/crates/higgs/src/types/openai.rs
+++ b/crates/higgs/src/types/openai.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 pub struct ChatCompletionRequest {
     pub model: String,
     pub messages: Vec<ChatCompletionMessage>,
-    #[serde(default)]
+    #[serde(default, alias = "max_completion_tokens", alias = "max_output_tokens")]
     pub max_tokens: Option<u32>,
     #[serde(default)]
     pub temperature: Option<f32>,
@@ -284,7 +284,7 @@ pub struct ToolCallFunctionDelta {
 pub struct CompletionRequest {
     pub model: String,
     pub prompt: String,
-    #[serde(default)]
+    #[serde(default, alias = "max_completion_tokens", alias = "max_output_tokens")]
     pub max_tokens: Option<u32>,
     #[serde(default)]
     pub temperature: Option<f32>,
@@ -729,6 +729,18 @@ mod tests {
     }
 
     #[test]
+    fn test_chat_request_accepts_max_completion_tokens_alias() {
+        let req = chat_request_with(r#""max_completion_tokens": 100"#);
+        assert_eq!(req.max_tokens, Some(100));
+    }
+
+    #[test]
+    fn test_chat_request_accepts_max_output_tokens_alias() {
+        let req = chat_request_with(r#""max_output_tokens": 100"#);
+        assert_eq!(req.max_tokens, Some(100));
+    }
+
+    #[test]
     fn test_chat_request_with_temperature_zero() {
         let req = chat_request_with(r#""temperature": 0.0"#);
         assert!((req.temperature.unwrap()).abs() < f32::EPSILON);
@@ -804,6 +816,17 @@ mod tests {
         assert!((req.top_p.unwrap() - 0.8).abs() < f32::EPSILON);
         assert_eq!(req.stream, Some(false));
         assert!(req.stop.is_some());
+    }
+
+    #[test]
+    fn test_completion_request_accepts_max_completion_tokens_alias() {
+        let json = r#"{
+            "model": "m",
+            "prompt": "test",
+            "max_completion_tokens": 100
+        }"#;
+        let req: CompletionRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.max_tokens, Some(100));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- share Qwen thinking-mode policy across OpenAI and Anthropic local routes
- default Qwen3.6 to non-thinking mode even when served through an alias
- accept max_completion_tokens and max_output_tokens as max_tokens aliases

## Testing
- cargo fmt
- cargo test -p higgs --lib

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded thinking/reasoning support for Anthropic and Chat flows (streaming and non-streaming) with model-name-aware detection.
  * Added serde aliases for token limits: max_completion_tokens and max_output_tokens.

* **Refactor**
  * Internal rework of reasoning extraction and message/content handling; updated internal OpenAI-related types.

* **Tests**
  * Added unit tests covering reasoning logic and token-alias deserialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->