### PR TITLE
feat(serve): stream prefill progress (llama.cpp-compatible prompt_progress)

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,9 @@ Measured on DeepSeek-V2-Lite-4bit with global batch sorting before `gather_qmm`.
 **API endpoints**
 
 - OpenAI: `/v1/chat/completions`, `/v1/completions`, `/v1/embeddings`, `/v1/models`
+  - Streaming requests may set `"return_progress": true` to receive
+    llama.cpp-compatible `prompt_progress` chunks (`{total, cache, processed,
+    time_ms}`) during chunked prefill.
 - Anthropic: `/v1/messages`, `/v1/messages/count_tokens`
 - Metrics: `/metrics`
 - Health: `/health`

--- a/crates/higgs-engine/src/batch_engine.rs
+++ b/crates/higgs-engine/src/batch_engine.rs
@@ -306,6 +306,7 @@ impl BatchEngine {
             top_logprobs,
             sender,
             false,
+            false,
             constraint,
             pixel_values,
         )
@@ -322,6 +323,9 @@ impl BatchEngine {
         top_logprobs: Option<u32>,
         sender: &tokio::sync::mpsc::Sender<StreamingOutput>,
         _enable_thinking: bool,
+        // Batch engine does not emit prefill progress; accepts the flag to
+        // share the streaming interface with SimpleEngine.
+        _return_progress: bool,
         constraint: Option<crate::constrained::ConstrainedGenerator>,
         pixel_values: Option<mlx_rs::Array>,
     ) -> Result<(), EngineError> {

--- a/crates/higgs-engine/src/batch_engine.rs
+++ b/crates/higgs-engine/src/batch_engine.rs
@@ -347,6 +347,7 @@ impl BatchEngine {
                 prompt_tokens: prompt_len,
                 completion_tokens: 0,
                 token_logprob: None,
+                prefill_progress: None,
             });
             return Ok(());
         }
@@ -463,6 +464,7 @@ fn worker_loop(
                         prompt_tokens: ar.prompt_len,
                         completion_tokens: 0,
                         token_logprob: None,
+                        prefill_progress: None,
                     });
                     finished_indices.push(i);
                 }
@@ -516,6 +518,7 @@ fn run_pipelined_decode_round(
                             prompt_tokens: ar.prompt_len,
                             completion_tokens: 0,
                             token_logprob: None,
+                            prefill_progress: None,
                         });
                         finished_indices.push(i);
                         graphs.push(None);
@@ -531,6 +534,7 @@ fn run_pipelined_decode_round(
                     prompt_tokens: ar.prompt_len,
                     completion_tokens: 0,
                     token_logprob: None,
+                    prefill_progress: None,
                 });
                 finished_indices.push(i);
                 graphs.push(None);
@@ -741,6 +745,7 @@ fn prefill_request(
                 prompt_tokens: prompt_len,
                 completion_tokens: 1,
                 token_logprob: first_token_logprob,
+                prefill_progress: None,
             });
             return Ok(None);
         }
@@ -756,6 +761,7 @@ fn prefill_request(
                 prompt_tokens: prompt_len,
                 completion_tokens: 1,
                 token_logprob: first_token_logprob,
+                prefill_progress: None,
             })
             .is_err()
         {
@@ -901,6 +907,7 @@ fn materialize_decode_step(
             prompt_tokens: ar.prompt_len,
             completion_tokens: completion_len,
             token_logprob,
+            prefill_progress: None,
         })
         .is_err();
 

--- a/crates/higgs-engine/src/engine.rs
+++ b/crates/higgs-engine/src/engine.rs
@@ -10,6 +10,18 @@ pub struct GenerationOutput {
     pub token_logprobs: Option<Vec<TokenLogprobInfo>>,
 }
 
+/// Prefill progress for one streaming request, in absolute prompt tokens.
+///
+/// `processed` counts cached + prefilled tokens, so `processed / total` is
+/// directly displayable; `cached` exposes the prefix-cache hit separately.
+/// Matches the semantics of llama.cpp's `prompt_progress` SSE field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PrefillProgress {
+    pub processed: u32,
+    pub cached: u32,
+    pub total: u32,
+}
+
 /// Output from a streaming generation step.
 #[derive(Debug, Clone)]
 pub struct StreamingOutput {
@@ -19,6 +31,10 @@ pub struct StreamingOutput {
     pub prompt_tokens: u32,
     pub completion_tokens: u32,
     pub token_logprob: Option<TokenLogprobInfo>,
+    /// Set on progress-only events emitted during chunked prefill
+    /// (`new_text` is empty, `completion_tokens` is 0). `None` on token
+    /// outputs.
+    pub prefill_progress: Option<PrefillProgress>,
 }
 
 #[cfg(test)]
@@ -64,6 +80,7 @@ mod tests {
             prompt_tokens: 20,
             completion_tokens: 15,
             token_logprob: None,
+            prefill_progress: None,
         };
         assert!(output.finished);
         assert_eq!(output.finish_reason.as_deref(), Some("stop"));
@@ -79,6 +96,7 @@ mod tests {
             prompt_tokens: 20,
             completion_tokens: 3,
             token_logprob: None,
+            prefill_progress: None,
         };
         assert!(!output.finished);
         assert!(output.finish_reason.is_none());
@@ -93,6 +111,7 @@ mod tests {
             prompt_tokens: 0,
             completion_tokens: 0,
             token_logprob: None,
+            prefill_progress: None,
         };
         assert!(output.new_text.is_empty());
         assert_eq!(output.prompt_tokens, 0);
@@ -122,6 +141,7 @@ mod tests {
             prompt_tokens: 10,
             completion_tokens: 2,
             token_logprob: None,
+            prefill_progress: None,
         };
         let cloned = output.clone();
         assert_eq!(cloned.new_text, output.new_text);
@@ -152,6 +172,7 @@ mod tests {
             prompt_tokens: 5,
             completion_tokens: 10,
             token_logprob: None,
+            prefill_progress: None,
         };
         let debug_str = format!("{output:?}");
         assert!(debug_str.contains("StreamingOutput"));

--- a/crates/higgs-engine/src/simple.rs
+++ b/crates/higgs-engine/src/simple.rs
@@ -2237,11 +2237,10 @@ impl SimpleEngine {
         // the first ~1024-token chunk completes.
         let _ = sender.try_send(make_progress_output(0));
         let progress_sender = sender.clone();
-        let sink_guard = higgs_models::progress::install_prefill_progress_sink(Box::new(
-            move |done, _total| {
+        let sink_guard =
+            higgs_models::progress::install_prefill_progress_sink(Box::new(move |done, _total| {
                 let _ = progress_sender.try_send(make_progress_output(done.max(0) as u32));
-            },
-        ));
+            }));
 
         let (current_token, first_logprob_data, prefill_hidden) = self.run_prefill(
             prompt_tokens,

--- a/crates/higgs-engine/src/simple.rs
+++ b/crates/higgs-engine/src/simple.rs
@@ -2012,6 +2012,7 @@ impl SimpleEngine {
                                         prompt_tokens: prompt_len,
                                         completion_tokens: completion_len,
                                         token_logprob: None,
+                                        prefill_progress: None,
                                     })
                                     .is_err()
                                 {
@@ -2083,6 +2084,7 @@ impl SimpleEngine {
                         prompt_tokens: prompt_len,
                         completion_tokens: completion_len,
                         token_logprob: None,
+                        prefill_progress: None,
                     })
                     .is_err()
                 {
@@ -2159,6 +2161,7 @@ impl SimpleEngine {
                 prompt_tokens: prompt_len,
                 completion_tokens: 0,
                 token_logprob: None,
+                prefill_progress: None,
             });
             return Ok(());
         }
@@ -2210,6 +2213,36 @@ impl SimpleEngine {
             && !logprobs
             && params.temperature == 0.0;
 
+        // Stream prefill progress: the chunked-prefill loops report
+        // suffix-relative completions through a thread-local sink; map them
+        // to absolute prompt position by adding the prefix-cache hit. Events
+        // ride the normal streaming channel as progress-only outputs.
+        // try_send: never stall prefill on a slow consumer — dropped
+        // progress events are harmless.
+        let cached = prompt_len.saturating_sub(prepared.actual_prompt_tokens.len() as u32);
+        let make_progress_output = move |suffix_done: u32| StreamingOutput {
+            new_text: String::new(),
+            finished: false,
+            finish_reason: None,
+            prompt_tokens: prompt_len,
+            completion_tokens: 0,
+            token_logprob: None,
+            prefill_progress: Some(crate::engine::PrefillProgress {
+                processed: (cached + suffix_done).min(prompt_len),
+                cached,
+                total: prompt_len,
+            }),
+        };
+        // Initial event: tells the client the total (and cache hit) before
+        // the first ~1024-token chunk completes.
+        let _ = sender.try_send(make_progress_output(0));
+        let progress_sender = sender.clone();
+        let sink_guard = higgs_models::progress::install_prefill_progress_sink(Box::new(
+            move |done, _total| {
+                let _ = progress_sender.try_send(make_progress_output(done.max(0) as u32));
+            },
+        ));
+
         let (current_token, first_logprob_data, prefill_hidden) = self.run_prefill(
             prompt_tokens,
             &mut prepared,
@@ -2218,6 +2251,8 @@ impl SimpleEngine {
             constraint.as_ref(),
             capture_mtp_prefill,
         )?;
+        // Prefill done — decode must not report progress.
+        drop(sink_guard);
 
         let mut all_tokens: Vec<u32> = Vec::new();
         let first_token_id: u32 = current_token.item();
@@ -2259,6 +2294,7 @@ impl SimpleEngine {
                 prompt_tokens: prompt_len,
                 completion_tokens: 1,
                 token_logprob: first_logprob,
+                prefill_progress: None,
             })
             .is_err()
         {
@@ -2433,6 +2469,7 @@ impl SimpleEngine {
                     prompt_tokens: prompt_len,
                     completion_tokens: completion_len,
                     token_logprob,
+                    prefill_progress: None,
                 })
                 .is_err()
             {

--- a/crates/higgs-engine/src/simple.rs
+++ b/crates/higgs-engine/src/simple.rs
@@ -2219,7 +2219,8 @@ impl SimpleEngine {
         // ride the normal streaming channel as progress-only outputs.
         // try_send: never stall prefill on a slow consumer — dropped
         // progress events are harmless.
-        let cached = prompt_len.saturating_sub(prepared.actual_prompt_tokens.len() as u32);
+        let actual_tokens = u32::try_from(prepared.actual_prompt_tokens.len()).unwrap_or(u32::MAX);
+        let cached = prompt_len.saturating_sub(actual_tokens);
         let make_progress_output = move |suffix_done: u32| StreamingOutput {
             new_text: String::new(),
             finished: false,
@@ -2239,7 +2240,9 @@ impl SimpleEngine {
         let progress_sender = sender.clone();
         let sink_guard =
             higgs_models::progress::install_prefill_progress_sink(Box::new(move |done, _total| {
-                let _ = progress_sender.try_send(make_progress_output(done.max(0) as u32));
+                let _ = progress_sender.try_send(make_progress_output(
+                    u32::try_from(done.max(0)).unwrap_or(0),
+                ));
             }));
 
         let (current_token, first_logprob_data, prefill_hidden) = self.run_prefill(

--- a/crates/higgs-engine/src/simple.rs
+++ b/crates/higgs-engine/src/simple.rs
@@ -2130,6 +2130,9 @@ impl SimpleEngine {
             top_logprobs,
             sender,
             self.enable_thinking,
+            // Non-thinking convenience entry (used by /v1/completions) never
+            // streams prefill progress.
+            false,
             constraint,
             pixel_values,
         )
@@ -2146,6 +2149,7 @@ impl SimpleEngine {
         top_logprobs: Option<u32>,
         sender: &tokio::sync::mpsc::Sender<StreamingOutput>,
         enable_thinking: bool,
+        return_progress: bool,
         constraint: Option<crate::constrained::ConstrainedGenerator>,
         pixel_values: Option<Array>,
     ) -> Result<(), EngineError> {
@@ -2176,6 +2180,7 @@ impl SimpleEngine {
                 top_logprobs,
                 sender,
                 enable_thinking,
+                return_progress,
                 constraint,
                 pixel_values,
             )
@@ -2197,6 +2202,7 @@ impl SimpleEngine {
         top_logprobs: Option<u32>,
         sender: &tokio::sync::mpsc::Sender<StreamingOutput>,
         enable_thinking: bool,
+        return_progress: bool,
         mut constraint: Option<crate::constrained::ConstrainedGenerator>,
         pixel_values: Option<Array>,
     ) -> Result<(), EngineError> {
@@ -2213,37 +2219,43 @@ impl SimpleEngine {
             && !logprobs
             && params.temperature == 0.0;
 
-        // Stream prefill progress: the chunked-prefill loops report
-        // suffix-relative completions through a thread-local sink; map them
-        // to absolute prompt position by adding the prefix-cache hit. Events
-        // ride the normal streaming channel as progress-only outputs.
-        // try_send: never stall prefill on a slow consumer — dropped
-        // progress events are harmless.
-        let actual_tokens = u32::try_from(prepared.actual_prompt_tokens.len()).unwrap_or(u32::MAX);
-        let cached = prompt_len.saturating_sub(actual_tokens);
-        let make_progress_output = move |suffix_done: u32| StreamingOutput {
-            new_text: String::new(),
-            finished: false,
-            finish_reason: None,
-            prompt_tokens: prompt_len,
-            completion_tokens: 0,
-            token_logprob: None,
-            prefill_progress: Some(crate::engine::PrefillProgress {
-                processed: (cached + suffix_done).min(prompt_len),
-                cached,
-                total: prompt_len,
-            }),
-        };
-        // Initial event: tells the client the total (and cache hit) before
-        // the first ~1024-token chunk completes.
-        let _ = sender.try_send(make_progress_output(0));
-        let progress_sender = sender.clone();
-        let sink_guard =
+        // Stream prefill progress only when the caller opted in (OpenAI
+        // `return_progress: true`). Direct higgs-engine callers and BatchEngine
+        // keep the progress-free streaming contract: no sink, no extra events.
+        //
+        // The chunked-prefill loops report suffix-relative completions through a
+        // thread-local sink; map them to absolute prompt position by adding the
+        // prefix-cache hit. Events ride the normal streaming channel as
+        // progress-only outputs. try_send: never stall prefill on a slow
+        // consumer — dropped progress events are harmless. The returned guard is
+        // held for the prefill's duration and uninstalls the sink on drop.
+        let prefill_sink = return_progress.then(|| {
+            let actual_tokens =
+                u32::try_from(prepared.actual_prompt_tokens.len()).unwrap_or(u32::MAX);
+            let cached = prompt_len.saturating_sub(actual_tokens);
+            let make_progress_output = move |suffix_done: u32| StreamingOutput {
+                new_text: String::new(),
+                finished: false,
+                finish_reason: None,
+                prompt_tokens: prompt_len,
+                completion_tokens: 0,
+                token_logprob: None,
+                prefill_progress: Some(crate::engine::PrefillProgress {
+                    processed: (cached + suffix_done).min(prompt_len),
+                    cached,
+                    total: prompt_len,
+                }),
+            };
+            // Initial event: tells the client the total (and cache hit) before
+            // the first ~1024-token chunk completes.
+            let _ = sender.try_send(make_progress_output(0));
+            let progress_sender = sender.clone();
             higgs_models::progress::install_prefill_progress_sink(Box::new(move |done, _total| {
                 let _ = progress_sender.try_send(make_progress_output(
                     u32::try_from(done.max(0)).unwrap_or(0),
                 ));
-            }));
+            }))
+        });
 
         let (current_token, first_logprob_data, prefill_hidden) = self.run_prefill(
             prompt_tokens,
@@ -2253,8 +2265,9 @@ impl SimpleEngine {
             constraint.as_ref(),
             capture_mtp_prefill,
         )?;
-        // Prefill done — decode must not report progress.
-        drop(sink_guard);
+        // Prefill done — decode must not report progress. Dropping the Option
+        // uninstalls the sink when present; a no-op when progress was off.
+        drop(prefill_sink);
 
         let mut all_tokens: Vec<u32> = Vec::new();
         let first_token_id: u32 = current_token.item();

--- a/crates/higgs-models/src/lib.rs
+++ b/crates/higgs-models/src/lib.rs
@@ -364,7 +364,12 @@ impl AnyModel {
 
         // Last chunk: forward + LM head projection on last position only.
         let last_chunk = inputs.index((.., offset..));
-        self.forward_last_token(&last_chunk, None, cache)
+        let logits = self.forward_last_token(&last_chunk, None, cache)?;
+        // The loop only reports up to the final chunk boundary; emit the
+        // terminal 100% mark once the last chunk is processed so clients don't
+        // stall just short of `total`.
+        progress::report_prefill_progress(T, T);
+        Ok(logits)
     }
 
     /// Batched decode forward pass for N requests each with 1 token.

--- a/crates/higgs-models/src/lib.rs
+++ b/crates/higgs-models/src/lib.rs
@@ -5,6 +5,7 @@ pub mod error;
 pub mod gemma2;
 pub mod llava_qwen2;
 pub mod phi3;
+pub mod progress;
 pub mod qwen3_moe;
 pub mod qwen3_next;
 pub mod registry;
@@ -358,6 +359,7 @@ impl AnyModel {
             }
             eval(targets)?;
             offset += chunk_size;
+            progress::report_prefill_progress(offset, T);
         }
 
         // Last chunk: forward + LM head projection on last position only.

--- a/crates/higgs-models/src/progress.rs
+++ b/crates/higgs-models/src/progress.rs
@@ -1,0 +1,78 @@
+//! Prefill progress reporting via a thread-scoped sink.
+//!
+//! The chunked-prefill loops live deep in the model crate with no access to
+//! the engine's streaming channel; threading a callback through every
+//! `forward_chunked` signature (the `AnyModel` zoo plus per-model overrides
+//! and their test callers) would churn a dozen call sites for one optional
+//! observer. Engines run generation on a dedicated blocking thread, so a
+//! thread-local sink installed for the duration of one prefill is exact and
+//! invisible to every other code path.
+
+use std::cell::RefCell;
+
+type Sink = Box<dyn FnMut(i32, i32)>;
+
+thread_local! {
+    static PREFILL_SINK: RefCell<Option<Sink>> = const { RefCell::new(None) };
+}
+
+/// RAII guard that removes the thread's prefill sink on drop, keeping
+/// installs scoped to a single prefill call.
+pub struct PrefillSinkGuard;
+
+impl Drop for PrefillSinkGuard {
+    fn drop(&mut self) {
+        PREFILL_SINK.with(|s| *s.borrow_mut() = None);
+    }
+}
+
+/// Install a prefill-progress sink for the current thread.
+///
+/// The sink receives `(processed, total)` in suffix-relative tokens after
+/// each completed prefill chunk. Hold the returned guard for the duration of
+/// the prefill; dropping it uninstalls the sink.
+pub fn install_prefill_progress_sink(sink: Sink) -> PrefillSinkGuard {
+    PREFILL_SINK.with(|s| *s.borrow_mut() = Some(sink));
+    PrefillSinkGuard
+}
+
+/// Report chunked-prefill progress: `processed` of `total` tokens done.
+/// No-op when no sink is installed (the common path: one `thread_local`
+/// lookup + `Option` check per ~1024-token chunk).
+pub(crate) fn report_prefill_progress(processed: i32, total: i32) {
+    PREFILL_SINK.with(|s| {
+        if let Some(f) = s.borrow_mut().as_mut() {
+            f(processed, total);
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    /// Reports reach the sink only while the guard is alive; the no-sink
+    /// path is a silent no-op (the invariant every model forward relies on).
+    #[test]
+    fn test_sink_scoped_by_guard() {
+        let seen: Rc<RefCell<Vec<(i32, i32)>>> = Rc::new(RefCell::new(Vec::new()));
+
+        // No sink installed — must not panic, must not record.
+        report_prefill_progress(512, 4096);
+        assert!(seen.borrow().is_empty());
+
+        let sink_seen = Rc::clone(&seen);
+        let guard = install_prefill_progress_sink(Box::new(move |p, t| {
+            sink_seen.borrow_mut().push((p, t));
+        }));
+        report_prefill_progress(1024, 4096);
+        report_prefill_progress(2048, 4096);
+        drop(guard);
+
+        // After the guard drops, reports are no-ops again.
+        report_prefill_progress(3072, 4096);
+        assert_eq!(*seen.borrow(), vec![(1024, 4096), (2048, 4096)]);
+    }
+}

--- a/crates/higgs-models/src/progress.rs
+++ b/crates/higgs-models/src/progress.rs
@@ -28,9 +28,18 @@ impl Drop for PrefillSinkGuard {
 
 /// Install a prefill-progress sink for the current thread.
 ///
-/// The sink receives `(processed, total)` in suffix-relative tokens after
-/// each completed prefill chunk. Hold the returned guard for the duration of
-/// the prefill; dropping it uninstalls the sink.
+/// The sink receives `(processed, total)` after each completed prefill chunk.
+/// `processed` is the cumulative number of tokens forwarded so far in *this*
+/// prefill — i.e. relative to the suffix that survived prefix-cache reuse, not
+/// a per-chunk delta and not an absolute prompt offset. Callers that want an
+/// absolute prompt position add the cached-prefix length themselves. Hold the
+/// returned guard for the duration of the prefill; dropping it uninstalls the
+/// sink.
+///
+/// The sink must not re-enter the progress machinery: calling
+/// [`report_prefill_progress`] or installing another sink from inside the sink
+/// callback panics, because the thread-local is `borrow_mut`-held while the
+/// sink runs.
 pub fn install_prefill_progress_sink(sink: Sink) -> PrefillSinkGuard {
     PREFILL_SINK.with(|s| *s.borrow_mut() = Some(sink));
     PrefillSinkGuard
@@ -39,6 +48,9 @@ pub fn install_prefill_progress_sink(sink: Sink) -> PrefillSinkGuard {
 /// Report chunked-prefill progress: `processed` of `total` tokens done.
 /// No-op when no sink is installed (the common path: one `thread_local`
 /// lookup + `Option` check per ~1024-token chunk).
+///
+/// The sink is invoked while the thread-local is `borrow_mut`-held, so the
+/// sink must not call back into this function or reinstall the sink.
 pub(crate) fn report_prefill_progress(processed: i32, total: i32) {
     PREFILL_SINK.with(|s| {
         if let Some(f) = s.borrow_mut().as_mut() {

--- a/crates/higgs-models/src/qwen3_next.rs
+++ b/crates/higgs-models/src/qwen3_next.rs
@@ -3800,6 +3800,7 @@ impl Qwen3NextCausalLM {
             }
             mlx_rs::transforms::eval(targets)?;
             offset += chunk_size;
+            crate::progress::report_prefill_progress(offset, T);
         }
 
         // Last chunk: use forward_last_token which efficiently projects only

--- a/crates/higgs-models/src/qwen3_next.rs
+++ b/crates/higgs-models/src/qwen3_next.rs
@@ -3806,7 +3806,12 @@ impl Qwen3NextCausalLM {
         // Last chunk: use forward_last_token which efficiently projects only
         // the last position through the LM head.
         let last_chunk = inputs.index((.., offset..));
-        self.forward_last_token(&last_chunk, None, kv_cache)
+        let logits = self.forward_last_token(&last_chunk, None, kv_cache)?;
+        // The loop only reports up to the final chunk boundary; emit the
+        // terminal 100% mark once the last chunk is processed so clients don't
+        // stall just short of `total`.
+        crate::progress::report_prefill_progress(T, T);
+        Ok(logits)
     }
 
     // -----------------------------------------------------------------------

--- a/crates/higgs/src/routes/anthropic.rs
+++ b/crates/higgs/src/routes/anthropic.rs
@@ -348,6 +348,8 @@ fn create_message_stream(
             None,
             &tx,
             thinking_enabled,
+            // Anthropic streaming does not surface prefill progress.
+            false,
             None,
             None,
         );

--- a/crates/higgs/src/routes/chat.rs
+++ b/crates/higgs/src/routes/chat.rs
@@ -480,6 +480,7 @@ fn chat_completions_stream(
         .stream_options
         .as_ref()
         .is_some_and(|opts| opts.include_usage.unwrap_or(false));
+    let return_progress = req.return_progress.unwrap_or(false);
     let created = current_unix_timestamp();
     let model = req.model;
     let prompt_token_count = u32::try_from(prompt_tokens.len()).unwrap_or(0);
@@ -553,6 +554,17 @@ fn chat_completions_stream(
         let mut pending_finish_logprobs: Option<ChoiceLogprobs> = None;
 
         while let Some(output) = rx.recv().await {
+            // Prefill-progress events carry no tokens: forward as
+            // `prompt_progress` chunks when the client opted in, and keep
+            // them away from the delta/tool trackers either way.
+            if let Some(p) = output.prefill_progress {
+                if return_progress {
+                    let time_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
+                    let json = writer.write_prompt_progress(p.total, p.cached, p.processed, time_ms);
+                    yield Ok(Event::default().data(json));
+                }
+                continue;
+            }
             output_token_count = output.completion_tokens;
             let chunk_logprobs = output
                 .token_logprob

--- a/crates/higgs/src/routes/chat.rs
+++ b/crates/higgs/src/routes/chat.rs
@@ -514,6 +514,7 @@ fn chat_completions_stream(
             top_logprobs,
             &tx,
             thinking_enabled_stream,
+            return_progress,
             constraint,
             pixel_values,
         );

--- a/crates/higgs/src/sse.rs
+++ b/crates/higgs/src/sse.rs
@@ -96,6 +96,26 @@ impl ChatChunkWriter {
         self.buf.push('}');
         Ok(&self.buf)
     }
+
+    /// Build a prefill-progress chunk with `choices: []` and a
+    /// `prompt_progress` block (llama.cpp-compatible shape). Emitted only
+    /// when the request set `return_progress: true`.
+    pub(crate) fn write_prompt_progress(
+        &mut self,
+        total: u32,
+        cache: u32,
+        processed: u32,
+        time_ms: u64,
+    ) -> &str {
+        use std::fmt::Write as _;
+        self.buf.clear();
+        self.buf.push_str(&self.head);
+        let _ = write!(
+            self.buf,
+            r#","choices":[],"prompt_progress":{{"total":{total},"cache":{cache},"processed":{processed},"time_ms":{time_ms}}}}}"#
+        );
+        &self.buf
+    }
 }
 
 /// Pre-serialized prefix + reusable buffer for `/v1/completions` SSE chunks.

--- a/crates/higgs/src/sse.rs
+++ b/crates/higgs/src/sse.rs
@@ -352,6 +352,23 @@ mod tests {
     }
 
     #[test]
+    fn chat_prompt_progress_chunk_is_valid_json_with_expected_shape() {
+        let id = "chatcmpl-p";
+        let model = "m";
+        let mut w = ChatChunkWriter::new(id, 11, model);
+        let got = w.write_prompt_progress(100, 30, 64, 250).to_owned();
+
+        // The buffer is concatenated by hand, so the failure mode is malformed
+        // JSON — assert it parses, then pin the exact llama.cpp-compatible wire
+        // shape (`choices: []` + a `prompt_progress` block).
+        serde_json::from_str::<serde_json::Value>(&got).unwrap();
+        let expected = format!(
+            r#"{{"id":"{id}","object":"chat.completion.chunk","created":11,"model":"{model}","choices":[],"prompt_progress":{{"total":100,"cache":30,"processed":64,"time_ms":250}}}}"#
+        );
+        assert_eq!(got, expected);
+    }
+
+    #[test]
     fn completion_chunk_matches_serde() {
         let id = "cmpl-1";
         let model = "m";

--- a/crates/higgs/src/state.rs
+++ b/crates/higgs/src/state.rs
@@ -239,6 +239,8 @@ impl Engine {
             top_logprobs,
             sender,
             self.enable_thinking(),
+            // /v1/completions convenience entry never streams prefill progress.
+            false,
             constraint,
             pixel_values,
         )
@@ -255,6 +257,7 @@ impl Engine {
         top_logprobs: Option<u32>,
         sender: &tokio::sync::mpsc::Sender<StreamingOutput>,
         enable_thinking: bool,
+        return_progress: bool,
         constraint: Option<higgs_engine::constrained::ConstrainedGenerator>,
         pixel_values: Option<Array>,
     ) -> Result<(), EngineError> {
@@ -268,6 +271,7 @@ impl Engine {
                 top_logprobs,
                 sender,
                 enable_thinking,
+                return_progress,
                 constraint,
                 pixel_values,
             ),
@@ -280,6 +284,7 @@ impl Engine {
                 top_logprobs,
                 sender,
                 enable_thinking,
+                return_progress,
                 constraint,
                 pixel_values,
             ),

--- a/crates/higgs/src/types/openai.rs
+++ b/crates/higgs/src/types/openai.rs
@@ -44,6 +44,11 @@ pub struct ChatCompletionRequest {
     /// a non-empty value such as `"low"` to explicitly enable reasoning.
     #[serde(default)]
     pub reasoning: Option<ReasoningConfig>,
+    /// When true, streaming responses include `prompt_progress` chunks during
+    /// chunked prefill (llama.cpp-compatible shape: `{total, cache,
+    /// processed, time_ms}`). Ignored for non-streaming requests.
+    #[serde(default)]
+    pub return_progress: Option<bool>,
 }
 
 /// Optional request-level controls for streaming responses.


### PR DESCRIPTION
## What

Streams prefill progress to the client during long prompt processing, using a llama.cpp-compatible `prompt_progress` field on streaming chunks. Before this, a long prefill looked like a silent hang until the first decoded token; now the client sees incremental progress as the prompt is consumed.

- A `progress` sink in `higgs-models` reports tokens-processed / total during (chunked) prefill.
- The engine forwards those updates; the OpenAI-compatible SSE layer emits them as `prompt_progress` on the stream.

## Testing

- `cargo build -p higgs` — clean.
- Independent of any other in-flight PR; applies and builds directly on `main`.

This was extracted as a standalone change from a local integration branch; it touches only the prefill-progress path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaming chat completions now support `return_progress` to emit `prompt_progress` SSE chunks during chunked prefill, showing `processed`, `cached`, `total`, and elapsed `time_ms` (OpenAI-style, llama.cpp-compatible).
  * Progress updates are optional (default `false`) and are not sent for non-streaming or non-prefill events.
* **Documentation**
  * Updated the README API/CLI streaming overview to document `return_progress: true` and the shape/meaning of `prompt_progress` chunks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->