### PR TITLE
feat(higgs): migrate from huggingface-cli to hf

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,7 +207,7 @@ jobs:
 
             depends_on :macos
             depends_on arch: :arm64
-            depends_on "huggingface-cli"
+            depends_on "hf"
 
             url "https://github.com/panbanda/higgs/releases/download/${TAG}/higgs_${VERSION}_aarch64-apple-darwin.tar.gz"
             sha256 "${DARWIN_ARM64_SHA}"

--- a/crates/higgs/src/main.rs
+++ b/crates/higgs/src/main.rs
@@ -261,23 +261,7 @@ fn load_engines(
                     is_interactive,
                     &mut std::io::stderr().lock(),
                     std::io::stdin().lock(),
-                    || {
-                        let status = std::process::Command::new("huggingface-cli")
-                            .args(["download", model_path])
-                            .status()
-                            .map_err(|e| {
-                                format!(
-                                    "failed to run huggingface-cli: {e}\nInstall with: brew install huggingface-cli"
-                                )
-                            })?;
-                        if status.success() {
-                            Ok(())
-                        } else {
-                            Err(format!(
-                                "huggingface-cli download failed for '{model_path}'"
-                            ))
-                        }
-                    },
+                    || download_via_hf_cli(model_path),
                 )?;
                 model_resolver::resolve(model_path)?
             }
@@ -341,6 +325,21 @@ fn ensure_local_runtime_ready(config: &HiggsConfig) -> Result<(), Box<dyn std::e
         }
     }
     Ok(())
+}
+
+fn download_via_hf_cli(model_path: &str) -> Result<(), String> {
+    const CMD: &str = "hf";
+
+    let status = std::process::Command::new(CMD)
+        .args(["download", model_path])
+        .status()
+        .map_err(|e| format!("failed to run {CMD}: {e}\nInstall with: brew install {CMD}"))?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("{CMD} download failed for '{model_path}'"))
+    }
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/higgs/src/model_download.rs
+++ b/crates/higgs/src/model_download.rs
@@ -3,7 +3,7 @@ use std::io::{BufRead, Write};
 /// Prompt the user to confirm downloading `model_id`, then call `run_download`.
 ///
 /// - `is_interactive`: if `false`, returns an error immediately with a hint to
-///   run `huggingface-cli download` manually (e.g. when stdin is not a TTY).
+///   run `hf download` manually (e.g. when stdin is not a TTY).
 /// - `out`: where the prompt is written (typically stderr).
 /// - `input`: where the user's response is read from (typically locked stdin).
 /// - `run_download`: called only when the user confirms; should execute the download.
@@ -21,7 +21,7 @@ where
 {
     if !is_interactive {
         return Err(format!(
-            "model '{model_id}' not found in HuggingFace cache; run: huggingface-cli download {model_id}"
+            "model '{model_id}' not found in HuggingFace cache; run: hf download {model_id}"
         ));
     }
 
@@ -64,7 +64,7 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(err.contains("org/model"));
-        assert!(err.contains("huggingface-cli download"));
+        assert!(err.contains("hf download"));
     }
 
     #[test]
@@ -142,6 +142,6 @@ mod tests {
             ok_download,
         );
         let err = result.unwrap_err();
-        assert!(err.contains("huggingface-cli download myorg/mymodel"));
+        assert!(err.contains("hf download myorg/mymodel"));
     }
 }

--- a/crates/higgs/tests/integration/cli_serve.rs
+++ b/crates/higgs/tests/integration/cli_serve.rs
@@ -1,0 +1,35 @@
+//! CLI integration tests for `higgs serve`.
+
+#![allow(clippy::panic, clippy::unwrap_used, clippy::tests_outside_test_module)]
+
+use std::process::Command;
+
+fn higgs_bin() -> std::path::PathBuf {
+    // cargo sets this during `cargo test`
+    let mut path = std::env::current_exe()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    path.push("higgs");
+    path
+}
+
+#[test]
+fn serve_with_non_cached_hf_model() {
+    let non_cached_model = "test/non-cached-hf-model";
+
+    let output = Command::new(higgs_bin())
+        .args(["serve", "--model", non_cached_model])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(&format!("run: hf download {non_cached_model}")),
+        "expected 'run: hf download {non_cached_model}' in stderr, got: {stderr}"
+    );
+}

--- a/crates/higgs/tests/integration/mod.rs
+++ b/crates/higgs/tests/integration/mod.rs
@@ -1,6 +1,7 @@
 mod api_contract;
 mod cli_contract;
 mod cli_exec;
+mod cli_serve;
 mod error_contract;
 mod proxy_e2e;
 mod request_validation;


### PR DESCRIPTION
## Summary
This PR migrates all references from `huggingface-cli` to `hf`.
The upstream `huggingface-cli` was renamed to `hf`.

```
➜  brew install panbanda/brews/higgs
Inspect the formula dependency plan before installing with `brew install --ask`.
Enable ask mode by setting `HOMEBREW_ASK=1`.
Hide these hints with `HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).
==> Fetching downloads for: higgs
Warning: Formula huggingface-cli was renamed to hf.
Warning: Formula huggingface-cli was renamed to hf.
✔︎ Formula higgs (1.3.0) ... Verified     44.0MB/ 44.0MB
==> Installing higgs from panbanda/brews
Warning: Formula huggingface-cli was renamed to hf.
Warning: Formula huggingface-cli was renamed to hf.
🍺  /opt/homebrew/Cellar/higgs/1.3.0: 5 files, 141.3MB, built in 1 second
==> Running `brew cleanup higgs`...
Disable this behaviour by setting `HOMEBREW_NO_INSTALL_CLEANUP=1`.
Hide these hints with `HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).
```
The old CLI still installs but produces a deprecation warning, and the `huggingface-cli` binary no longer works at all — it exits with code 1 and prints:
```
➜  ~ huggingface-cli download mlx-community/Qwen3.6-35B-A3B-4bit
Warning: `huggingface-cli` is deprecated and no longer works. Use `hf` instead.

Hint: `hf` is already installed! Use it directly.

Hint: Examples:
  hf auth login
  hf download unsloth/gemma-4-31B-it-GGUF
  hf upload my-cool-model . .
  hf models ls --search "gemma"
  hf repos ls --format json
  hf jobs run python:3.12 python -c 'print("Hello!")'
  hf --help

➜  ~ echo $?
1
```

This means `higgs serve --model <id>` on a cold cache is broken for anyone relying on automatic download via `huggingface-cli`.

```
➜  higgs serve --model nvidia/dvlt
2026-06-04T08:37:02.799587Z  INFO higgs: Resolving model path model=nvidia/dvlt
Model 'nvidia/dvlt' not found in HuggingFace cache. Download now? [y/N] y
Warning: `huggingface-cli` is deprecated and no longer works. Use `hf` instead.
                                                                                                                                                                                                                                  
Hint: `hf` is already installed! Use it directly.
                                                                                                                                                                                                                                  
Hint: Examples:
  hf auth login                                                                                                                                                                                                                   
  hf download unsloth/gemma-4-31B-it-GGUF                                                                                                                                                                                         
  hf upload my-cool-model . .                                                                                                                                                                                                     
  hf models ls --search "gemma"                                                                                                                                                                                                   
  hf repos ls --format json                                                                                                                                                                                                       
  hf jobs run python:3.12 python -c 'print("Hello!")'                                                                                                                                                                             
  hf --help                                                                                                                                                                                                                       
                                                                                                                                                                                                                                  
Error: "huggingface-cli download failed for 'nvidia/dvlt'"
```

## Verification
- cargo test -- --test-threads=1
- cargo clippy
- cargo fmt --check
- cargo build --release and download a model
```
➜  ./higgs serve --model nvidia/dvlt
2026-06-04T08:37:37.989539Z  INFO higgs: restored mlx.metallib next to executable from Cargo build output source=/target/release/build/mlx-sys-2132f80883b99581/out/build/lib/mlx.metallib destination=/target/release/mlx.metallib
2026-06-04T08:37:37.989698Z  INFO higgs: Resolving model path model=nvidia/dvlt
Model 'nvidia/dvlt' not found in HuggingFace cache. Download now? [y/N] y
Downloading (incomplete total...): 0.00B [00:00, ?B/s]
Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.                                                                   | 0/5 [00:00<?, ?it/s]
Fetching 5 files: 100%|█| 5/5 [00:20<00:00,  4.16s/it]
Download complete: 100%|█| 468M/468M [00:20<00:00, 30.2MB/s]✓ Downloaded  
``` 

Note: `nvidia/dvlt` random small model just for local check of download process
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Replaced references to the old HuggingFace CLI with the new `hf` command across downloads, install hints, and generated Homebrew formula.

* **Tests**
  * Added an integration test to verify the serve command surfaces the new `hf download <model>` guidance on failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->