### PR TITLE
fix(release): use explicit higgs-bench package version

### DIFF
--- a/crates/higgs-bench/Cargo.toml
+++ b/crates/higgs-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "higgs-bench"
-version = { workspace = true }
+version = "1.0.0"
 edition = { workspace = true }
 license = { workspace = true }
 rust-version = { workspace = true }


### PR DESCRIPTION
## Summary
- Replace higgs-bench workspace-inherited package version with an explicit string version.
- Keep Cargo behavior the same while satisfying release-please cargo-workspace parsing.

## Verification
- Python TOML guard over branch tarball: all crates/* package.version fields are strings.
- cargo metadata --format-version 1 --no-deps --manifest-path /private/tmp/higgs-release-fix-verify/Cargo.toml.