### PR TITLE
Optimize MTP follow-up modes

### DIFF
--- a/crates/higgs-bench/src/bin/bench_decode.rs
+++ b/crates/higgs-bench/src/bin/bench_decode.rs
@@ -22,8 +22,9 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use futures::StreamExt;
 use higgs_bench::{
-    BenchOutput, ModelInfo, OutputFormat, RunMetadata, default_manifest_path, format_json,
-    format_markdown, models, path_for_output, persist_result, public_model_ref, server, stats,
+    BENCH_SCHEMA_VERSION, BenchOutput, ModelInfo, OutputFormat, RunMetadata, default_manifest_path,
+    format_json, format_markdown, models, path_for_output, persist_result, public_model_ref,
+    server, stats,
 };
 use serde::Serialize;
 
@@ -232,6 +233,7 @@ async fn run(args: Args) -> Result<()> {
     };
 
     let output = BenchOutput {
+        schema_version: BENCH_SCHEMA_VERSION,
         metadata,
         params,
         results,

--- a/crates/higgs-bench/src/bin/bench_speculative.rs
+++ b/crates/higgs-bench/src/bin/bench_speculative.rs
@@ -19,9 +19,9 @@ use std::time::{Duration, Instant};
 use anyhow::{Context, Result};
 use clap::Parser;
 use higgs_bench::{
-    BenchOutput, ModelInfo, OutputFormat, RunMetadata, default_manifest_path, format_json,
-    format_markdown, models, path_for_output, persist_result, public_model_ref, results_dir,
-    server, speculative, stats,
+    BENCH_SCHEMA_VERSION, BenchOutput, ModelInfo, OutputFormat, RunMetadata, default_manifest_path,
+    format_json, format_markdown, models, path_for_output, persist_result, public_model_ref,
+    results_dir, server, speculative, stats,
 };
 use serde::Serialize;
 
@@ -69,8 +69,8 @@ struct Args {
     repeats: u32,
 
     /// Comma-separated trial modes: `baseline`, `mtp_default`,
-    /// `prompt_lookup`, `prompt_lookup_unchecked`, or numeric MTP draft
-    /// depths such as `1,2,3`.
+    /// `mtp_adaptive`, `mtp_hybrid`, `prompt_lookup`,
+    /// `prompt_lookup_unchecked`, or numeric MTP draft depths such as `1,2,3`.
     #[arg(long, default_value = "baseline,1,2,3")]
     trials: String,
 
@@ -234,6 +234,7 @@ async fn run(args: Args) -> Result<()> {
     };
 
     let output = BenchOutput {
+        schema_version: BENCH_SCHEMA_VERSION,
         metadata,
         params,
         results: Results { trials: summaries },
@@ -494,6 +495,8 @@ fn clear_speculative_env(cmd: &mut Command) {
 const SPECULATIVE_ENV_KEYS: &[&str] = &[
     "HIGGS_MTP",
     "HIGGS_MTP_DRAFT_N_MAX",
+    "HIGGS_MTP_ADAPTIVE_DRAFT",
+    "HIGGS_MTP_PROMPT_LOOKUP",
     "HIGGS_PROMPT_LOOKUP",
     "HIGGS_PROMPT_LOOKUP_UNCHECKED",
     "HIGGS_MTP_PRIME_PREFILL",

--- a/crates/higgs-bench/src/lib.rs
+++ b/crates/higgs-bench/src/lib.rs
@@ -32,6 +32,9 @@ mod built_info {
 /// Bench-crate version (from `CARGO_PKG_VERSION` at compile time).
 pub const BENCH_VERSION: &str = env!("CARGO_PKG_VERSION");
 
+/// Version of the JSON/Markdown benchmark output envelope.
+pub const BENCH_SCHEMA_VERSION: u32 = 1;
+
 /// Returns the short git commit hash captured at compile time.
 #[must_use]
 pub fn git_commit_short() -> String {
@@ -204,7 +207,9 @@ pub fn path_for_output(path: &Path) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{hostname_for_output, public_model_ref, redact_arg_for_output};
+    use super::{
+        BENCH_SCHEMA_VERSION, hostname_for_output, public_model_ref, redact_arg_for_output,
+    };
 
     #[test]
     fn benchmark_metadata_redacts_hostname_by_default() {
@@ -239,6 +244,26 @@ mod tests {
             public_model_ref("/Users/alice/models/private-qwen", "local-qwen"),
             "local-qwen"
         );
+    }
+
+    #[test]
+    fn bench_output_includes_schema_version() -> anyhow::Result<()> {
+        let output = super::BenchOutput {
+            schema_version: BENCH_SCHEMA_VERSION,
+            metadata: super::RunMetadata::capture("unit"),
+            params: serde_json::json!({}),
+            results: serde_json::json!({}),
+        };
+        let json = super::format_json(&output)?;
+        let value: serde_json::Value = serde_json::from_str(&json)?;
+
+        assert_eq!(
+            value
+                .get("schema_version")
+                .and_then(serde_json::Value::as_u64),
+            Some(1)
+        );
+        Ok(())
     }
 }
 
@@ -316,6 +341,8 @@ where
     P: Serialize,
     R: Serialize,
 {
+    /// JSON/Markdown envelope schema version.
+    pub schema_version: u32,
     /// Reproducibility metadata (host, model, git, argv, timing).
     pub metadata: RunMetadata,
     /// Bench-specific parameters (CLI flags, prompt, etc.).
@@ -368,6 +395,7 @@ where
         meta.git_commit_short,
         if meta.git_dirty { " (dirty)" } else { "" }
     )?;
+    writeln!(s, "| schema_version | {} |", output.schema_version)?;
     writeln!(s, "| started_at | {} |", meta.started_at.to_rfc3339())?;
     writeln!(s, "| duration_ms | {} |", meta.duration_ms)?;
     if let Some(model) = &meta.model {

--- a/crates/higgs-bench/src/speculative.rs
+++ b/crates/higgs-bench/src/speculative.rs
@@ -74,8 +74,10 @@ fn looks_like_huggingface_repo_id(model_path: &str) -> bool {
 
 /// Parses a comma-separated trial list.
 ///
-/// Supported items are `baseline`, `mtp_default`, numeric MTP draft depths,
-/// `prompt_lookup`, and `prompt_lookup_unchecked`.
+/// Supported items are `baseline`, `mtp_default`, `mtp_adaptive`,
+/// `mtp_hybrid` (prompt lookup plus adaptive MTP), numeric MTP draft depths,
+/// `prompt_lookup`, and
+/// `prompt_lookup_unchecked`.
 pub fn parse_trial_specs(input: &str) -> Result<Vec<TrialSpec>> {
     let mut trials = Vec::new();
     for raw in input.split(',') {
@@ -97,6 +99,18 @@ fn parse_trial_spec(trial: &str) -> Result<TrialSpec> {
     match trial {
         "baseline" => Ok(trial_spec("baseline_mtp_off", [("HIGGS_MTP", "0")])),
         "mtp_default" | "default" => Ok(trial_spec("mtp_default", [("HIGGS_MTP", "1")])),
+        "mtp_adaptive" | "adaptive" => Ok(trial_spec(
+            "mtp_adaptive",
+            [("HIGGS_MTP", "1"), ("HIGGS_MTP_ADAPTIVE_DRAFT", "1")],
+        )),
+        "mtp_hybrid" | "hybrid" => Ok(trial_spec(
+            "mtp_hybrid",
+            [
+                ("HIGGS_MTP", "1"),
+                ("HIGGS_MTP_ADAPTIVE_DRAFT", "1"),
+                ("HIGGS_MTP_PROMPT_LOOKUP", "1"),
+            ],
+        )),
         "prompt_lookup" | "plookup" => Ok(trial_spec(
             "prompt_lookup",
             [("HIGGS_MTP", "0"), ("HIGGS_PROMPT_LOOKUP", "1")],
@@ -176,14 +190,17 @@ mod tests {
 
     #[test]
     fn parse_trial_specs_sets_expected_env_overrides() -> anyhow::Result<()> {
-        let trials =
-            parse_trial_specs("baseline,mtp_default,2,prompt_lookup,prompt_lookup_unchecked")?;
+        let trials = parse_trial_specs(
+            "baseline,mtp_default,mtp_adaptive,mtp_hybrid,2,prompt_lookup,prompt_lookup_unchecked",
+        )?;
 
         let baseline = trial_at(&trials, 0)?;
         let mtp_default = trial_at(&trials, 1)?;
-        let mtp_draft_2 = trial_at(&trials, 2)?;
-        let prompt_lookup = trial_at(&trials, 3)?;
-        let prompt_lookup_unchecked = trial_at(&trials, 4)?;
+        let mtp_adaptive = trial_at(&trials, 2)?;
+        let mtp_hybrid = trial_at(&trials, 3)?;
+        let mtp_draft_2 = trial_at(&trials, 4)?;
+        let prompt_lookup = trial_at(&trials, 5)?;
+        let prompt_lookup_unchecked = trial_at(&trials, 6)?;
 
         assert_eq!(baseline.label, "baseline_mtp_off");
         assert_eq!(baseline.env.get("HIGGS_MTP").map(String::as_str), Some("0"));
@@ -191,6 +208,39 @@ mod tests {
         assert_eq!(mtp_default.label, "mtp_default");
         assert_eq!(
             mtp_default.env.get("HIGGS_MTP").map(String::as_str),
+            Some("1")
+        );
+
+        assert_eq!(mtp_adaptive.label, "mtp_adaptive");
+        assert_eq!(
+            mtp_adaptive.env.get("HIGGS_MTP").map(String::as_str),
+            Some("1")
+        );
+        assert_eq!(
+            mtp_adaptive
+                .env
+                .get("HIGGS_MTP_ADAPTIVE_DRAFT")
+                .map(String::as_str),
+            Some("1")
+        );
+
+        assert_eq!(mtp_hybrid.label, "mtp_hybrid");
+        assert_eq!(
+            mtp_hybrid.env.get("HIGGS_MTP").map(String::as_str),
+            Some("1")
+        );
+        assert_eq!(
+            mtp_hybrid
+                .env
+                .get("HIGGS_MTP_ADAPTIVE_DRAFT")
+                .map(String::as_str),
+            Some("1")
+        );
+        assert_eq!(
+            mtp_hybrid
+                .env
+                .get("HIGGS_MTP_PROMPT_LOOKUP")
+                .map(String::as_str),
             Some("1")
         );
 

--- a/crates/higgs-engine/src/mlx_tuning.rs
+++ b/crates/higgs-engine/src/mlx_tuning.rs
@@ -414,7 +414,21 @@ fn heuristic_paged_kv_target_bytes(
     size_class: ModelSizeClass,
     is_moe: bool,
 ) -> usize {
-    let Some(max_recommended) = configured_max_working_set_bytes() else {
+    heuristic_paged_kv_target_bytes_with_max(
+        metadata,
+        size_class,
+        is_moe,
+        configured_max_working_set_bytes(),
+    )
+}
+
+fn heuristic_paged_kv_target_bytes_with_max(
+    metadata: &ModelMetadata,
+    size_class: ModelSizeClass,
+    is_moe: bool,
+    max_working_set_bytes: Option<usize>,
+) -> usize {
+    let Some(max_recommended) = max_working_set_bytes else {
         return DEFAULT_PAGED_KV_TARGET_BYTES;
     };
 
@@ -426,7 +440,7 @@ fn heuristic_paged_kv_target_bytes(
         });
 
     if available == 0 {
-        return DEFAULT_PAGED_KV_TARGET_BYTES;
+        return DEFAULT_PAGED_KV_TARGET_BYTES.min(max_recommended);
     }
 
     let divisor = if is_moe {
@@ -440,7 +454,7 @@ fn heuristic_paged_kv_target_bytes(
         }
     };
 
-    clamp_paged_kv_target_bytes(available / divisor)
+    clamp_paged_kv_target_bytes(available / divisor).min(max_recommended)
 }
 
 fn configured_max_working_set_bytes() -> Option<usize> {
@@ -543,9 +557,9 @@ fn model_weight_bytes(model_dir: &Path) -> Option<u64> {
 mod tests {
     use super::{
         MlxRuntimeTuning, ModelMetadata, ModelSizeClass, RequestedMlxProfile, ResolvedMlxProfile,
-        default_mtp_draft_n_max, model_weight_bytes, parse_enabled_flag, parse_mtp_draft_n_max,
-        parse_positive_chunked_prefill_value, resolve_effective_mlx_profile,
-        resolve_profile_from_metadata, resolve_runtime_tuning,
+        default_mtp_draft_n_max, heuristic_paged_kv_target_bytes_with_max, model_weight_bytes,
+        parse_enabled_flag, parse_mtp_draft_n_max, parse_positive_chunked_prefill_value,
+        resolve_effective_mlx_profile, resolve_profile_from_metadata, resolve_runtime_tuning,
     };
     use std::fs;
     use tempfile::TempDir;
@@ -725,6 +739,23 @@ mod tests {
         assert_eq!(parse_enabled_flag(Some("maybe")), None);
         assert_eq!(parse_enabled_flag(Some("3")), None);
         assert_eq!(parse_enabled_flag(None), None);
+    }
+
+    #[test]
+    fn test_paged_kv_target_respects_configured_working_set_cap() {
+        let metadata = ModelMetadata {
+            weight_bytes: Some(134_217_728),
+            ..ModelMetadata::default()
+        };
+
+        let target = heuristic_paged_kv_target_bytes_with_max(
+            &metadata,
+            ModelSizeClass::Small,
+            false,
+            Some(134_217_728),
+        );
+
+        assert_eq!(target, 134_217_728);
     }
 
     #[test]

--- a/crates/higgs-engine/src/mtp.rs
+++ b/crates/higgs-engine/src/mtp.rs
@@ -35,15 +35,21 @@ pub struct MtpStats {
 }
 
 impl MtpStats {
-    pub fn record_cycle(&mut self, drafted_count: usize, emitted_count: usize) {
+    pub fn record_cycle(
+        &mut self,
+        drafted_count: usize,
+        emitted_count: usize,
+        accepted_drafts_count: usize,
+    ) {
         let drafted = u32::try_from(drafted_count).unwrap_or(u32::MAX);
         let emitted = u32::try_from(emitted_count).unwrap_or(u32::MAX);
+        let accepted_drafts = u32::try_from(accepted_drafts_count)
+            .unwrap_or(u32::MAX)
+            .min(drafted);
         self.cycles = self.cycles.saturating_add(1);
         self.drafted = self.drafted.saturating_add(drafted);
         self.emitted = self.emitted.saturating_add(emitted);
-        self.accepted_drafts = self
-            .accepted_drafts
-            .saturating_add(emitted.saturating_sub(1).min(drafted));
+        self.accepted_drafts = self.accepted_drafts.saturating_add(accepted_drafts);
     }
 
     pub const fn cycles(&self) -> u32 {
@@ -68,6 +74,48 @@ impl MtpStats {
             0.0
         } else {
             f64::from(self.accepted_drafts) * 100.0 / f64::from(self.drafted)
+        }
+    }
+}
+
+/// Small adaptive controller for choosing the next MTP draft depth.
+#[derive(Debug, Clone)]
+pub struct AdaptiveDraftDepth {
+    current: usize,
+    min: usize,
+    max: usize,
+}
+
+impl AdaptiveDraftDepth {
+    #[must_use]
+    pub fn new(initial: usize, max_depth: usize) -> Self {
+        let capped_max = max_depth.max(1);
+        Self {
+            current: initial.clamp(1, capped_max),
+            min: 1,
+            max: capped_max,
+        }
+    }
+
+    #[must_use]
+    pub const fn current(&self) -> usize {
+        self.current
+    }
+
+    pub const fn observe(&mut self, accepted_drafts: usize, drafted: usize) {
+        if drafted == 0 {
+            self.current = self.min;
+            return;
+        }
+
+        if accepted_drafts == drafted && self.current < self.max {
+            self.current += 1;
+        } else if accepted_drafts.saturating_mul(4) <= drafted && self.current > self.min {
+            self.current -= 1;
+        } else if accepted_drafts.saturating_mul(4) >= drafted.saturating_mul(3)
+            && self.current < self.max
+        {
+            self.current += 1;
         }
     }
 }
@@ -114,6 +162,92 @@ pub struct PromptLookupCycleResult {
     pub drafted: usize,
     /// Number of prompt-lookup draft tokens accepted this cycle.
     pub accepted_drafts: usize,
+}
+
+/// Run one prompt-lookup draft inside an MTP decode loop.
+///
+/// This verifies copied prompt/history tokens with the backbone and mirrors the
+/// accepted verifier span into the MTP cache, so the next cycle can continue
+/// with either prompt lookup or the model's MTP head.
+pub fn mtp_prompt_lookup_cycle(
+    model: &mut AnyModel,
+    cache: &mut AnyCache,
+    mtp_cache: &mut MtpCache,
+    previous_hidden: &Array,
+    history_before_confirmed: &[u32],
+    confirmed_token_id: u32,
+    config: PromptLookupConfig,
+) -> Result<Option<MtpCycleResult>, EngineError> {
+    let mut lookup_context = Vec::with_capacity(history_before_confirmed.len().saturating_add(1));
+    lookup_context.extend_from_slice(history_before_confirmed);
+    lookup_context.push(confirmed_token_id);
+    let drafts = prompt_lookup_draft(
+        &lookup_context,
+        config.max_drafts,
+        config.max_ngram,
+        config.max_window,
+    );
+    if drafts.is_empty() {
+        return Ok(None);
+    }
+
+    let base_cache = cache.clone();
+    let base_mtp_cache = mtp_cache.clone();
+    let mut verify_tokens = Vec::with_capacity(drafts.len().saturating_add(1));
+    verify_tokens.push(confirmed_token_id);
+    verify_tokens.extend(drafts.iter().copied());
+
+    let (verify_hidden, verifier_targets) = backbone_verify_batch(model, cache, &verify_tokens)?;
+    let verify_hidden_for_mtp = verify_hidden.clone();
+    if verifier_targets.len() < verify_tokens.len() {
+        return Err(EngineError::Generation(format!(
+            "hybrid prompt-lookup verifier returned {} target ids for {} input tokens",
+            verifier_targets.len(),
+            verify_tokens.len()
+        )));
+    }
+
+    let accepted_drafts = accepted_draft_prefix_len(&drafts, &verifier_targets);
+    let tokens = emitted_tokens(confirmed_token_id, &drafts, accepted_drafts);
+
+    let (accepted_hidden_rows, next_token_id) = if accepted_drafts == drafts.len() {
+        let next = *verifier_targets.get(accepted_drafts).ok_or_else(|| {
+            EngineError::Generation(format!(
+                "hybrid prompt-lookup verifier missing target at accepted index {accepted_drafts}"
+            ))
+        })?;
+        (verify_hidden, next)
+    } else {
+        *cache = base_cache;
+        let (replay_hidden, replay_targets) = backbone_verify_batch(model, cache, &tokens)?;
+        let next = *replay_targets.get(accepted_drafts).ok_or_else(|| {
+            EngineError::Generation(format!(
+                "hybrid prompt-lookup replay returned {} target ids for accepted index {}",
+                replay_targets.len(),
+                accepted_drafts
+            ))
+        })?;
+        (replay_hidden, next)
+    };
+
+    let h_last = hidden_row(&accepted_hidden_rows, accepted_drafts)?;
+    mirror_verified_mtp_cache(
+        model,
+        mtp_cache,
+        base_mtp_cache,
+        previous_hidden,
+        &verify_hidden_for_mtp,
+        &verify_tokens,
+        tokens.len(),
+    )?;
+
+    Ok(Some(MtpCycleResult {
+        tokens,
+        hidden: h_last,
+        next_token_id,
+        drafted: drafts.len(),
+        accepted_drafts,
+    }))
 }
 
 fn greedy_token_id(logits: &Array) -> Result<u32, EngineError> {
@@ -580,11 +714,10 @@ pub fn mtp_cycle(
         )?;
     }
 
-    if accepted_drafts < drafts.len() && tokens.is_empty() {
-        return Err(EngineError::Generation(
-            "MTP accepted no committed tokens".to_owned(),
-        ));
-    }
+    debug_assert!(
+        !tokens.is_empty(),
+        "MTP must always emit the confirmed token"
+    );
 
     Ok(MtpCycleResult {
         tokens,
@@ -598,8 +731,8 @@ pub fn mtp_cycle(
 #[cfg(test)]
 mod tests {
     use super::{
-        MtpStats, accepted_draft_prefix_len, draft_matches_target, emitted_tokens,
-        prompt_lookup_draft,
+        AdaptiveDraftDepth, MtpStats, accepted_draft_prefix_len, draft_matches_target,
+        emitted_tokens, prompt_lookup_draft,
     };
 
     #[test]
@@ -613,16 +746,30 @@ mod tests {
     }
 
     #[test]
-    fn mtp_stats_tracks_drafted_and_bonus_acceptance_rate() {
+    fn mtp_stats_tracks_explicit_accepted_draft_count() {
         let mut stats = MtpStats::default();
-        stats.record_cycle(3, 4);
-        stats.record_cycle(2, 1);
+        stats.record_cycle(3, 2, 2);
+        stats.record_cycle(2, 1, 0);
 
         assert_eq!(stats.cycles(), 2);
         assert_eq!(stats.drafted(), 5);
-        assert_eq!(stats.emitted(), 5);
-        assert_eq!(stats.accepted_drafts(), 3);
-        assert!((stats.acceptance_rate_percent() - 60.0).abs() < f64::EPSILON);
+        assert_eq!(stats.emitted(), 3);
+        assert_eq!(stats.accepted_drafts(), 2);
+        assert!((stats.acceptance_rate_percent() - 40.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn adaptive_draft_depth_grows_on_full_acceptance_and_backs_off_on_rejection() {
+        let mut depth = AdaptiveDraftDepth::new(2, 4);
+
+        depth.observe(2, 2);
+        assert_eq!(depth.current(), 3);
+
+        depth.observe(3, 3);
+        assert_eq!(depth.current(), 4);
+
+        depth.observe(0, 4);
+        assert_eq!(depth.current(), 3);
     }
 
     #[test]

--- a/crates/higgs-engine/src/simple.rs
+++ b/crates/higgs-engine/src/simple.rs
@@ -69,6 +69,18 @@ fn unchecked_prompt_lookup_enabled() -> bool {
     .unwrap_or(false)
 }
 
+fn mtp_adaptive_draft_enabled() -> bool {
+    parse_enabled_flag(std::env::var("HIGGS_MTP_ADAPTIVE_DRAFT").ok().as_deref()).unwrap_or(false)
+}
+
+fn mtp_prompt_lookup_enabled() -> bool {
+    parse_enabled_flag(std::env::var("HIGGS_MTP_PROMPT_LOOKUP").ok().as_deref()).unwrap_or(false)
+}
+
+fn adaptive_draft_depth_for_cap(configured_max: usize) -> crate::mtp::AdaptiveDraftDepth {
+    crate::mtp::AdaptiveDraftDepth::new(configured_max, configured_max)
+}
+
 fn mtp_prefill_priming_enabled() -> bool {
     parse_enabled_flag(std::env::var("HIGGS_MTP_PRIME_PREFILL").ok().as_deref()).unwrap_or(true)
 }
@@ -1450,7 +1462,7 @@ impl SimpleEngine {
             } else {
                 crate::mtp::prompt_lookup_cycle(model, cache, tokens, confirmed_token_id, config)?
             };
-            stats.record_cycle(result.drafted, result.tokens.len());
+            stats.record_cycle(result.drafted, result.tokens.len(), result.accepted_drafts);
 
             for &tok in &result.tokens {
                 if let Some(close_id) = think_close_token {
@@ -1613,6 +1625,10 @@ impl SimpleEngine {
         let mut current_hidden = h;
         let mut confirmed_token_id: u32 = next_arr.item();
         let mut mtp_stats = crate::mtp::MtpStats::default();
+        let mut adaptive_depth = mtp_adaptive_draft_enabled()
+            .then(|| adaptive_draft_depth_for_cap(self.tuning.mtp_draft_n_max()));
+        let hybrid_prompt_lookup = mtp_prompt_lookup_enabled();
+        let hybrid_prompt_lookup_config = prompt_lookup_config();
         let t_start = std::time::Instant::now();
 
         // Thinking budget: force </think> after N tokens if model hasn't closed it.
@@ -1628,16 +1644,60 @@ impl SimpleEngine {
             think_close_token.is_some_and(|close_id| first_token_id == close_id);
 
         loop {
-            let result = crate::mtp::mtp_cycle(
-                model,
-                cache,
-                &mut mtp_cache,
-                &current_hidden,
-                confirmed_token_id,
-                self.tuning.mtp_draft_n_max(),
-            )?;
+            let cycle_completion_len = Self::completion_len(tokens)?;
+            let remaining = usize::try_from(max_tokens.saturating_sub(cycle_completion_len))
+                .map_err(|_| EngineError::Generation("max_tokens overflow".to_owned()))?;
+            let draft_depth = adaptive_depth
+                .as_ref()
+                .map_or_else(
+                    || self.tuning.mtp_draft_n_max(),
+                    crate::mtp::AdaptiveDraftDepth::current,
+                )
+                .min(remaining.saturating_sub(1).max(1));
+            let prompt_config = crate::mtp::PromptLookupConfig {
+                max_drafts: hybrid_prompt_lookup_config
+                    .max_drafts
+                    .min(remaining.saturating_sub(1)),
+                ..hybrid_prompt_lookup_config
+            };
+            let result = if hybrid_prompt_lookup && prompt_config.max_drafts > 0 {
+                crate::mtp::mtp_prompt_lookup_cycle(
+                    model,
+                    cache,
+                    &mut mtp_cache,
+                    &current_hidden,
+                    tokens,
+                    confirmed_token_id,
+                    prompt_config,
+                )?
+                .map_or_else(
+                    || {
+                        crate::mtp::mtp_cycle(
+                            model,
+                            cache,
+                            &mut mtp_cache,
+                            &current_hidden,
+                            confirmed_token_id,
+                            draft_depth,
+                        )
+                    },
+                    Ok,
+                )?
+            } else {
+                crate::mtp::mtp_cycle(
+                    model,
+                    cache,
+                    &mut mtp_cache,
+                    &current_hidden,
+                    confirmed_token_id,
+                    draft_depth,
+                )?
+            };
 
-            mtp_stats.record_cycle(result.drafted, result.tokens.len());
+            mtp_stats.record_cycle(result.drafted, result.tokens.len(), result.accepted_drafts);
+            if let Some(depth) = &mut adaptive_depth {
+                depth.observe(result.accepted_drafts, result.drafted);
+            }
 
             for &tok in &result.tokens {
                 // Thinking budget enforcement
@@ -1804,6 +1864,10 @@ impl SimpleEngine {
         let mut current_hidden = h;
         let mut confirmed_token_id: u32 = next_arr.item();
         let mut mtp_stats = crate::mtp::MtpStats::default();
+        let mut adaptive_depth = mtp_adaptive_draft_enabled()
+            .then(|| adaptive_draft_depth_for_cap(self.tuning.mtp_draft_n_max()));
+        let hybrid_prompt_lookup = mtp_prompt_lookup_enabled();
+        let hybrid_prompt_lookup_config = prompt_lookup_config();
         let t_start = std::time::Instant::now();
 
         const THINKING_BUDGET: u32 = 256;
@@ -1817,16 +1881,60 @@ impl SimpleEngine {
             think_close_token.is_some_and(|close_id| first_token_id == close_id);
 
         loop {
-            let result = crate::mtp::mtp_cycle(
-                model,
-                cache,
-                &mut mtp_cache,
-                &current_hidden,
-                confirmed_token_id,
-                self.tuning.mtp_draft_n_max(),
-            )?;
+            let cycle_completion_len = Self::completion_len(tokens)?;
+            let remaining = usize::try_from(max_tokens.saturating_sub(cycle_completion_len))
+                .map_err(|_| EngineError::Generation("max_tokens overflow".to_owned()))?;
+            let draft_depth = adaptive_depth
+                .as_ref()
+                .map_or_else(
+                    || self.tuning.mtp_draft_n_max(),
+                    crate::mtp::AdaptiveDraftDepth::current,
+                )
+                .min(remaining.saturating_sub(1).max(1));
+            let prompt_config = crate::mtp::PromptLookupConfig {
+                max_drafts: hybrid_prompt_lookup_config
+                    .max_drafts
+                    .min(remaining.saturating_sub(1)),
+                ..hybrid_prompt_lookup_config
+            };
+            let result = if hybrid_prompt_lookup && prompt_config.max_drafts > 0 {
+                crate::mtp::mtp_prompt_lookup_cycle(
+                    model,
+                    cache,
+                    &mut mtp_cache,
+                    &current_hidden,
+                    tokens,
+                    confirmed_token_id,
+                    prompt_config,
+                )?
+                .map_or_else(
+                    || {
+                        crate::mtp::mtp_cycle(
+                            model,
+                            cache,
+                            &mut mtp_cache,
+                            &current_hidden,
+                            confirmed_token_id,
+                            draft_depth,
+                        )
+                    },
+                    Ok,
+                )?
+            } else {
+                crate::mtp::mtp_cycle(
+                    model,
+                    cache,
+                    &mut mtp_cache,
+                    &current_hidden,
+                    confirmed_token_id,
+                    draft_depth,
+                )?
+            };
 
-            mtp_stats.record_cycle(result.drafted, result.tokens.len());
+            mtp_stats.record_cycle(result.drafted, result.tokens.len(), result.accepted_drafts);
+            if let Some(depth) = &mut adaptive_depth {
+                depth.observe(result.accepted_drafts, result.drafted);
+            }
 
             for &tok in &result.tokens {
                 // Thinking budget enforcement
@@ -2479,7 +2587,8 @@ fn detect_thinking_support(model_dir: &Path) -> bool {
 #[allow(clippy::panic, clippy::unwrap_used)]
 mod tests {
     use super::{
-        check_stop_sequences, derive_model_name, estimate_paged_kv_blocks, parse_enabled_flag,
+        adaptive_draft_depth_for_cap, check_stop_sequences, derive_model_name,
+        estimate_paged_kv_blocks, parse_enabled_flag,
     };
     use std::path::Path;
 
@@ -2514,6 +2623,15 @@ mod tests {
     fn test_derive_model_name_relative_path() {
         let name = derive_model_name(Path::new("./my-model"));
         assert_eq!(name, "my-model");
+    }
+
+    #[test]
+    fn adaptive_draft_depth_respects_configured_cap() {
+        let mut depth = adaptive_draft_depth_for_cap(1);
+
+        depth.observe(1, 1);
+
+        assert_eq!(depth.current(), 1);
     }
 
     /// Create a temp dir, write config.json with the given content, and return

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -66,21 +66,32 @@ experiments. `HIGGS_MTP_MIRROR_VERIFY=1` enables full verifier-window MTP cache
 mirroring; on the Qwen3.6 27B MTP 8-bit benchmark below it was slightly slower
 than the default accepted-prefix replay path, so it remains opt-in.
 
+`HIGGS_MTP_ADAPTIVE_DRAFT=1` enables a lightweight controller that grows the
+draft window after high verifier acceptance and backs off after rejections.
+`HIGGS_MTP_PROMPT_LOOKUP=1` enables a hybrid path that verifies repeated
+prompt/history spans inside the MTP loop and mirrors accepted verifier rows into
+the MTP cache, so it can fall back to normal MTP-head cycles on models without
+useful repeated spans.
+
 Measured on M4 Max 128GB, `temperature=0`, 96 completion tokens, prompt:
 `Write a concise technical explanation of speculative decoding for local LLM inference...`
 
 | Runtime | Mode | Request tok/s | Decode-only tok/s | Speedup vs runtime baseline |
 | --- | ---: | ---: | ---: | ---: |
-| Higgs | baseline MTP off | 14.32 | n/a | 1.00x |
-| Higgs | MTP draft depth 2 | 22.89 | 28.0 | 1.60x request / 1.96x vs request baseline |
-| llama.cpp `b1-d374e71` | baseline | n/a | 15.9 | 1.00x |
-| llama.cpp `b1-d374e71` | MTP draft depth 1 | n/a | 25.0 | 1.57x |
-| llama.cpp `b1-d374e71` | MTP draft depth 2 | n/a | 24.3 | 1.53x |
+| Higgs | baseline MTP off | 14.14 | n/a | 1.00x |
+| Higgs | MTP default | 22.75 | n/a | 1.61x request |
+| Higgs | MTP adaptive | 22.11 | n/a | 1.56x request |
+| Higgs | MTP hybrid prompt lookup + adaptive | 18.45 | n/a | 1.30x request |
+| Higgs | MTP draft depth 2 | 22.79 | n/a | 1.61x request |
+| llama.cpp `b9410-031ddb2e0` | baseline | 14.62 | 15.64 | 1.00x |
+| llama.cpp `b9410-031ddb2e0` | `draft-mtp`, depth 2 | 21.63 | 24.16 | 1.48x request / 1.55x decode |
 
-The Higgs request-level number includes HTTP and prompt processing; llama.cpp's
-CLI line reports generation only. The closest decode-only comparison from this
-run is Higgs MTP depth 2 at `28.0 tok/s` versus llama.cpp's best measured MTP
-setting at `25.0 tok/s`.
+The Higgs numbers are from `bench_speculative`, which starts a fresh server per
+mode and reports end-to-end request tok/s. The llama.cpp rows use the
+OpenAI-compatible server with Qwen thinking disabled via
+`chat_template_kwargs.enable_thinking=false`, prompt cache disabled, and
+`draft-mtp` depth 2. On this run, Higgs MTP draft depth 2 was `1.05x` faster
+than llama.cpp `draft-mtp` depth 2 at the request level.
 
 ## Iterations
 
@@ -201,12 +212,13 @@ not time-to-visible-answer for thinking-mode models.
 ### `bench_speculative`
 
 Starts a fresh Higgs server per speculative mode and compares baseline greedy
-decode with MTP draft depths and architecture-neutral prompt lookup.
+decode with MTP draft depths, adaptive MTP, hybrid prompt-lookup+MTP, and
+architecture-neutral prompt lookup.
 
 ```bash
 cargo run --release -p higgs-bench --bin bench_speculative -- \
   --model qwen3.6-27B-mtp-8bit \
-  --trials baseline,mtp_default,1,2,3,prompt_lookup,prompt_lookup_unchecked \
+  --trials baseline,mtp_default,mtp_adaptive,mtp_hybrid,1,2,3,prompt_lookup,prompt_lookup_unchecked \
   --max-tokens 96 --repeats 3 --format markdown
 ```
 
@@ -214,6 +226,10 @@ cargo run --release -p higgs-bench --bin bench_speculative -- \
 tokens/sec when a `baseline` trial appears before the speculative trial. Server
 logs are captured under `target/bench-results/bench_speculative/logs/`, and the
 JSON result stores only filtered speculative telemetry lines.
+
+The `mtp_hybrid` trial intentionally combines MTP heads, adaptive draft depth,
+and MTP-local prompt lookup. Use `prompt_lookup` for architecture-neutral prompt
+lookup without MTP heads.
 
 ### `bench_summarize`
 
@@ -233,7 +249,7 @@ cargo run --release -p higgs-bench --bin bench_summarize
 3. Look up the model with `higgs_bench::models::find_by_key(...)` and
    set `metadata.model`.
 4. Define `Params` and `Results` structs (must implement `Serialize`).
-5. Build `BenchOutput { metadata, params, results }` and call
+5. Build `BenchOutput { schema_version: higgs_bench::BENCH_SCHEMA_VERSION, metadata, params, results }` and call
    `higgs_bench::persist_result(&output)` plus
    `higgs_bench::format_json` / `format_markdown` based on
    `--format`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,7 +38,9 @@ This document collects the full CLI, environment, and config-file reference for 
 - `HIGGS_CHUNKED_PREFILL_THRESHOLD` enables chunked prefill above a token threshold.
 - `HIGGS_CHUNKED_PREFILL_CHUNK_SIZE` controls chunk size during chunked prefill.
 - `HIGGS_MTP=0|1` overrides the tuning profile's speculative decode choice when conditions allow.
-- `HIGGS_MTP_DRAFT_N_MAX` controls the maximum MTP draft tokens per speculative cycle. The default is `3` when MTP is enabled, clamped to `1..=8`.
+- `HIGGS_MTP_DRAFT_N_MAX` controls the maximum MTP draft tokens per speculative cycle. The default is `2` for huge checkpoints and `1` otherwise, clamped to `1..=8`.
+- `HIGGS_MTP_ADAPTIVE_DRAFT=1` lets the decode loop increase or decrease the MTP draft window based on recent verifier acceptance.
+- `HIGGS_MTP_PROMPT_LOOKUP=1` enables a hybrid MTP loop that tries verified prompt-lookup drafts when the prompt/history has a repeated suffix, then keeps the MTP cache synchronized for later MTP-head cycles.
 - `HIGGS_CLEAR_CACHE_AFTER_PREFILL` overrides the selected MLX profile behavior for cache clearing.
 - `HIGGS_TURBOQUANT_MIN_TOKENS` overrides the TurboQuant activation threshold. The default is `2048`.
 - `HIGGS_EXPERIMENTAL_PAGED_KV=1` enables the experimental paged-KV path.


### PR DESCRIPTION
## Summary
- add explicit accepted-draft telemetry so MTP and prompt-lookup stats no longer infer acceptance from emitted token count
- add opt-in adaptive MTP draft depth and hybrid prompt-lookup+MTP cache mirroring for repeated prompt/history spans
- add benchmark schema versioning plus benchmark trial aliases for mtp_adaptive and mtp_hybrid
- fix MLX paged-KV heuristic to honor a configured working-set cap and update MTP/benchmark docs
- add fresh llama.cpp server comparison using Qwen3.6 MTP Q8_0 GGUF
- address CodeRabbit follow-ups: mtp_hybrid is now documented/tested as prompt lookup plus adaptive MTP, and adaptive depth respects the configured MTP cap

## Qwen3.6 benchmark
Short release sweep, M4 Max 128GB, 96 max completion tokens, one repeat per mode:

| Runtime | Mode | tok/s | speedup vs runtime baseline |
| --- | --- | ---: | ---: |
| Higgs | baseline_mtp_off | 14.14 request | 1.00x |
| Higgs | mtp_default | 22.75 request | 1.61x |
| Higgs | mtp_adaptive | 22.11 request | 1.56x |
| Higgs | mtp_hybrid prompt lookup + adaptive | 18.45 request | 1.30x |
| Higgs | mtp_draft_2 | 22.79 request | 1.61x |
| llama.cpp b9410-031ddb2e0 | baseline | 14.62 request / 15.64 decode | 1.00x |
| llama.cpp b9410-031ddb2e0 | draft-mtp depth 2 | 21.63 request / 24.16 decode | 1.48x request / 1.55x decode |

Result: fixed Higgs depth 2 remains the best measured Higgs setting in this sweep. It was 1.05x faster than llama.cpp draft-mtp depth 2 at the request level. Adaptive and hybrid are included as opt-in experiment modes, not promoted as defaults.

## llama.cpp comparison notes
- installed llama.cpp b9410 with Homebrew
- downloaded ggml-org/Qwen3.6-27B-MTP-GGUF Q8_0
- used llama.cpp OpenAI-compatible server, Qwen thinking disabled via chat_template_kwargs.enable_thinking=false, prompt cache disabled, temperature 0, max_tokens 96

## Verification
- cargo fmt
- cargo fmt --check
- git diff --check
- cargo check --workspace --no-default-features
- cargo clippy --workspace --no-default-features --all-targets -- -D warnings
- cargo test -p higgs-engine adaptive_draft_depth_respects_configured_cap --no-default-features
- cargo test -p higgs-bench parse_trial_specs_sets_expected_env_overrides --no-default-features
- cargo test --workspace --no-default-features
- cargo build --release -p higgs -p higgs-bench --bins --no-default-features
- target/release/bench_speculative --model qwen3.6-27B-mtp-8bit --trials baseline,mtp_default,mtp_adaptive,mtp_hybrid,2 --max-tokens 96 --repeats 1 --format markdown --startup-timeout-secs 300 --request-timeout-secs 600
- llama.cpp server baseline and draft-mtp depth 2 requests against Qwen3.6 MTP Q8_0 GGUF

Note: the first local full-suite run inside the sandbox failed only on two doctor port-binding tests with Operation not permitted. The rerun outside the sandbox passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added schema versioning to benchmark outputs for improved tracking.
  * Introduced adaptive draft-depth control for speculative decoding with new `HIGGS_MTP_ADAPTIVE_DRAFT` environment variable.
  * Added hybrid prompt-lookup MTP mode with `HIGGS_MTP_PROMPT_LOOKUP` environment variable.
  * New speculative trial modes: `mtp_adaptive` and `mtp_hybrid`.

* **Documentation**
  * Updated benchmarking and configuration guides with new MTP options, trial modes, and adjusted defaults for `HIGGS_MTP_DRAFT_N_MAX`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/panbanda/higgs/pull/166?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->