### PR TITLE
feat: enable MiniCPM5-1B (explicit head_dim + special-token decode + tojson kwarg + tool parser)

### DIFF
--- a/crates/higgs-engine/src/batch_engine.rs
+++ b/crates/higgs-engine/src/batch_engine.rs
@@ -733,7 +733,13 @@ fn prefill_request(
 
         // Decode the first token incrementally (routes through IncrementalDetok
         // so partial UTF-8 is held back and prefix-before-stop is correctly emitted).
-        let mut detok = IncrementalDetok::new(String::new(), 0);
+        // Preserve content-bearing special tokens (e.g. MiniCPM tool-call markup)
+        // while stripping control tokens, matching SimpleEngine's decode path.
+        let skip_ids = std::sync::Arc::new(crate::simple::content_preserving_skip_ids(
+            tokenizer,
+            eos_token_ids,
+        ));
+        let mut detok = IncrementalDetok::new(String::new(), 0, skip_ids);
         let first_chunk = detok
             .append(tokenizer, &[first_token_id])
             .unwrap_or_default();
@@ -968,7 +974,11 @@ mod tests {
             constraint: None,
             response_tx: tx,
             prompt_len: 5,
-            detok: IncrementalDetok::new(String::new(), 0),
+            detok: IncrementalDetok::new(
+                String::new(),
+                0,
+                std::sync::Arc::new(std::collections::HashSet::new()),
+            ),
         };
         (ar, rx)
     }

--- a/crates/higgs-engine/src/chat_template.rs
+++ b/crates/higgs-engine/src/chat_template.rs
@@ -354,9 +354,9 @@ mod tests {
         assert_eq!(result, r#""hello""#);
     }
 
-    /// HF templates (e.g. MiniCPM5 at `chat:6`) call `tojson(ensure_ascii=…)`.
+    /// HF templates (e.g. `MiniCPM5` at `chat:6`) call `tojson(ensure_ascii=…)`.
     /// The filter must accept the kwarg instead of failing with "too many
-    /// arguments"; the value is ignored since serde_json emits UTF-8.
+    /// arguments"; the value is ignored since `serde_json` emits UTF-8.
     #[test]
     fn test_tojson_filter_accepts_ensure_ascii_kwarg() {
         let env = tojson_env(r"{{ value | tojson(ensure_ascii=false) }}");

--- a/crates/higgs-engine/src/chat_template.rs
+++ b/crates/higgs-engine/src/chat_template.rs
@@ -1,3 +1,4 @@
+use minijinja::value::Kwargs;
 use minijinja::{Environment, Value};
 use serde::Serialize;
 
@@ -275,8 +276,12 @@ fn normalize_arguments_value(args: &mut serde_json::Value) {
     *args = serde_json::Value::Object(serde_json::Map::new());
 }
 
+/// `tojson` filter. `_kwargs` absorbs keyword arguments HF chat templates pass
+/// — notably `tojson(ensure_ascii=false)` (e.g. `MiniCPM5`). `serde_json` already
+/// emits UTF-8, which matches `ensure_ascii=false`, so the kwarg is accepted and
+/// ignored rather than failing the render with "too many arguments".
 #[allow(clippy::needless_pass_by_value)]
-fn tojson_filter(value: Value) -> Result<String, minijinja::Error> {
+fn tojson_filter(value: Value, _kwargs: Kwargs) -> Result<String, minijinja::Error> {
     let serialized = serde_json::to_string(&value).map_err(|e| {
         minijinja::Error::new(
             minijinja::ErrorKind::InvalidOperation,
@@ -347,6 +352,20 @@ mod tests {
             .render(minijinja::context! { value => "hello" })
             .unwrap();
         assert_eq!(result, r#""hello""#);
+    }
+
+    /// HF templates (e.g. MiniCPM5 at `chat:6`) call `tojson(ensure_ascii=…)`.
+    /// The filter must accept the kwarg instead of failing with "too many
+    /// arguments"; the value is ignored since serde_json emits UTF-8.
+    #[test]
+    fn test_tojson_filter_accepts_ensure_ascii_kwarg() {
+        let env = tojson_env(r"{{ value | tojson(ensure_ascii=false) }}");
+        let tmpl = env.get_template("test").unwrap();
+        let result = tmpl
+            .render(minijinja::context! { value => "café" })
+            .unwrap();
+        // UTF-8 preserved (not \u-escaped), and the call did not error.
+        assert_eq!(result, "\"café\"");
     }
 
     #[test]

--- a/crates/higgs-engine/src/simple.rs
+++ b/crates/higgs-engine/src/simple.rs
@@ -245,6 +245,10 @@ pub struct SimpleEngine {
     template: Option<ChatTemplateRenderer>,
     model_name: String,
     eos_token_ids: Vec<u32>,
+    /// Control tokens stripped from decoded output (EOS + `<|…|>` chat
+    /// delimiters + classic sentinels), while content-bearing special tokens
+    /// (tool-call markup, `<think>`) are preserved. See [`Self::decode_tokens`].
+    decode_skip_ids: std::collections::HashSet<u32>,
     /// Whether to enable thinking mode (Qwen3.5 `<think>` tags).
     enable_thinking: bool,
     /// Token ID for `</think>`, resolved from the tokenizer at load time.
@@ -292,6 +296,25 @@ impl SimpleEngine {
         }
 
         let eos_token_ids = extract_eos_tokens(model_dir);
+
+        // Control tokens that must never surface in decoded text. `decode_tokens`
+        // keeps content-bearing special tokens (so tool-call markup like
+        // MiniCPM's `<function>`/`<param>` reaches the parser) but strips these:
+        // the EOS set, the `<|…|>` chat-control delimiters, and classic
+        // sentinels. Content tokens like `<think>`, `<tool_call>`, `<function>`
+        // do not match and are preserved.
+        let decode_skip_ids: std::collections::HashSet<u32> = {
+            let mut ids: std::collections::HashSet<u32> = eos_token_ids.iter().copied().collect();
+            for (id, added) in tokenizer.get_added_tokens_decoder() {
+                let content = added.content.as_str();
+                let is_control = (content.starts_with("<|") && content.ends_with("|>"))
+                    || matches!(content, "<s>" | "</s>" | "<pad>" | "<unk>" | "<mask>");
+                if is_control {
+                    ids.insert(id);
+                }
+            }
+            ids
+        };
 
         // Auto-detect thinking mode: Qwen3.5 models support <think> tags.
         // Override with HIGGS_ENABLE_THINKING=0/1, off/true, yes/no etc.
@@ -432,6 +455,7 @@ impl SimpleEngine {
             template,
             model_name,
             eos_token_ids,
+            decode_skip_ids,
             enable_thinking,
             think_close_token,
             gen_prompt_suffix_len,
@@ -759,10 +783,30 @@ impl SimpleEngine {
     }
 
     /// Decode the token buffer and return the text, mapping tokenizer errors.
+    ///
+    /// Decodes WITHOUT skipping special tokens so content-bearing markup
+    /// survives — notably models (e.g. `MiniCPM5`) that encode their tool-call
+    /// structure (`<function>`, `<param>`, …) as special tokens, which the
+    /// tool parser needs to see. Control tokens (EOS) are filtered out first so
+    /// they never leak into visible text. Plain text contains no special
+    /// tokens and decodes identically either way, so normal responses are
+    /// unaffected.
     fn decode_tokens(&self, tokens: &[u32]) -> Result<String, EngineError> {
-        self.tokenizer
-            .decode(tokens, true)
-            .map_err(|e| EngineError::Tokenization(e.to_string()))
+        let decode = |ids: &[u32]| {
+            self.tokenizer
+                .decode(ids, false)
+                .map_err(|e| EngineError::Tokenization(e.to_string()))
+        };
+        // Fast path: no control token present, decode the slice as-is.
+        if !tokens.iter().any(|id| self.decode_skip_ids.contains(id)) {
+            return decode(tokens);
+        }
+        let filtered: Vec<u32> = tokens
+            .iter()
+            .copied()
+            .filter(|id| !self.decode_skip_ids.contains(id))
+            .collect();
+        decode(&filtered)
     }
 
     /// The model's hidden dimension (embedding output size).

--- a/crates/higgs-engine/src/simple.rs
+++ b/crates/higgs-engine/src/simple.rs
@@ -248,7 +248,9 @@ pub struct SimpleEngine {
     /// Control tokens stripped from decoded output (EOS + `<|…|>` chat
     /// delimiters + classic sentinels), while content-bearing special tokens
     /// (tool-call markup, `<think>`) are preserved. See [`Self::decode_tokens`].
-    decode_skip_ids: std::collections::HashSet<u32>,
+    /// Wrapped in `Arc` so each request's streaming [`IncrementalDetok`] shares
+    /// the same set and strips identically to `decode_tokens`.
+    decode_skip_ids: std::sync::Arc<std::collections::HashSet<u32>>,
     /// Whether to enable thinking mode (Qwen3.5 `<think>` tags).
     enable_thinking: bool,
     /// Token ID for `</think>`, resolved from the tokenizer at load time.
@@ -297,24 +299,12 @@ impl SimpleEngine {
 
         let eos_token_ids = extract_eos_tokens(model_dir);
 
-        // Control tokens that must never surface in decoded text. `decode_tokens`
-        // keeps content-bearing special tokens (so tool-call markup like
-        // MiniCPM's `<function>`/`<param>` reaches the parser) but strips these:
-        // the EOS set, the `<|…|>` chat-control delimiters, and classic
-        // sentinels. Content tokens like `<think>`, `<tool_call>`, `<function>`
-        // do not match and are preserved.
-        let decode_skip_ids: std::collections::HashSet<u32> = {
-            let mut ids: std::collections::HashSet<u32> = eos_token_ids.iter().copied().collect();
-            for (id, added) in tokenizer.get_added_tokens_decoder() {
-                let content = added.content.as_str();
-                let is_control = (content.starts_with("<|") && content.ends_with("|>"))
-                    || matches!(content, "<s>" | "</s>" | "<pad>" | "<unk>" | "<mask>");
-                if is_control {
-                    ids.insert(id);
-                }
-            }
-            ids
-        };
+        // Control tokens that must never surface in decoded text (EOS + the
+        // `<|…|>` chat-control delimiters + classic sentinels). Shared via `Arc`
+        // with each request's streaming `IncrementalDetok` so streaming strips
+        // identically to `decode_tokens`.
+        let decode_skip_ids =
+            std::sync::Arc::new(content_preserving_skip_ids(&tokenizer, &eos_token_ids));
 
         // Auto-detect thinking mode: Qwen3.5 models support <think> tags.
         // Override with HIGGS_ENABLE_THINKING=0/1, off/true, yes/no etc.
@@ -2303,7 +2293,11 @@ impl SimpleEngine {
         }
         all_tokens.push(first_token_id);
 
-        let mut detok = IncrementalDetok::new(String::new(), 0);
+        let mut detok = IncrementalDetok::new(
+            String::new(),
+            0,
+            std::sync::Arc::clone(&self.decode_skip_ids),
+        );
         let first_new_text = detok.append(&self.tokenizer, &all_tokens)?;
         let first_emitted_before = detok.text.len() - first_new_text.len();
         let (mut first_text, first_hit_stop) = if stop_sequences.is_empty() {
@@ -2563,6 +2557,31 @@ const MAX_DETOK_WINDOW: usize = 64;
 /// start at the same token, so tokenizer boundary effects cancel out. Text
 /// ending in an incomplete UTF-8 sequence (trailing replacement char) is held
 /// back until a later token completes it.
+/// Token IDs that must never surface in decoded output text.
+///
+/// Seeded with the model's EOS ids, plus every added *control* special token:
+/// the `<|…|>` chat-control delimiters and the classic `<s>`/`</s>`/`<pad>`/
+/// `<unk>`/`<mask>` sentinels. Content-bearing special tokens (`<think>`,
+/// `<tool_call>`, `MiniCPM`'s `<function>`/`<param>`) deliberately do NOT match,
+/// so they survive decoding and reach the tool-call / reasoning parsers. Shared
+/// by the non-streaming decode path ([`SimpleEngine::decode_tokens`]) and the
+/// streaming detokenizer ([`IncrementalDetok`]) so the two strip identically.
+pub(crate) fn content_preserving_skip_ids(
+    tokenizer: &Tokenizer,
+    eos_token_ids: &[u32],
+) -> std::collections::HashSet<u32> {
+    let mut ids: std::collections::HashSet<u32> = eos_token_ids.iter().copied().collect();
+    for (id, added) in tokenizer.get_added_tokens_decoder() {
+        let content = added.content.as_str();
+        let is_control = (content.starts_with("<|") && content.ends_with("|>"))
+            || matches!(content, "<s>" | "</s>" | "<pad>" | "<unk>" | "<mask>");
+        if is_control {
+            ids.insert(id);
+        }
+    }
+    ids
+}
+
 pub(crate) struct IncrementalDetok {
     /// Start of the decode window; advanced whenever text is emitted.
     prefix_offset: usize,
@@ -2570,22 +2589,45 @@ pub(crate) struct IncrementalDetok {
     read_offset: usize,
     /// All text decoded so far (streamed to the client incrementally).
     pub(crate) text: String,
+    /// Control-token IDs filtered out before decoding so content-bearing
+    /// special tokens (tool-call markup) survive streaming. See
+    /// [`content_preserving_skip_ids`].
+    skip_ids: std::sync::Arc<std::collections::HashSet<u32>>,
 }
 
 impl IncrementalDetok {
     /// Start from text already decoded for the first `token_count` tokens.
-    pub(crate) const fn new(text: String, token_count: usize) -> Self {
+    pub(crate) const fn new(
+        text: String,
+        token_count: usize,
+        skip_ids: std::sync::Arc<std::collections::HashSet<u32>>,
+    ) -> Self {
         Self {
             prefix_offset: 0,
             read_offset: token_count,
             text,
+            skip_ids,
         }
     }
 
-    fn decode(tokenizer: &Tokenizer, tokens: &[u32]) -> Result<String, EngineError> {
-        tokenizer
-            .decode(tokens, true)
-            .map_err(|e| EngineError::Tokenization(e.to_string()))
+    /// Decode `tokens`, dropping only the control tokens in `skip_ids` while
+    /// preserving content-bearing special tokens. Mirrors
+    /// [`SimpleEngine::decode_tokens`] so streamed and non-streamed text match.
+    fn decode(&self, tokenizer: &Tokenizer, tokens: &[u32]) -> Result<String, EngineError> {
+        let run = |ids: &[u32]| {
+            tokenizer
+                .decode(ids, false)
+                .map_err(|e| EngineError::Tokenization(e.to_string()))
+        };
+        if !tokens.iter().any(|id| self.skip_ids.contains(id)) {
+            return run(tokens);
+        }
+        let filtered: Vec<u32> = tokens
+            .iter()
+            .copied()
+            .filter(|id| !self.skip_ids.contains(id))
+            .collect();
+        run(&filtered)
     }
 
     /// Decode the trailing window of `tokens`, appending newly stable text to
@@ -2599,8 +2641,8 @@ impl IncrementalDetok {
             .get(self.prefix_offset..self.read_offset)
             .unwrap_or_default();
         let window_tokens = tokens.get(self.prefix_offset..).unwrap_or_default();
-        let prefix_text = Self::decode(tokenizer, prefix_tokens)?;
-        let window_text = Self::decode(tokenizer, window_tokens)?;
+        let prefix_text = self.decode(tokenizer, prefix_tokens)?;
+        let window_text = self.decode(tokenizer, window_tokens)?;
 
         let over_window = window_tokens.len() > MAX_DETOK_WINDOW;
         if window_text.len() > prefix_text.len()
@@ -2639,8 +2681,8 @@ impl IncrementalDetok {
             .get(self.prefix_offset..self.read_offset)
             .unwrap_or_default();
         let window_tokens = tokens.get(self.prefix_offset..).unwrap_or_default();
-        let prefix_text = Self::decode(tokenizer, prefix_tokens)?;
-        let window_text = Self::decode(tokenizer, window_tokens)?;
+        let prefix_text = self.decode(tokenizer, prefix_tokens)?;
+        let window_text = self.decode(tokenizer, window_tokens)?;
         let new_text = window_text
             .get(prefix_text.len()..)
             .unwrap_or_default()
@@ -3327,12 +3369,51 @@ mod tests {
         Tokenizer::from_bytes(json.as_bytes()).unwrap()
     }
 
+    /// Empty skip-id set for detok tests that exercise plain (non-special)
+    /// tokens, where `skip_special_tokens` makes no difference.
+    fn no_skip() -> std::sync::Arc<std::collections::HashSet<u32>> {
+        std::sync::Arc::new(std::collections::HashSet::new())
+    }
+
+    /// `content_preserving_skip_ids` strips control tokens (chat delimiters,
+    /// sentinels, the explicit EOS list) but keeps content-bearing special
+    /// tokens so tool-call markup reaches the parser.
+    #[test]
+    fn skip_ids_strip_control_but_keep_content_special_tokens() {
+        let mut tok = Tokenizer::new(tokenizers::models::bpe::BPE::default());
+        let _ = tok.add_special_tokens([
+            tokenizers::AddedToken::from("<|im_end|>", true),
+            tokenizers::AddedToken::from("</s>", true),
+            tokenizers::AddedToken::from("<function>", true),
+            tokenizers::AddedToken::from("<tool_call>", true),
+        ]);
+        let im_end = tok.token_to_id("<|im_end|>").unwrap();
+        let skip = super::content_preserving_skip_ids(&tok, &[im_end, 7]);
+
+        // Stripped: <|…|> delimiter, the </s> sentinel, and the explicit eos id.
+        assert!(skip.contains(&im_end), "<|…|> delimiter is a control token");
+        assert!(
+            skip.contains(&tok.token_to_id("</s>").unwrap()),
+            "</s> sentinel stripped"
+        );
+        assert!(skip.contains(&7), "explicit eos id retained");
+        // Preserved: content-bearing tool-call markup the parser depends on.
+        assert!(
+            !skip.contains(&tok.token_to_id("<function>").unwrap()),
+            "<function> preserved for the tool-call parser"
+        );
+        assert!(
+            !skip.contains(&tok.token_to_id("<tool_call>").unwrap()),
+            "<tool_call> preserved"
+        );
+    }
+
     #[test]
     fn incremental_detok_emits_per_token_diffs() {
         let tokenizer = word_tokenizer();
         let mut tokens: Vec<u32> = vec![0];
         let first = tokenizer.decode(&tokens, true).unwrap();
-        let mut detok = IncrementalDetok::new(first.clone(), tokens.len());
+        let mut detok = IncrementalDetok::new(first.clone(), tokens.len(), no_skip());
 
         tokens.push(1);
         let second = detok.append(&tokenizer, &tokens).unwrap();
@@ -3349,7 +3430,7 @@ mod tests {
         let tokenizer = word_tokenizer();
         let mut tokens: Vec<u32> = vec![0];
         let first = tokenizer.decode(&tokens, true).unwrap();
-        let mut detok = IncrementalDetok::new(first, tokens.len());
+        let mut detok = IncrementalDetok::new(first, tokens.len(), no_skip());
 
         tokens.push(1);
         detok.append(&tokenizer, &tokens).unwrap();
@@ -3362,7 +3443,7 @@ mod tests {
     #[test]
     fn incremental_detok_first_token_partial_utf8_held_back() {
         let tokenizer = word_tokenizer();
-        let mut detok = IncrementalDetok::new(String::new(), 0);
+        let mut detok = IncrementalDetok::new(String::new(), 0, no_skip());
 
         // First partial piece: held back, no replacement char emitted
         let held = detok.append(&tokenizer, &[3]).unwrap();
@@ -3381,7 +3462,7 @@ mod tests {
     #[test]
     fn incremental_detok_flush_emits_pending() {
         let tokenizer = word_tokenizer();
-        let mut detok = IncrementalDetok::new(String::new(), 0);
+        let mut detok = IncrementalDetok::new(String::new(), 0, no_skip());
 
         // Partial piece held back
         let held = detok.append(&tokenizer, &[3]).unwrap();

--- a/crates/higgs-engine/src/simple.rs
+++ b/crates/higgs-engine/src/simple.rs
@@ -2978,7 +2978,7 @@ mod tests {
         assert!(detect_thinking_support(dir.path()));
     }
 
-    /// A plain Llama (no reasoning model_type, no `enable_thinking` in the
+    /// A plain Llama (no reasoning `model_type`, no `enable_thinking` in the
     /// template) must NOT be treated as a thinking model.
     #[test]
     fn no_thinking_for_plain_llama() {

--- a/crates/higgs-engine/src/simple.rs
+++ b/crates/higgs-engine/src/simple.rs
@@ -346,10 +346,7 @@ impl SimpleEngine {
             enable_thinking = false;
         }
         if enable_thinking {
-            tracing::info!(
-                think_close_token,
-                "Thinking mode enabled (Qwen3.5 model detected)"
-            );
+            tracing::info!(think_close_token, "Thinking mode enabled");
         }
 
         set_wired_limit_to_max(raise_wired_limit);
@@ -2826,18 +2823,31 @@ fn special_token_id(model_dir: &Path, content: &str) -> Option<u32> {
 }
 
 /// Detect whether a model supports thinking mode based on `model_type`.
+/// Whether the model *supports* a thinking toggle (capability, not default).
+///
+/// The per-request default — e.g. Qwen3.6 reasons off unless asked — is decided
+/// separately by `model_defaults_to_non_thinking` in the router; this only
+/// answers "can it think at all".
+///
+/// Signals, in order:
+/// 1. the chat template exposes an `enable_thinking` switch — the model
+///    author's own marker, which covers Qwen3.5/3.6, `MiniCPM5`, and future
+///    reasoning models without hardcoding model types; or
+/// 2. a known reasoning `model_type`.
+///
+/// The caller additionally requires a single-token `</think>`, so a stray
+/// mention can't enable thinking for a model that wasn't trained for it.
 fn detect_thinking_support(model_dir: &Path) -> bool {
-    let config_path = model_dir.join("config.json");
-    let config_str = match std::fs::read_to_string(&config_path) {
-        Ok(s) => s,
-        Err(_) => return false,
+    if chat_template_mentions_enable_thinking(model_dir) {
+        return true;
+    }
+    let Ok(config_str) = std::fs::read_to_string(model_dir.join("config.json")) else {
+        return false;
     };
-    let config: serde_json::Value = match serde_json::from_str(&config_str) {
-        Ok(v) => v,
-        Err(_) => return false,
+    let Ok(config) = serde_json::from_str::<serde_json::Value>(&config_str) else {
+        return false;
     };
-    // Qwen3.5 models (qwen3_5, qwen3_5_moe) support <think> tags.
-    // Check both top-level and nested text_config for VLM wrappers.
+    // Check both top-level and nested text_config (VLM wrappers).
     let model_type = config
         .get("model_type")
         .and_then(|v| v.as_str())
@@ -2850,13 +2860,42 @@ fn detect_thinking_support(model_dir: &Path) -> bool {
     matches!(model_type, Some("qwen3_5" | "qwen3_5_moe"))
 }
 
+/// Whether the model's chat template references the `enable_thinking` toggle,
+/// read from `chat_template.jinja` or `tokenizer_config.json`'s `chat_template`
+/// (a string, or a `{name, template}` array).
+fn chat_template_mentions_enable_thinking(model_dir: &Path) -> bool {
+    const MARKER: &str = "enable_thinking";
+    if let Ok(jinja) = std::fs::read_to_string(model_dir.join("chat_template.jinja")) {
+        return jinja.contains(MARKER);
+    }
+    let Ok(cfg_str) = std::fs::read_to_string(model_dir.join("tokenizer_config.json")) else {
+        return false;
+    };
+    let Ok(cfg) = serde_json::from_str::<serde_json::Value>(&cfg_str) else {
+        return false;
+    };
+    let template = cfg.get("chat_template");
+    if let Some(s) = template.and_then(|v| v.as_str()) {
+        return s.contains(MARKER);
+    }
+    if let Some(arr) = template.and_then(|v| v.as_array()) {
+        return arr.iter().any(|entry| {
+            entry
+                .get("template")
+                .and_then(|t| t.as_str())
+                .is_some_and(|t| t.contains(MARKER))
+        });
+    }
+    false
+}
+
 #[cfg(test)]
 #[allow(clippy::panic, clippy::unwrap_used)]
 mod tests {
     use super::{
         IncrementalDetok, Tokenizer, adaptive_draft_depth_for_cap, check_stop_sequences,
-        derive_model_name, estimate_paged_kv_blocks, extract_eos_tokens, find_stop_in_tail,
-        parse_enabled_flag,
+        derive_model_name, detect_thinking_support, estimate_paged_kv_blocks, extract_eos_tokens,
+        find_stop_in_tail, parse_enabled_flag,
     };
     use std::path::Path;
 
@@ -2913,6 +2952,44 @@ mod tests {
         .unwrap();
         let ids = extract_eos_tokens(dir.path());
         assert_eq!(ids, vec![2], "non-gemma must not add end_of_turn: {ids:?}");
+    }
+
+    // --- detect_thinking_support tests ---
+
+    /// MiniCPM5-style: a non-reasoning `model_type` (llama) but a chat template
+    /// that exposes the `enable_thinking` switch ⇒ thinking-capable.
+    #[test]
+    fn detect_thinking_from_template_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        write_config(dir.path(), r#"{"model_type": "llama"}"#);
+        std::fs::write(
+            dir.path().join("chat_template.jinja"),
+            "{%- if enable_thinking %}<think>\n{%- endif %}",
+        )
+        .unwrap();
+        assert!(detect_thinking_support(dir.path()));
+    }
+
+    /// Qwen3.5 reasoning `model_type` is detected even without a template file.
+    #[test]
+    fn detect_thinking_from_model_type() {
+        let dir = tempfile::tempdir().unwrap();
+        write_config(dir.path(), r#"{"model_type": "qwen3_5_moe"}"#);
+        assert!(detect_thinking_support(dir.path()));
+    }
+
+    /// A plain Llama (no reasoning model_type, no `enable_thinking` in the
+    /// template) must NOT be treated as a thinking model.
+    #[test]
+    fn no_thinking_for_plain_llama() {
+        let dir = tempfile::tempdir().unwrap();
+        write_config(dir.path(), r#"{"model_type": "llama"}"#);
+        std::fs::write(
+            dir.path().join("chat_template.jinja"),
+            "{%- for m in messages %}{{ m.content }}{%- endfor %}",
+        )
+        .unwrap();
+        assert!(!detect_thinking_support(dir.path()));
     }
 
     // --- derive_model_name tests ---

--- a/crates/higgs-engine/src/tool_parser.rs
+++ b/crates/higgs-engine/src/tool_parser.rs
@@ -409,17 +409,21 @@ fn extract_param_value(vr: &str) -> (&str, &str) {
 /// Returns `None` when no `name="…"` attribute is present so the caller can
 /// preserve the text verbatim.
 fn parse_minicpm_function(block: &str, schema: Option<&ToolSchema>) -> Option<ParsedToolCall> {
-    let name_attr = block.find(NAME_ATTR)?;
-    let after_attr = block.get(name_attr + NAME_ATTR.len()..)?;
+    // Read `name="…"` only from the opening `<function …>` tag (before its
+    // closing `>`). Scanning the whole block would let a malformed payload
+    // like `<function><param name="x">…` be parsed as a tool call named `x`
+    // instead of being preserved verbatim.
+    let tag_close = block.find('>')?;
+    let open_tag = block.get(..tag_close)?;
+    let name_attr = open_tag.find(NAME_ATTR)?;
+    let after_attr = open_tag.get(name_attr + NAME_ATTR.len()..)?;
     let name_end = after_attr.find('"')?;
     let name = after_attr.get(..name_end)?.to_owned();
     if name.is_empty() {
         return None;
     }
     // Params start after the `>` that closes the `<function …>` open tag.
-    let after_name = after_attr.get(name_end + 1..)?;
-    let tag_close = after_name.find('>')?;
-    let mut rest = after_name.get(tag_close + 1..).unwrap_or_default();
+    let mut rest = block.get(tag_close + 1..).unwrap_or_default();
 
     let mut map = serde_json::Map::new();
     while let Some(p_open) = rest.find(MINICPM_PARAM_OPEN) {
@@ -1480,6 +1484,17 @@ After last."#;
             result.tool_calls.first().unwrap().arguments,
             serde_json::json!({})
         );
+    }
+
+    /// A `<function>` opener with no `name="…"` attribute must NOT borrow the
+    /// `name` from a nested `<param>` — the block is preserved verbatim rather
+    /// than routed into the tool-execution path as a call named "city".
+    #[test]
+    fn minicpm_function_without_name_is_not_parsed() {
+        let input = "<function ><param name=\"city\">Paris</param></function>";
+        let result = parse_tool_calls(input, None);
+        assert!(result.tool_calls.is_empty());
+        assert!(result.text.contains("<param name=\"city\">"));
     }
 
     /// Streaming: the tracker reassembles a `MiniCPM` call split inside the

--- a/crates/higgs-engine/src/tool_parser.rs
+++ b/crates/higgs-engine/src/tool_parser.rs
@@ -64,6 +64,14 @@ const MAX_INSIDE_TOOL_CALL_BYTES: usize = 1024 * 1024;
 ///
 /// Returns the non-tool-call text and any extracted tool calls.
 pub fn parse_tool_calls(text: &str, schema: Option<&ToolSchema>) -> ToolParseResult {
+    // MiniCPM5 emits bare `<function name=…>…</function>` with no `<tool_call>`
+    // wrapper. When there's no wrapper but a function opener is present, take
+    // that path; otherwise fall through to the `<tool_call>` scanner (which
+    // covers both the JSON and Qwen `<function=` XML inner forms).
+    if !text.contains(TOOL_CALL_OPEN) && text.contains(MINICPM_FUNCTION_OPEN) {
+        return parse_minicpm_tool_calls(text, schema);
+    }
+
     let mut result_text = String::new();
     let mut tool_calls = Vec::new();
     let mut remaining = text;
@@ -126,6 +134,16 @@ const FUNCTION_OPEN: &str = "<function=";
 const FUNCTION_CLOSE: &str = "</function>";
 const PARAM_OPEN: &str = "<parameter=";
 const PARAM_CLOSE: &str = "</parameter>";
+
+// MiniCPM5-style tool calls: `<function name="NAME"><param name="KEY">VALUE</param></function>`
+// with no `<tool_call>` wrapper and optional `<![CDATA[…]]>`-wrapped values.
+// `FUNCTION_CLOSE` (`</function>`) is shared with the Qwen XML form above.
+const MINICPM_FUNCTION_OPEN: &str = "<function ";
+const MINICPM_PARAM_OPEN: &str = "<param name=\"";
+const MINICPM_PARAM_CLOSE: &str = "</param>";
+const NAME_ATTR: &str = "name=\"";
+const CDATA_OPEN: &str = "<![CDATA[";
+const CDATA_CLOSE: &str = "]]>";
 
 /// Declared JSON-schema type for a single tool parameter, used to coerce the
 /// raw string values that the Qwen XML tool-call format emits.
@@ -332,6 +350,144 @@ fn parse_tool_call_block(content: &str, schema: Option<&ToolSchema>) -> Option<P
     }
 }
 
+/// Byte offset of the `</function>` that closes a `MiniCPM` function block in
+/// `s`, skipping any `<![CDATA[ … ]]>` spans whose content may itself contain
+/// a literal `</function>`.
+///
+/// Returns `None` when the block is not yet terminated: either no closer has
+/// arrived, or scanning is parked inside an unclosed CDATA span (the caller
+/// should wait for more input).
+fn minicpm_function_end(s: &str) -> Option<usize> {
+    let mut i = 0;
+    loop {
+        let rest = s.get(i..)?;
+        let next_close = rest.find(FUNCTION_CLOSE);
+        // A CDATA span that opens before the next close tag must be skipped
+        // whole, otherwise a `</function>` inside it would close early.
+        if let Some(d) = rest.find(CDATA_OPEN) {
+            if next_close.is_none_or(|c| d < c) {
+                let after_open = d + CDATA_OPEN.len();
+                let close = rest.get(after_open..)?.find(CDATA_CLOSE)?;
+                i += after_open + close + CDATA_CLOSE.len();
+                continue;
+            }
+        }
+        return next_close.map(|c| i + c);
+    }
+}
+
+/// Extract one `MiniCPM` `<param>` value from `vr` — the text immediately after
+/// the param tag's `>`. Returns `(value, rest_after_</param>)`. A
+/// `<![CDATA[…]]>` wrapper yields its verbatim content; otherwise the value is
+/// the text up to `</param>`. Both returned slices borrow `vr`.
+fn extract_param_value(vr: &str) -> (&str, &str) {
+    if let Some(stripped) = vr.strip_prefix(CDATA_OPEN) {
+        if let Some(close) = stripped.find(CDATA_CLOSE) {
+            let value = stripped.get(..close).unwrap_or_default();
+            let tail = stripped
+                .get(close + CDATA_CLOSE.len()..)
+                .unwrap_or_default();
+            let after = tail
+                .find(MINICPM_PARAM_CLOSE)
+                .and_then(|i| tail.get(i + MINICPM_PARAM_CLOSE.len()..))
+                .unwrap_or_default();
+            return (value, after);
+        }
+        return (stripped, "");
+    }
+    vr.find(MINICPM_PARAM_CLOSE).map_or((vr, ""), |i| {
+        (
+            vr.get(..i).unwrap_or_default(),
+            vr.get(i + MINICPM_PARAM_CLOSE.len()..).unwrap_or_default(),
+        )
+    })
+}
+
+/// Parse a single `MiniCPM` function block (`<function name="…">…` up to, but
+/// not including, the closing `</function>`).
+///
+/// Returns `None` when no `name="…"` attribute is present so the caller can
+/// preserve the text verbatim.
+fn parse_minicpm_function(block: &str, schema: Option<&ToolSchema>) -> Option<ParsedToolCall> {
+    let name_attr = block.find(NAME_ATTR)?;
+    let after_attr = block.get(name_attr + NAME_ATTR.len()..)?;
+    let name_end = after_attr.find('"')?;
+    let name = after_attr.get(..name_end)?.to_owned();
+    if name.is_empty() {
+        return None;
+    }
+    // Params start after the `>` that closes the `<function …>` open tag.
+    let after_name = after_attr.get(name_end + 1..)?;
+    let tag_close = after_name.find('>')?;
+    let mut rest = after_name.get(tag_close + 1..).unwrap_or_default();
+
+    let mut map = serde_json::Map::new();
+    while let Some(p_open) = rest.find(MINICPM_PARAM_OPEN) {
+        let after_p = rest
+            .get(p_open + MINICPM_PARAM_OPEN.len()..)
+            .unwrap_or_default();
+        let Some(key_end) = after_p.find('"') else {
+            break;
+        };
+        let key = after_p.get(..key_end).unwrap_or_default().to_owned();
+        let after_key = after_p.get(key_end + 1..).unwrap_or_default();
+        let Some(gt) = after_key.find('>') else {
+            break;
+        };
+        let value_region = after_key.get(gt + 1..).unwrap_or_default();
+        let (raw_value, after) = extract_param_value(value_region);
+        if !key.is_empty() {
+            let declared = schema.and_then(|s| s.param_type(&name, &key));
+            map.insert(key, coerce_param_value(raw_value, declared));
+        }
+        rest = after;
+    }
+
+    Some(ParsedToolCall {
+        name,
+        arguments: serde_json::Value::Object(map),
+    })
+}
+
+/// Scan text for one or more bare `MiniCPM` `<function …>…</function>` blocks
+/// (no `<tool_call>` wrapper). Text outside the blocks is preserved as visible
+/// content; unparseable or unterminated blocks are preserved verbatim.
+fn parse_minicpm_tool_calls(text: &str, schema: Option<&ToolSchema>) -> ToolParseResult {
+    let mut result_text = String::new();
+    let mut tool_calls = Vec::new();
+    let mut remaining = text;
+
+    loop {
+        let Some(start) = remaining.find(MINICPM_FUNCTION_OPEN) else {
+            result_text.push_str(remaining);
+            break;
+        };
+        result_text.push_str(remaining.get(..start).unwrap_or_default());
+        let block_region = remaining.get(start..).unwrap_or_default();
+
+        let Some(end) = minicpm_function_end(block_region) else {
+            result_text.push_str(block_region);
+            break;
+        };
+
+        let block = block_region.get(..end).unwrap_or_default();
+        if let Some(parsed) = parse_minicpm_function(block, schema) {
+            tool_calls.push(parsed);
+        } else {
+            result_text.push_str(block);
+            result_text.push_str(FUNCTION_CLOSE);
+        }
+        remaining = block_region
+            .get(end + FUNCTION_CLOSE.len()..)
+            .unwrap_or_default();
+    }
+
+    ToolParseResult {
+        text: result_text.trim().to_owned(),
+        tool_calls,
+    }
+}
+
 /// One chunk of streaming output from [`StreamingToolCallTracker::process`]
 /// or [`StreamingToolCallTracker::flush`].
 ///
@@ -348,29 +504,47 @@ pub struct StreamingToolOutput {
     pub new_tool_calls: Vec<ParsedToolCall>,
 }
 
-/// State machine that buffers streaming text chunks and extracts
-/// `<tool_call>{json}</tool_call>` blocks on the fly.
+/// Longest opener token. In the scanning state the tracker keeps this many
+/// bytes at the buffer tail so a `<tool_call>` or `<function ` opener split
+/// across a chunk boundary is still detected next chunk.
+const MAX_OPENER_LEN: usize = if TOOL_CALL_OPEN.len() > MINICPM_FUNCTION_OPEN.len() {
+    TOOL_CALL_OPEN.len()
+} else {
+    MINICPM_FUNCTION_OPEN.len()
+};
+
+/// Which kind of tool-call block the tracker is currently inside.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Inside {
+    /// Scanning for the next opener.
+    None,
+    /// Inside a `<tool_call>…</tool_call>` block (JSON or Qwen `<function=` XML).
+    ToolCall,
+    /// Inside a bare `MiniCPM` `<function …>…</function>` block.
+    Function,
+}
+
+/// State machine that buffers streaming text chunks and extracts tool-call
+/// blocks on the fly — `<tool_call>…</tool_call>` (JSON or Qwen `<function=`
+/// XML) and bare `MiniCPM` `<function …>…</function>`.
 ///
 /// Designed to be cheap: when `active = false` (no tools in the request),
 /// `process` is a single allocation per chunk and `flush` is a no-op.
 ///
-/// When active, it accumulates a tail buffer just large enough that the
-/// `<tool_call>` opener can't straddle a chunk boundary. As soon as a
-/// complete `<tool_call>…</tool_call>` block is in the buffer, the JSON
-/// between the tags is parsed and emitted as a [`ParsedToolCall`]. Text
-/// before/after tags streams out verbatim.
+/// When active, it retains a small tail so an opener can't straddle a chunk
+/// boundary; once a complete block is buffered it is parsed and emitted as a
+/// [`ParsedToolCall`]. Text before/after blocks streams out verbatim.
 ///
 /// Invariants:
-/// - **Never silently drops tokens.** Unclosed tool-call tags at `flush`
-///   are re-emitted (with the `<tool_call>` opener prepended) as visible
-///   content rather than discarded.
+/// - **Never silently drops tokens.** Unclosed tags at `flush` are re-emitted
+///   as visible content rather than discarded.
 /// - **UTF-8 safe.** Tail-flushes walk back to the previous char boundary
 ///   so a partial multi-byte sequence is never split.
 /// - **Pure passthrough when inactive.** Zero parsing cost on requests
 ///   that did not pass `tools` to the chat route.
 pub struct StreamingToolCallTracker {
     buffer: String,
-    inside_tool_call: bool,
+    inside: Inside,
     completed_count: usize,
     active: bool,
     schema: Option<ToolSchema>,
@@ -382,7 +556,7 @@ impl StreamingToolCallTracker {
     pub const fn new(active: bool, schema: Option<ToolSchema>) -> Self {
         Self {
             buffer: String::new(),
-            inside_tool_call: false,
+            inside: Inside::None,
             completed_count: 0,
             active,
             schema,
@@ -395,6 +569,52 @@ impl StreamingToolCallTracker {
 
     pub const fn has_tool_calls(&self) -> bool {
         self.completed_count > 0
+    }
+
+    /// In the scanning state, advance to the next opener — entering
+    /// `ToolCall`/`Function` — or flush all-but-tail and signal "wait".
+    /// Returns `true` to keep looping, `false` to break (need more input).
+    fn scan_for_opener(&mut self, out: &mut StreamingToolOutput) -> bool {
+        let tc = self.buffer.find(TOOL_CALL_OPEN);
+        let fc = self.buffer.find(MINICPM_FUNCTION_OPEN);
+        // Enter whichever opener appears first; `(pos, is_tool_call)`.
+        let pick = match (tc, fc) {
+            (Some(t), Some(f)) => Some(if f < t { (f, false) } else { (t, true) }),
+            (Some(t), None) => Some((t, true)),
+            (None, Some(f)) => Some((f, false)),
+            (None, None) => None,
+        };
+        let Some((pos, is_tool_call)) = pick else {
+            // No opener yet — flush all but a tail large enough to hold a
+            // split opener, walking back to a UTF-8 char boundary.
+            if self.buffer.len() > MAX_OPENER_LEN {
+                let target_len = self.buffer.len() - MAX_OPENER_LEN;
+                let mut safe_len = target_len;
+                while safe_len > 0 && !self.buffer.is_char_boundary(safe_len) {
+                    safe_len -= 1;
+                }
+                out.visible
+                    .push_str(self.buffer.get(..safe_len).unwrap_or_default());
+                self.buffer = self.buffer.get(safe_len..).unwrap_or_default().to_owned();
+            }
+            return false;
+        };
+        out.visible
+            .push_str(self.buffer.get(..pos).unwrap_or_default());
+        if is_tool_call {
+            // Strip the `<tool_call>` opener; the inner body is parsed at the closer.
+            self.buffer = self
+                .buffer
+                .get(pos + TOOL_CALL_OPEN.len()..)
+                .unwrap_or_default()
+                .to_owned();
+            self.inside = Inside::ToolCall;
+        } else {
+            // Keep the `<function …` opener for the block parser.
+            self.buffer = self.buffer.get(pos..).unwrap_or_default().to_owned();
+            self.inside = Inside::Function;
+        }
+        true
     }
 
     /// Feed a chunk of streamed text. Returns visible text + any tool calls
@@ -411,74 +631,76 @@ impl StreamingToolCallTracker {
         let mut out = StreamingToolOutput::default();
 
         loop {
-            if self.inside_tool_call {
-                // Look for closing tag — once seen, parse the JSON body
-                // and continue scanning (another tool call may follow in
-                // the same chunk).
-                if let Some(end) = self.buffer.find(TOOL_CALL_CLOSE) {
-                    let raw_block = self.buffer.get(..end).unwrap_or_default();
-                    let call_content = raw_block.trim();
-                    if let Some(parsed) = parse_tool_call_block(call_content, self.schema.as_ref())
-                    {
-                        out.new_tool_calls.push(parsed);
-                        self.completed_count += 1;
-                    } else {
-                        // Invalid JSON inside the tag — preserve verbatim
-                        // so the client/operator can see what the model
-                        // emitted instead of silent loss.
+            match self.inside {
+                Inside::ToolCall => {
+                    // Seek `</tool_call>`; once seen, parse the inner block
+                    // (JSON or Qwen `<function=` XML) and keep scanning.
+                    if let Some(end) = self.buffer.find(TOOL_CALL_CLOSE) {
+                        let raw_block = self.buffer.get(..end).unwrap_or_default();
+                        let call_content = raw_block.trim();
+                        if let Some(parsed) =
+                            parse_tool_call_block(call_content, self.schema.as_ref())
+                        {
+                            out.new_tool_calls.push(parsed);
+                            self.completed_count += 1;
+                        } else {
+                            // Unparseable inner — preserve verbatim so the
+                            // client/operator sees what the model emitted.
+                            out.visible.push_str(TOOL_CALL_OPEN);
+                            out.visible.push_str(raw_block);
+                            out.visible.push_str(TOOL_CALL_CLOSE);
+                        }
+                        self.buffer = self
+                            .buffer
+                            .get(end + TOOL_CALL_CLOSE.len()..)
+                            .unwrap_or_default()
+                            .to_owned();
+                        self.inside = Inside::None;
+                    } else if self.buffer.len() > MAX_INSIDE_TOOL_CALL_BYTES {
+                        // Overflow guard: opener seen, closer never arrived.
+                        let leftover = std::mem::take(&mut self.buffer);
                         out.visible.push_str(TOOL_CALL_OPEN);
-                        out.visible.push_str(raw_block);
-                        out.visible.push_str(TOOL_CALL_CLOSE);
+                        out.visible.push_str(&leftover);
+                        self.inside = Inside::None;
+                        break;
+                    } else {
+                        break;
                     }
-                    self.buffer = self
-                        .buffer
-                        .get(end + TOOL_CALL_CLOSE.len()..)
-                        .unwrap_or_default()
-                        .to_owned();
-                    self.inside_tool_call = false;
-                } else if self.buffer.len() > MAX_INSIDE_TOOL_CALL_BYTES {
-                    // Overflow guard: `<tool_call>` opened but the close
-                    // tag never arrived within the cap. Abandon the parse
-                    // and emit verbatim so tokens still aren't dropped.
-                    let leftover = std::mem::take(&mut self.buffer);
-                    out.visible.push_str(TOOL_CALL_OPEN);
-                    out.visible.push_str(&leftover);
-                    self.inside_tool_call = false;
-                    break;
-                } else {
-                    // Still accumulating — wait for more.
-                    break;
                 }
-            } else if let Some(start) = self.buffer.find(TOOL_CALL_OPEN) {
-                // Everything before the open tag flushes out as visible.
-                out.visible
-                    .push_str(self.buffer.get(..start).unwrap_or_default());
-                self.buffer = self
-                    .buffer
-                    .get(start + TOOL_CALL_OPEN.len()..)
-                    .unwrap_or_default()
-                    .to_owned();
-                self.inside_tool_call = true;
-            } else if self.buffer.len() > TOOL_CALL_OPEN.len() {
-                // No open tag yet, but the buffer is bigger than the open
-                // tag — safe to flush all-but-tail. Keep
-                // `TOOL_CALL_OPEN.len()` bytes at the tail so a partial
-                // `<tool_call>` straddling the next chunk is still
-                // detectable.
-                let target_len = self.buffer.len() - TOOL_CALL_OPEN.len();
-                // Walk back to the previous UTF-8 char boundary so a
-                // multi-byte sequence is never split.
-                let mut safe_len = target_len;
-                while safe_len > 0 && !self.buffer.is_char_boundary(safe_len) {
-                    safe_len -= 1;
+                Inside::Function => {
+                    // The `<function …` opener is kept in the buffer so the
+                    // block parser can read the `name="…"` attribute. Seek a
+                    // CDATA-aware `</function>`.
+                    if let Some(end) = minicpm_function_end(&self.buffer) {
+                        let block = self.buffer.get(..end).unwrap_or_default();
+                        if let Some(parsed) = parse_minicpm_function(block, self.schema.as_ref()) {
+                            out.new_tool_calls.push(parsed);
+                            self.completed_count += 1;
+                        } else {
+                            out.visible.push_str(block);
+                            out.visible.push_str(FUNCTION_CLOSE);
+                        }
+                        self.buffer = self
+                            .buffer
+                            .get(end + FUNCTION_CLOSE.len()..)
+                            .unwrap_or_default()
+                            .to_owned();
+                        self.inside = Inside::None;
+                    } else if self.buffer.len() > MAX_INSIDE_TOOL_CALL_BYTES {
+                        // Overflow guard: `<function …` opened, never closed.
+                        let leftover = std::mem::take(&mut self.buffer);
+                        out.visible.push_str(&leftover);
+                        self.inside = Inside::None;
+                        break;
+                    } else {
+                        break;
+                    }
                 }
-                out.visible
-                    .push_str(self.buffer.get(..safe_len).unwrap_or_default());
-                self.buffer = self.buffer.get(safe_len..).unwrap_or_default().to_owned();
-                break;
-            } else {
-                // Buffer smaller than the open tag — keep waiting.
-                break;
+                Inside::None => {
+                    if !self.scan_for_opener(&mut out) {
+                        break;
+                    }
+                }
             }
         }
 
@@ -490,22 +712,25 @@ impl StreamingToolCallTracker {
     /// (with its opener prepended) so no tokens silently vanish.
     pub fn flush(&mut self) -> StreamingToolOutput {
         let leftover = std::mem::take(&mut self.buffer);
-        let was_inside = self.inside_tool_call;
-        self.inside_tool_call = false;
+        let inside = self.inside;
+        self.inside = Inside::None;
 
-        if was_inside {
-            let mut visible = String::with_capacity(TOOL_CALL_OPEN.len() + leftover.len());
-            visible.push_str(TOOL_CALL_OPEN);
-            visible.push_str(&leftover);
-            StreamingToolOutput {
-                visible,
-                new_tool_calls: Vec::new(),
+        let visible = match inside {
+            // The `<tool_call>` opener was stripped on entry, so re-prepend it.
+            Inside::ToolCall => {
+                let mut v = String::with_capacity(TOOL_CALL_OPEN.len() + leftover.len());
+                v.push_str(TOOL_CALL_OPEN);
+                v.push_str(&leftover);
+                v
             }
-        } else {
-            StreamingToolOutput {
-                visible: leftover,
-                new_tool_calls: Vec::new(),
-            }
+            // `Function` keeps its `<function …` opener in the buffer, and
+            // `None` is plain text — both emit the leftover verbatim.
+            Inside::Function | Inside::None => leftover,
+        };
+
+        StreamingToolOutput {
+            visible,
+            new_tool_calls: Vec::new(),
         }
     }
 }
@@ -1159,5 +1384,125 @@ After last."#;
             result.tool_calls[0].arguments,
             serde_json::json!({ "city": "Paris" })
         );
+    }
+
+    // ============================================================
+    // MiniCPM5 tool-call format: <function name="…"><param name="…">…
+    // (no <tool_call> wrapper, attribute-named, optional CDATA values)
+    // ============================================================
+
+    /// Canonical `MiniCPM` shape: bare `<function name=…>` with one param.
+    #[test]
+    fn minicpm_single_call_one_param() {
+        let input = r#"<function name="get_weather"><param name="city">London</param></function>"#;
+        let result = parse_tool_calls(input, None);
+        assert_eq!(result.tool_calls.len(), 1);
+        let tc = result.tool_calls.first().unwrap();
+        assert_eq!(tc.name, "get_weather");
+        assert_eq!(tc.arguments, serde_json::json!({ "city": "London" }));
+        assert!(result.text.is_empty());
+    }
+
+    /// Multiple consecutive blocks, with text before/between them preserved.
+    #[test]
+    fn minicpm_multiple_calls_with_text() {
+        let input = concat!(
+            "Sure.",
+            r#"<function name="a"><param name="x">1</param></function>"#,
+            " then ",
+            r#"<function name="b"><param name="y">two</param></function>"#,
+        );
+        let result = parse_tool_calls(input, None);
+        assert_eq!(result.tool_calls.len(), 2);
+        assert_eq!(result.tool_calls[0].name, "a");
+        // No schema → best-effort: "1" parses to a number.
+        assert_eq!(
+            result.tool_calls[0].arguments,
+            serde_json::json!({ "x": 1 })
+        );
+        assert_eq!(result.tool_calls[1].name, "b");
+        assert_eq!(
+            result.tool_calls[1].arguments,
+            serde_json::json!({ "y": "two" })
+        );
+        assert!(result.text.contains("Sure."));
+        assert!(result.text.contains("then"));
+    }
+
+    /// A CDATA value containing both a newline and a literal `</function>`
+    /// must be captured verbatim and must NOT close the block early.
+    #[test]
+    fn minicpm_cdata_value_with_literal_close_tag() {
+        let input = "<function name=\"write\"><param name=\"code\"><![CDATA[fn main() {\n  // </function> not a real close\n}]]></param></function>";
+        let result = parse_tool_calls(input, None);
+        assert_eq!(result.tool_calls.len(), 1);
+        let tc = result.tool_calls.first().unwrap();
+        assert_eq!(tc.name, "write");
+        let code = tc.arguments.get("code").unwrap().as_str().unwrap();
+        assert!(code.contains("fn main()"));
+        assert!(code.contains("</function> not a real close"));
+        assert!(code.contains('\n'));
+        assert!(result.text.is_empty());
+    }
+
+    /// Declared schema coerces `MiniCPM` param values; a `string`-typed `"123"`
+    /// stays a string (schema beats the best-effort number guess).
+    #[test]
+    fn minicpm_schema_driven_coercion() {
+        let tools = vec![serde_json::json!({
+            "type": "function",
+            "function": {
+                "name": "cfg",
+                "parameters": { "type": "object", "properties": {
+                    "count": { "type": "integer" },
+                    "on": { "type": "boolean" },
+                    "label": { "type": "string" }
+                }}
+            }
+        })];
+        let schema = ToolSchema::from_tools(Some(tools.as_slice()));
+        let input = r#"<function name="cfg"><param name="count">7</param><param name="on">true</param><param name="label">123</param></function>"#;
+        let result = parse_tool_calls(input, schema.as_ref());
+        assert_eq!(
+            result.tool_calls.first().unwrap().arguments,
+            serde_json::json!({ "count": 7, "on": true, "label": "123" })
+        );
+    }
+
+    /// A function with no params yields empty arguments, not a failure.
+    #[test]
+    fn minicpm_no_param_function() {
+        let input = r#"<function name="ping"></function>"#;
+        let result = parse_tool_calls(input, None);
+        assert_eq!(result.tool_calls.len(), 1);
+        assert_eq!(result.tool_calls.first().unwrap().name, "ping");
+        assert_eq!(
+            result.tool_calls.first().unwrap().arguments,
+            serde_json::json!({})
+        );
+    }
+
+    /// Streaming: the tracker reassembles a `MiniCPM` call split inside the
+    /// `<function` opener AND inside a CDATA value, with no leak to visible.
+    #[test]
+    fn streaming_minicpm_split_across_chunks() {
+        let mut t = StreamingToolCallTracker::new(true, None);
+        let (vis, calls) = drain_visible_and_calls(
+            &mut t,
+            &[
+                "<func",
+                "tion name=\"run\"><param name=\"cmd\">",
+                "<![CDATA[echo ",
+                "hi]]></param></function>",
+            ],
+        );
+        assert!(
+            vis.trim().is_empty(),
+            "split MiniCPM must not leak to visible, got {vis:?}"
+        );
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "run");
+        assert_eq!(calls[0].arguments, serde_json::json!({ "cmd": "echo hi" }));
+        assert_eq!(t.completed_count(), 1);
     }
 }

--- a/crates/higgs-models/src/transformer.rs
+++ b/crates/higgs-models/src/transformer.rs
@@ -90,6 +90,14 @@ pub struct ModelArgs {
     pub sliding_window: Option<i32>,
     #[serde(default)]
     pub rope_scaling: Option<serde_json::Value>,
+    /// Explicit attention head dimension (`head_dim` in config.json). Most
+    /// Llama-family configs omit it, in which case `head_dim()` falls back to
+    /// `hidden_size / num_attention_heads`. Some models set it to a value that
+    /// differs from that ratio — e.g. `MiniCPM5` uses 128 while 1536/16 = 96 —
+    /// and the attention projections, `RoPE`, and scale must use the explicit
+    /// value or the model produces garbage.
+    #[serde(default, rename = "head_dim")]
+    pub head_dim_override: Option<i32>,
 
     // Quantization (present in pre-quantized MLX models)
     #[serde(default)]
@@ -106,10 +114,14 @@ impl ModelArgs {
             .unwrap_or(matches!(self.model_type.as_str(), "qwen2"))
     }
 
-    /// Head dimension, computed from `hidden_size / num_attention_heads`.
+    /// Head dimension. Uses the explicit `head_dim` from config when present,
+    /// otherwise `hidden_size / num_attention_heads`.
     ///
-    /// Panics in debug builds if not evenly divisible.
+    /// Panics in debug builds if the fallback is not evenly divisible.
     pub fn head_dim(&self) -> i32 {
+        if let Some(head_dim) = self.head_dim_override {
+            return head_dim;
+        }
         debug_assert!(
             self.num_attention_heads != 0 && self.hidden_size % self.num_attention_heads == 0,
             "hidden_size ({}) must be divisible by num_attention_heads ({})",
@@ -119,8 +131,18 @@ impl ModelArgs {
         self.hidden_size / self.num_attention_heads
     }
 
-    /// Validated head dimension that returns an error if not evenly divisible.
+    /// Validated head dimension. Honours an explicit `head_dim` from config;
+    /// otherwise returns an error if `hidden_size` is not evenly divisible by
+    /// `num_attention_heads`.
     pub fn checked_head_dim(&self) -> Result<i32, ModelError> {
+        if let Some(head_dim) = self.head_dim_override {
+            if head_dim <= 0 {
+                return Err(ModelError::ShapeMismatch(
+                    "explicit head_dim must be positive".to_owned(),
+                ));
+            }
+            return Ok(head_dim);
+        }
         if self.num_attention_heads == 0 {
             return Err(ModelError::ShapeMismatch(
                 "num_attention_heads must be positive".to_owned(),
@@ -1015,6 +1037,7 @@ mod tests {
             use_sliding_window: false,
             sliding_window: None,
             rope_scaling: None,
+            head_dim_override: None,
             quantization: None,
         }
     }
@@ -1218,6 +1241,37 @@ mod tests {
         assert!(args.sliding_window.is_none());
         assert!(args.rope_scaling.is_none());
         assert!(args.quantization.is_none());
+    }
+
+    #[test]
+    fn test_explicit_head_dim_honored() {
+        // MiniCPM5-1B: head_dim=128 even though hidden/heads = 1536/16 = 96.
+        // Must use the explicit value or attention/RoPE are wrong.
+        let json = r#"{
+            "architectures": ["LlamaForCausalLM"],
+            "model_type": "llama",
+            "hidden_size": 1536,
+            "num_hidden_layers": 24,
+            "intermediate_size": 4608,
+            "num_attention_heads": 16,
+            "rms_norm_eps": 1e-06,
+            "vocab_size": 130560,
+            "num_key_value_heads": 2,
+            "max_position_embeddings": 131072,
+            "head_dim": 128
+        }"#;
+        let args = assert_model_config(json, "llama", 1536, 128, false);
+        assert_eq!(args.head_dim_override, Some(128));
+        assert_eq!(args.checked_head_dim().unwrap(), 128);
+    }
+
+    #[test]
+    fn test_head_dim_falls_back_when_config_omits_it() {
+        // Standard Llama config has no `head_dim` → fall back to 4096/32 = 128.
+        let args = make_model_args("llama", 4096, 32, 32, 32000, 32);
+        assert_eq!(args.head_dim_override, None);
+        assert_eq!(args.head_dim(), 128);
+        assert_eq!(args.checked_head_dim().unwrap(), 128);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Takes `openbmb/MiniCPM5-1B` (MLX 4-bit) from *loads-but-emits-garbage* to fully working **chat and tool-calling** on higgs. Four self-contained commits — three are general fixes that help any model, one adds the MiniCPM tool-call format.

> **Stacked on #164** (streaming tool-call deltas + Qwen XML). The first 5 commits here belong to #164 — please review those there. This PR adds the **4 commits** listed below; once #164 merges, only those remain in this diff.

## The 4 new commits

1. **`feat(models): honor explicit head_dim`** — `ModelArgs::head_dim()` always computed `hidden_size / num_attention_heads`, ignoring an explicit `head_dim` in `config.json`. MiniCPM5 sets `head_dim=128` while `1536/16=96`, so it loaded but produced garbage (wrong RoPE dimension + `1/√head_dim` scale). Now honors the config value. **Regression-safe**: every other Llama-family config omits `head_dim` → `None` → behaviour unchanged. General fix for any explicit-`head_dim` checkpoint.

2. **`fix(engine): preserve content special tokens on decode`** — `decode_tokens` used `skip_special_tokens=true`, deleting *content-bearing* special tokens. MiniCPM5 encodes its tool-call markup (`<function>`/`<param>`, token ids 18–21) as special tokens, so calls silently vanished into empty content. Now decodes with specials kept and strips only a precomputed **control** set (EOS ids + `<|…|>` delimiters + `<s>`/`</s>`/…). Plain text has no special tokens and decodes identically, so normal responses are unaffected. Also fixes latent control-token leakage for other models.

3. **`fix(chat_template): accept ensure_ascii kwarg in tojson`** — HF templates call `tojson(ensure_ascii=false)` (MiniCPM5 at `chat:6`); the custom filter rejected kwargs and 500'd any tools-bearing request. Now accepts (and ignores) them — `serde_json::to_string` already emits UTF-8, i.e. `ensure_ascii=false`. Templates calling `tojson` with no args are unaffected.

4. **`feat(tool_parser): MiniCPM5 `<function name=…>` tool format`** — a third tool-call format (attribute-named, optional `<![CDATA[…]]>` values, no `<tool_call>` wrapper), dispatched on content shape. CDATA-aware end detection (a literal `</function>` inside a value can't close the block early); the streaming tracker's flag becomes an `Inside { None, ToolCall, Function }` enum (the existing arms unchanged). Reuses the `ToolSchema` coercion from #164. 6 new unit tests.

## Verification (release builds)

- `cargo test --release` — higgs-engine **258**, higgs-models **457**, higgs **98**; **0 failed**. `cargo clippy`/`cargo fmt` clean across touched crates.
- **Live e2e** on `mlx-community/MiniCPM5-1B-4bit`:
  - plain chat coherent (`"Paris is the capital of France."` — was `"I cannot answer: 1."` before the head_dim fix)
  - tool call → `{"name":"get_weather","arguments":{"city":"London"}}`, `finish_reason: tool_calls`, no markup leak — **non-streaming and streaming**.
- **Regression** on `Qwen3.5-4B-MLX-4bit`: tool calls still parse to structured `tool_calls`; the decode change also removes a stray `<|im_end|>` that could leak into content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for MiniCPM5 tool-call format.
  * Expanded thinking capability detection to recognize chat template markers.
  * Added optional head dimension configuration override for model customization.

* **Bug Fixes**
  * Fixed template keyword argument handling for Qwen-Hermes compatibility.
  * Improved special token filtering to prevent control characters from appearing in decoded text while preserving meaningful markup.
  * Enhanced tool-call parsing robustness with CDATA-aware extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->