### PR TITLE
feat(api): runtime model load/unload endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ curl http://localhost:8000/v1/chat/completions \
 - Release artifacts bundle `mlx.metallib`.
 - Source builds also require `mlx.metallib` next to the executable. Higgs now restores it automatically from Cargo build output when possible, then fails loudly if it still cannot be found.
 - `[local].raise_wired_limit` defaults to `false`. Enable it only when you explicitly want MLX to raise the process wired-memory limit.
+- `[local].allow_runtime_model_load` defaults to `false`. Enable it to load/unload models at runtime via `POST`/`DELETE /v1/models`; protect it with `server.api_key`.
 - `batch=true` is only supported for transformer families with true batched decode support.
 
 ## Performance
@@ -195,8 +196,32 @@ Measured on DeepSeek-V2-Lite-4bit with global batch sorting before `gather_qmm`.
 
 - OpenAI: `/v1/chat/completions`, `/v1/completions`, `/v1/embeddings`, `/v1/models`
 - Anthropic: `/v1/messages`, `/v1/messages/count_tokens`
+- Runtime model management (opt-in): `POST /v1/models`, `DELETE /v1/models/{name}`
 - Metrics: `/metrics`
 - Health: `/health`
+
+### Runtime model management
+
+By default the set of loaded models is fixed at startup. To add or remove models
+while the server runs, set `allow_runtime_model_load = true` under `[local]`
+(protect it with `server.api_key` -- the load endpoint can read local model
+directories and trigger downloads). Changes are in-memory only and do not persist
+to the config file.
+
+```bash
+# Load a model (body mirrors a [[models]] entry; path required)
+curl http://localhost:8000/v1/models \
+  -H "Authorization: Bearer $HIGGS_API_KEY" \
+  -d '{"path": "mlx-community/Llama-3.2-1B-Instruct-4bit", "name": "llama"}'
+
+# Unload it and free its GPU memory (204 once freed, 202 if a request is still in flight)
+curl -X DELETE http://localhost:8000/v1/models/llama \
+  -H "Authorization: Bearer $HIGGS_API_KEY"
+```
+
+An in-flight request keeps the model resident until it completes; `DELETE` removes
+it from routing immediately and frees memory once the last request drains. A model
+bound to the auto-router cannot be unloaded.
 
 **Core commands**
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ curl http://localhost:8000/v1/chat/completions \
 - Release artifacts bundle `mlx.metallib`.
 - Source builds also require `mlx.metallib` next to the executable. Higgs now restores it automatically from Cargo build output when possible, then fails loudly if it still cannot be found.
 - `[local].raise_wired_limit` defaults to `false`. Enable it only when you explicitly want MLX to raise the process wired-memory limit.
-- `[local].allow_runtime_model_load` defaults to `false`. Enable it to load/unload models at runtime via `POST`/`DELETE /v1/models`; protect it with `server.api_key`.
+- `[local].allow_runtime_model_load` defaults to `false`. Enable it to load/unload pre-downloaded models at runtime via `POST`/`DELETE /v1/models`; protect it with `server.api_key`.
 - `batch=true` is only supported for transformer families with true batched decode support.
 
 ## Performance
@@ -204,9 +204,13 @@ Measured on DeepSeek-V2-Lite-4bit with global batch sorting before `gather_qmm`.
 
 By default the set of loaded models is fixed at startup. To add or remove models
 while the server runs, set `allow_runtime_model_load = true` under `[local]`
-(protect it with `server.api_key` -- the load endpoint can read local model
-directories and trigger downloads). Changes are in-memory only and do not persist
-to the config file.
+(protect it with `server.api_key`). The load endpoint reads an existing local
+model directory or an existing Hugging Face cache entry; it does not download
+models. Changes are in-memory only and do not persist to the config file.
+With `[local].runtime_model_roots` set, local paths must resolve beneath one of
+those directories; otherwise only Hugging Face model IDs are accepted. Use
+`runtime_max_loaded_models` and `runtime_max_concurrent_loads` to bound resident
+models and simultaneous load attempts.
 
 ```bash
 # Load a model (body mirrors a [[models]] entry; path required)
@@ -214,14 +218,15 @@ curl http://localhost:8000/v1/models \
   -H "Authorization: Bearer $HIGGS_API_KEY" \
   -d '{"path": "mlx-community/Llama-3.2-1B-Instruct-4bit", "name": "llama"}'
 
-# Unload it and free its GPU memory (204 once freed, 202 if a request is still in flight)
+# Unload it and release its engine resources (204 if released immediately, 202 if release is deferred while a request is in flight)
 curl -X DELETE http://localhost:8000/v1/models/llama \
   -H "Authorization: Bearer $HIGGS_API_KEY"
 ```
 
 An in-flight request keeps the model resident until it completes; `DELETE` removes
-it from routing immediately and frees memory once the last request drains. A model
-bound to the auto-router cannot be unloaded.
+it from routing immediately and releases the engine when the last request drains.
+Allocator or process-wide cache state may remain available for reuse. A model bound
+to the auto-router cannot be unloaded.
 
 **Core commands**
 

--- a/crates/higgs/src/config.rs
+++ b/crates/higgs/src/config.rs
@@ -901,7 +901,10 @@ fn validate_config(config: &HiggsConfig, simple_mode: bool) -> Result<(), String
             return Err("server.api_key contains invalid characters".to_owned());
         }
     }
-
+    validate_runtime_model_load_api_key(config)?;
+    for root in &config.local.runtime_model_roots {
+        crate::model_resolver::validate_runtime_model_root(root)?;
+    }
     if config.local.runtime_max_concurrent_loads == 0 {
         return Err("runtime_max_concurrent_loads must be greater than zero".to_owned());
     }
@@ -923,6 +926,15 @@ fn validate_config(config: &HiggsConfig, simple_mode: bool) -> Result<(), String
         }
     }
 
+    Ok(())
+}
+
+fn validate_runtime_model_load_api_key(config: &HiggsConfig) -> Result<(), String> {
+    if config.local.allow_runtime_model_load && config.server.api_key.is_none() {
+        return Err(
+            "server.api_key is required when local.allow_runtime_model_load is enabled".to_owned(),
+        );
+    }
     Ok(())
 }
 
@@ -1207,6 +1219,43 @@ mod tests {
 
         let err = load_config_file(&path, None).unwrap_err();
         assert!(err.contains("server.api_key contains invalid characters"));
+    }
+
+    #[test]
+    fn test_runtime_model_load_without_api_key_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            "[provider.stub]\nurl = \"http://127.0.0.1:1\"\n\n[local]\nallow_runtime_model_load = true\n",
+        )
+        .unwrap();
+
+        let err = load_config_file(&path, None).unwrap_err();
+        assert!(
+            err.contains(
+                "server.api_key is required when local.allow_runtime_model_load is enabled"
+            )
+        );
+    }
+
+    #[test]
+    fn test_invalid_runtime_model_root_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("not-a-directory");
+        std::fs::write(&file, "not a directory").unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            format!(
+                "[provider.stub]\nurl = \"http://127.0.0.1:1\"\n\n[local]\nruntime_model_roots = [\"{}\"]\n",
+                file.display()
+            ),
+        )
+        .unwrap();
+
+        let err = load_config_file(&path, None).unwrap_err();
+        assert!(err.contains("is not a directory"), "got: {err}");
     }
 
     #[test]

--- a/crates/higgs/src/config.rs
+++ b/crates/higgs/src/config.rs
@@ -365,11 +365,38 @@ pub struct LocalConfig {
     pub raise_wired_limit: bool,
     /// Allow loading and unloading models at runtime via `POST`/`DELETE /v1/models`.
     ///
-    /// Off by default: the load endpoint can read arbitrary local model
-    /// directories and trigger downloads, so it is opt-in and only reachable by
-    /// authenticated operators.
+    /// Off by default: the load endpoint reads local model directories but does
+    /// not download them, so it is opt-in and only reachable by authenticated
+    /// operators. Requires
+    /// `server.api_key` to be set (the doctor fails otherwise, since without
+    /// an api key the mutating endpoints would be unauthenticated).
     #[serde(default)]
     pub allow_runtime_model_load: bool,
+    /// Optional allowlist of local directory roots a runtime load may read.
+    ///
+    /// When non-empty, `POST /v1/models` accepts Hugging Face model ids
+    /// (resolved through the local HF cache) and absolute or relative paths
+    /// that resolve inside one of these roots; anything else is a 400.
+    /// Empty (the default) means only Hugging Face model ids are accepted —
+    /// no arbitrary local filesystem reads from caller-supplied paths.
+    #[serde(default)]
+    pub runtime_model_roots: Vec<String>,
+    /// Maximum number of models that may be resident via runtime loads.
+    ///
+    /// Counts only models loaded through `POST /v1/models`; startup-configured
+    /// models are not budgeted. `None` (the default) means no explicit cap —
+    /// memory is still bounded by the machine and by
+    /// `runtime_max_concurrent_loads` serializing loads. A typical value on a
+    /// 64 GB host is 1-2 large models.
+    #[serde(default)]
+    pub runtime_max_loaded_models: Option<usize>,
+    /// Maximum number of runtime load attempts that may run concurrently.
+    ///
+    /// Each load is GPU- and memory-heavy; concurrent loads of large models
+    /// can out-of-memory the host before any single load fails. Default 1
+    /// (loads serialize).
+    #[serde(default = "default_runtime_max_concurrent_loads")]
+    pub runtime_max_concurrent_loads: usize,
     /// Internal requested profile after resolving precedence (`model` > `--mlx-profile` > `HIGGS_MLX_PROFILE` > local default).
     #[serde(skip, default)]
     pub requested_mlx_profile: RequestedMlxProfile,
@@ -381,9 +408,16 @@ impl Default for LocalConfig {
             mlx_profile: MlxProfile::Auto,
             raise_wired_limit: false,
             allow_runtime_model_load: false,
+            runtime_model_roots: Vec::new(),
+            runtime_max_loaded_models: None,
+            runtime_max_concurrent_loads: default_runtime_max_concurrent_loads(),
             requested_mlx_profile: RequestedMlxProfile::Auto,
         }
     }
+}
+
+const fn default_runtime_max_concurrent_loads() -> usize {
+    1
 }
 
 // -- Model config -----------------------------------------------------------
@@ -859,6 +893,36 @@ fn validate_config(config: &HiggsConfig, simple_mode: bool) -> Result<(), String
         return Err("timeout must be a finite, positive number".to_owned());
     }
 
+    if let Some(api_key) = config.server.api_key.as_deref() {
+        if api_key.trim().is_empty() {
+            return Err("server.api_key must not be blank".to_owned());
+        }
+        if api_key.bytes().any(|byte| byte <= b' ' || byte >= 0x7f) {
+            return Err("server.api_key contains invalid characters".to_owned());
+        }
+    }
+
+    if config.local.runtime_max_concurrent_loads == 0 {
+        return Err("runtime_max_concurrent_loads must be greater than zero".to_owned());
+    }
+    if config.local.runtime_max_concurrent_loads > tokio::sync::Semaphore::MAX_PERMITS {
+        return Err(format!(
+            "runtime_max_concurrent_loads exceeds Tokio's maximum of {}",
+            tokio::sync::Semaphore::MAX_PERMITS
+        ));
+    }
+    if let Some(max_loaded) = config.local.runtime_max_loaded_models {
+        if max_loaded == 0 {
+            return Err("runtime_max_loaded_models must be greater than zero".to_owned());
+        }
+        if max_loaded > tokio::sync::Semaphore::MAX_PERMITS {
+            return Err(format!(
+                "runtime_max_loaded_models exceeds Tokio's maximum of {}",
+                tokio::sync::Semaphore::MAX_PERMITS
+            ));
+        }
+    }
+
     Ok(())
 }
 
@@ -1095,11 +1159,71 @@ mod tests {
         assert!(config.server.api_key.is_none());
         assert_eq!(config.server.rate_limit, 0);
         assert_eq!(config.local.mlx_profile, MlxProfile::Auto);
+        assert_eq!(config.local.runtime_max_concurrent_loads, 1);
         assert_eq!(
             config.local.requested_mlx_profile,
             RequestedMlxProfile::Auto
         );
         assert_eq!(config.default.provider, "higgs");
+    }
+
+    #[test]
+    fn test_zero_runtime_concurrent_loads_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            "[provider.stub]\nurl = \"http://127.0.0.1:1\"\n\n[local]\nruntime_max_concurrent_loads = 0\n",
+        )
+        .unwrap();
+
+        let err = load_config_file(&path, None).unwrap_err();
+        assert!(err.contains("runtime_max_concurrent_loads must be greater than zero"));
+    }
+
+    #[test]
+    fn test_blank_api_key_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            "[provider.stub]\nurl = \"http://127.0.0.1:1\"\n\n[server]\napi_key = \"   \"\n",
+        )
+        .unwrap();
+
+        let err = load_config_file(&path, None).unwrap_err();
+        assert!(err.contains("server.api_key must not be blank"));
+    }
+
+    #[test]
+    fn test_control_character_api_key_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            "[provider.stub]\nurl = \"http://127.0.0.1:1\"\n\n[server]\napi_key = \"bad\\u0001key\"\n",
+        )
+        .unwrap();
+
+        let err = load_config_file(&path, None).unwrap_err();
+        assert!(err.contains("server.api_key contains invalid characters"));
+    }
+
+    #[test]
+    fn test_runtime_semaphore_limits_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let too_many = tokio::sync::Semaphore::MAX_PERMITS + 1;
+        std::fs::write(
+            &path,
+            format!(
+                "[provider.stub]\nurl = \"http://127.0.0.1:1\"\n\n[local]\nruntime_max_concurrent_loads = {too_many}\nruntime_max_loaded_models = {too_many}\n"
+            ),
+        )
+        .unwrap();
+
+        let err = load_config_file(&path, None).unwrap_err();
+        assert!(err.contains("runtime_max_concurrent_loads exceeds"));
     }
 
     #[test]

--- a/crates/higgs/src/config.rs
+++ b/crates/higgs/src/config.rs
@@ -363,6 +363,13 @@ pub struct LocalConfig {
     /// Raise MLX's wired memory limit to the device-recommended maximum.
     #[serde(default)]
     pub raise_wired_limit: bool,
+    /// Allow loading and unloading models at runtime via `POST`/`DELETE /v1/models`.
+    ///
+    /// Off by default: the load endpoint can read arbitrary local model
+    /// directories and trigger downloads, so it is opt-in and only reachable by
+    /// authenticated operators.
+    #[serde(default)]
+    pub allow_runtime_model_load: bool,
     /// Internal requested profile after resolving precedence (`model` > `--mlx-profile` > `HIGGS_MLX_PROFILE` > local default).
     #[serde(skip, default)]
     pub requested_mlx_profile: RequestedMlxProfile,
@@ -373,6 +380,7 @@ impl Default for LocalConfig {
         Self {
             mlx_profile: MlxProfile::Auto,
             raise_wired_limit: false,
+            allow_runtime_model_load: false,
             requested_mlx_profile: RequestedMlxProfile::Auto,
         }
     }

--- a/crates/higgs/src/daemon.rs
+++ b/crates/higgs/src/daemon.rs
@@ -102,7 +102,7 @@ pub fn cmd_stop(profile: Option<&str>, force: bool) -> i32 {
     }
 }
 
-#[allow(clippy::print_stderr)]
+#[allow(clippy::print_stderr, clippy::too_many_lines)]
 pub fn cmd_init(profile: Option<&str>) {
     let dir = config::config_dir();
     let filename = profile.map_or_else(
@@ -148,6 +148,9 @@ port = 8000
 # Allow loading/unloading models at runtime via POST/DELETE /v1/models.
 # Off by default; protect with server.api_key before enabling.
 # allow_runtime_model_load = false
+# runtime_model_roots = ["/models"]
+# runtime_max_loaded_models = 2
+# runtime_max_concurrent_loads = 1
 
 # --- Local models ---
 # Each [[models]] entry loads an MLX model into GPU memory.

--- a/crates/higgs/src/daemon.rs
+++ b/crates/higgs/src/daemon.rs
@@ -145,6 +145,9 @@ port = 8000
 
 # [local]
 # mlx_profile = "auto"
+# Allow loading/unloading models at runtime via POST/DELETE /v1/models.
+# Off by default; protect with server.api_key before enabling.
+# allow_runtime_model_load = false
 
 # --- Local models ---
 # Each [[models]] entry loads an MLX model into GPU memory.

--- a/crates/higgs/src/doctor.rs
+++ b/crates/higgs/src/doctor.rs
@@ -52,6 +52,7 @@ pub async fn run_doctor(
     check_route_consistency(config, &mut result);
     check_default_provider(config, &mut result);
     check_auto_router(config, &mut result);
+    check_runtime_model_load(config, &mut result);
     check_port_availability(config, &mut result);
     check_orphaned_providers(config, &mut result);
 
@@ -327,6 +328,17 @@ fn check_models(config: &HiggsConfig, result: &mut DoctorResult) {
             }
             Err(err) => fail(&format!("model {label} not found: {err}"), result),
         }
+    }
+}
+
+fn check_runtime_model_load(config: &HiggsConfig, result: &mut DoctorResult) {
+    if config.local.allow_runtime_model_load {
+        warn(
+            "local.allow_runtime_model_load is enabled: POST/DELETE /v1/models can load and unload models at runtime; ensure server.api_key restricts this to trusted operators",
+            result,
+        );
+    } else {
+        pass("runtime model load/unload disabled", result);
     }
 }
 

--- a/crates/higgs/src/doctor.rs
+++ b/crates/higgs/src/doctor.rs
@@ -71,6 +71,10 @@ fn check_config_valid(result: &mut DoctorResult) {
 
 fn check_server_section(config: &crate::config::HiggsConfig, result: &mut DoctorResult) {
     let server = &config.server;
+    let has_api_key = server
+        .api_key
+        .as_deref()
+        .is_some_and(|api_key| !api_key.trim().is_empty());
 
     if server.max_tokens == 0 {
         fail(
@@ -130,7 +134,7 @@ fn check_server_section(config: &crate::config::HiggsConfig, result: &mut Doctor
         );
     }
 
-    if server.api_key.is_some() {
+    if has_api_key {
         pass("server.api_key set; API key auth enabled", result);
     } else {
         pass(
@@ -143,7 +147,7 @@ fn check_server_section(config: &crate::config::HiggsConfig, result: &mut Doctor
         server.host.parse::<std::net::IpAddr>(),
         Ok(ip) if !ip.is_loopback()
     );
-    if non_loopback && server.api_key.is_none() {
+    if non_loopback && !has_api_key {
         warn(
             &format!(
                 "server.host=\"{}\" is reachable from the network but server.api_key is unset; \
@@ -333,10 +337,29 @@ fn check_models(config: &HiggsConfig, result: &mut DoctorResult) {
 
 fn check_runtime_model_load(config: &HiggsConfig, result: &mut DoctorResult) {
     if config.local.allow_runtime_model_load {
-        warn(
-            "local.allow_runtime_model_load is enabled: POST/DELETE /v1/models can load and unload models at runtime; ensure server.api_key restricts this to trusted operators",
-            result,
-        );
+        // The runtime-load endpoints are mutating admin surface. When no
+        // server.api_key is configured the bearer-auth layer is not installed
+        // at all, so POST/DELETE /v1/models (with permissive CORS) would be
+        // fully unauthenticated. That combination is the dangerous config the
+        // feature docs caution against, so it fails the doctor outright.
+        let has_api_key = config
+            .server
+            .api_key
+            .as_deref()
+            .is_some_and(|api_key| !api_key.trim().is_empty());
+        if has_api_key {
+            pass(
+                "runtime model load/unload enabled; server.api_key restricts it",
+                result,
+            );
+        } else {
+            fail(
+                "local.allow_runtime_model_load is enabled but server.api_key is unset: \
+                 POST/DELETE /v1/models would be unauthenticated. Set server.api_key \
+                 or disable local.allow_runtime_model_load",
+                result,
+            );
+        }
     } else {
         pass("runtime model load/unload disabled", result);
     }
@@ -593,6 +616,42 @@ mod tests {
         fail("test", &mut result);
         assert_eq!(result.passes, 0);
         assert_eq!(result.warnings, 0);
+        assert_eq!(result.failures, 1);
+    }
+
+    #[test]
+    fn runtime_load_without_api_key_fails_doctor() {
+        let mut config = HiggsConfig::default();
+        config.local.allow_runtime_model_load = true;
+        let mut result = empty_result();
+
+        check_runtime_model_load(&config, &mut result);
+
+        assert_eq!(result.failures, 1);
+    }
+
+    #[test]
+    fn runtime_load_with_api_key_passes_doctor() {
+        let mut config = HiggsConfig::default();
+        config.local.allow_runtime_model_load = true;
+        config.server.api_key = Some("test-key".to_owned());
+        let mut result = empty_result();
+
+        check_runtime_model_load(&config, &mut result);
+
+        assert_eq!(result.failures, 0);
+        assert_eq!(result.passes, 1);
+    }
+
+    #[test]
+    fn runtime_load_with_blank_api_key_fails_doctor() {
+        let mut config = HiggsConfig::default();
+        config.local.allow_runtime_model_load = true;
+        config.server.api_key = Some("  ".to_owned());
+        let mut result = empty_result();
+
+        check_runtime_model_load(&config, &mut result);
+
         assert_eq!(result.failures, 1);
     }
 

--- a/crates/higgs/src/doctor.rs
+++ b/crates/higgs/src/doctor.rs
@@ -363,6 +363,16 @@ fn check_runtime_model_load(config: &HiggsConfig, result: &mut DoctorResult) {
     } else {
         pass("runtime model load/unload disabled", result);
     }
+
+    for root in &config.local.runtime_model_roots {
+        match model_resolver::validate_runtime_model_root(root) {
+            Ok(()) => pass(
+                &format!("runtime model root '{root}' is resolvable"),
+                result,
+            ),
+            Err(err) => fail(&err, result),
+        }
+    }
 }
 
 fn check_duplicate_models(config: &HiggsConfig, result: &mut DoctorResult) {
@@ -652,6 +662,21 @@ mod tests {
 
         check_runtime_model_load(&config, &mut result);
 
+        assert_eq!(result.failures, 1);
+    }
+
+    #[test]
+    fn runtime_load_with_unresolvable_root_fails_doctor() {
+        let missing_root = tempfile::tempdir().unwrap().path().join("missing-root");
+        let mut config = HiggsConfig::default();
+        config.local.allow_runtime_model_load = true;
+        config.local.runtime_model_roots = vec![missing_root.to_string_lossy().into_owned()];
+        config.server.api_key = Some("test-key".to_owned());
+        let mut result = empty_result();
+
+        check_runtime_model_load(&config, &mut result);
+
+        assert_eq!(result.passes, 1);
         assert_eq!(result.failures, 1);
     }
 

--- a/crates/higgs/src/error.rs
+++ b/crates/higgs/src/error.rs
@@ -31,6 +31,12 @@ pub enum ServerError {
     #[error("Model not found: {0}")]
     ModelNotFound(String),
 
+    #[error("Conflict: {0}")]
+    Conflict(String),
+
+    #[error("Forbidden: {0}")]
+    Forbidden(String),
+
     #[error("Internal error: {0}")]
     InternalError(String),
 
@@ -59,6 +65,8 @@ impl IntoResponse for ServerError {
                 "model_not_found",
                 format!("Model '{model}' is not loaded"),
             ),
+            Self::Conflict(msg) => (StatusCode::CONFLICT, "conflict", msg.clone()),
+            Self::Forbidden(msg) => (StatusCode::FORBIDDEN, "forbidden", msg.clone()),
             Self::InternalError(msg) => {
                 tracing::error!(error = %msg, "Internal error");
                 (

--- a/crates/higgs/src/error.rs
+++ b/crates/higgs/src/error.rs
@@ -226,6 +226,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_conflict_returns_409_with_contract_body() {
+        let message = "model is already loaded";
+        let resp = ServerError::Conflict(message.to_owned()).into_response();
+        let (status, body) = response_status_and_body(resp).await;
+
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert_eq!(body["error"]["type"], "conflict");
+        assert_eq!(body["error"]["message"], message);
+        assert!(body["error"]["code"].is_null());
+    }
+
+    #[tokio::test]
+    async fn test_forbidden_returns_403_with_contract_body() {
+        let message = "runtime model loading is disabled";
+        let resp = ServerError::Forbidden(message.to_owned()).into_response();
+        let (status, body) = response_status_and_body(resp).await;
+
+        assert_eq!(status, StatusCode::FORBIDDEN);
+        assert_eq!(body["error"]["type"], "forbidden");
+        assert_eq!(body["error"]["message"], message);
+        assert!(body["error"]["code"].is_null());
+    }
+
+    #[tokio::test]
     async fn test_proxy_error_returns_502() {
         let error = ServerError::ProxyError("connection refused".to_owned());
         let resp = error.into_response();

--- a/crates/higgs/src/lib.rs
+++ b/crates/higgs/src/lib.rs
@@ -33,7 +33,7 @@ use axum::{
     http::{HeaderValue, StatusCode},
     middleware::{self, Next},
     response::Response,
-    routing::{get, post},
+    routing::{delete, get, post},
 };
 use governor::{Quota, RateLimiter, clock::DefaultClock, state::keyed::DefaultKeyedStateStore};
 use tower_http::{
@@ -67,7 +67,11 @@ pub fn build_router(
 
     let mut api_routes = Router::new()
         .route("/metrics", get(routes::metrics::metrics))
-        .route("/v1/models", get(routes::models::list_models))
+        .route(
+            "/v1/models",
+            get(routes::models::list_models).post(routes::models::load_model),
+        )
+        .route("/v1/models/{name}", delete(routes::models::unload_model))
         .route("/v1/chat/completions", post(routes::chat::chat_completions))
         .route("/v1/completions", post(routes::completions::completions))
         .route("/v1/embeddings", post(routes::embeddings::embeddings))

--- a/crates/higgs/src/lib.rs
+++ b/crates/higgs/src/lib.rs
@@ -54,7 +54,7 @@ pub(crate) fn test_env_lock() -> &'static std::sync::Mutex<()> {
 }
 
 /// Build the Axum router with all routes and middleware.
-#[allow(clippy::needless_pass_by_value)]
+#[allow(clippy::needless_pass_by_value, clippy::significant_drop_tightening)]
 pub fn build_router(
     state: SharedState,
     timeout_secs: f64,

--- a/crates/higgs/src/main.rs
+++ b/crates/higgs/src/main.rs
@@ -8,7 +8,6 @@ use std::sync::Arc;
 use std::time::SystemTime;
 
 use clap::Parser;
-use higgs_engine::mlx_tuning::resolve_runtime_tuning;
 
 use higgs::{
     build_router,
@@ -18,7 +17,7 @@ use higgs::{
     },
     model_download, model_resolver,
     router::Router,
-    state::{AppState, Engine},
+    state::{AppState, Engine, build_engine},
 };
 
 #[tokio::main]
@@ -292,29 +291,7 @@ fn load_engines(
         };
 
         tracing::info!(model = %model_path, resolved = %resolved.display(), "Loading model");
-        if model_cfg.batch && !config::resolved_model_supports_batch(&resolved)? {
-            return Err(format!(
-                "batch=true is only supported for transformer models (llama, mistral, qwen2, qwen3); {model_path} is not supported"
-            )
-            .into());
-        }
-        let kv_cache_config = model_cfg.kv_cache_config();
-        let engine = if model_cfg.batch {
-            Engine::load_batch(&resolved, kv_cache_config, config.local.raise_wired_limit)?
-        } else {
-            let tuning =
-                resolve_runtime_tuning(&resolved, model_cfg.requested_mlx_profile(&config.local));
-            Engine::load_simple(
-                &resolved,
-                kv_cache_config,
-                tuning,
-                config.local.raise_wired_limit,
-            )?
-        };
-        let name = model_cfg
-            .name
-            .clone()
-            .unwrap_or_else(|| engine.model_name().to_owned());
+        let (name, engine) = build_engine(&resolved, model_cfg, &config.local)?;
         tracing::info!(model_name = %name, "Model loaded");
 
         if engines.insert(name.clone(), Arc::new(engine)).is_some() {

--- a/crates/higgs/src/main.rs
+++ b/crates/higgs/src/main.rs
@@ -143,6 +143,7 @@ fn load_config_for_command(cli: &Cli) -> Result<HiggsConfig, Box<dyn std::error:
     config::load_config_file(&path, None).map_err(Into::into)
 }
 
+#[allow(clippy::significant_drop_tightening)]
 async fn cmd_serve(cli: &Cli, args: &ServeArgs) -> Result<(), Box<dyn std::error::Error>> {
     init_tracing(cli.verbose);
 

--- a/crates/higgs/src/model_resolver.rs
+++ b/crates/higgs/src/model_resolver.rs
@@ -36,24 +36,6 @@ pub fn is_hf_model_id(s: &str) -> bool {
     matches!(s.split_once('/'), Some((org, name)) if !org.is_empty() && !name.is_empty() && !name.contains('/'))
 }
 
-/// Policy gate for caller-supplied runtime-load paths.
-///
-/// Accepts Hugging Face model ids (which resolve through the local HF cache,
-/// not the caller's filesystem) unless the same string names an existing local
-/// directory. Local paths are accepted only when they resolve (after `~`
-/// expansion and symlink resolution) inside one of `roots`. Returns a reason
-/// string on rejection.
-#[cfg(test)]
-fn runtime_load_path_allowed(path: &str, roots: &[String]) -> Result<(), String> {
-    // A syntactically valid `org/name` can also be a relative local
-    // directory. `resolve` prefers existing directories, so do not let that
-    // local path bypass the filesystem allowlist.
-    if is_hf_model_id(path) && !Path::new(path).is_dir() {
-        return Ok(());
-    }
-    canonical_runtime_local_path(path, roots).map(|_| ())
-}
-
 /// Resolve and authorize one runtime-load request, returning the exact path
 /// that the loader must use.
 ///
@@ -96,13 +78,7 @@ fn canonical_runtime_local_path(path: &str, roots: &[String]) -> Result<PathBuf,
         .canonicalize()
         .map_err(|e| format!("path '{path}' cannot be resolved: {e}"))?;
     for root in roots {
-        let root_expanded = expand_user_path(root);
-        let root_canonical = root_expanded.canonicalize().map_err(|e| {
-            format!(
-                "configured local.runtime_model_roots entry '{}' cannot be resolved: {e}",
-                root_expanded.display()
-            )
-        })?;
+        let root_canonical = canonical_runtime_model_root(root)?;
         if canonical.starts_with(&root_canonical) {
             return Ok(canonical);
         }
@@ -110,6 +86,31 @@ fn canonical_runtime_local_path(path: &str, roots: &[String]) -> Result<PathBuf,
     Err(format!(
         "path '{path}' is outside all configured local.runtime_model_roots"
     ))
+}
+
+pub(crate) fn validate_runtime_model_root(root: &str) -> Result<(), String> {
+    canonical_runtime_model_root(root).map(|_| ())
+}
+
+fn canonical_runtime_model_root(root: &str) -> Result<PathBuf, String> {
+    if root.trim().is_empty() {
+        return Err("configured local.runtime_model_roots entry must not be blank".to_owned());
+    }
+
+    let expanded = expand_user_path(root);
+    let canonical = expanded.canonicalize().map_err(|e| {
+        format!(
+            "configured local.runtime_model_roots entry '{}' cannot be resolved: {e}",
+            expanded.display()
+        )
+    })?;
+    if !canonical.is_dir() {
+        return Err(format!(
+            "configured local.runtime_model_roots entry '{}' is not a directory",
+            expanded.display()
+        ));
+    }
+    Ok(canonical)
 }
 
 fn expand_user_path(path: &str) -> PathBuf {
@@ -368,31 +369,76 @@ mod tests {
     }
 
     #[test]
-    fn test_runtime_policy_does_not_treat_existing_relative_directory_as_hf_id() {
+    fn test_runtime_resolver_rejects_existing_relative_directory_without_roots() {
         assert!(Path::new("src/.").is_dir());
-        assert!(runtime_load_path_allowed("src/.", &[]).is_err());
+        let error = resolve_runtime_model_with_cache("src/.", &[], None).unwrap_err();
+
+        assert_eq!(
+            error,
+            "path 'src/.' is not a Hugging Face model id and local.runtime_model_roots is empty; \
+             use an HF model id or configure local.runtime_model_roots"
+        );
     }
 
     #[test]
-    fn test_runtime_policy_allows_hf_id_without_local_roots() {
-        assert!(runtime_load_path_allowed("org/model", &[]).is_ok());
+    fn test_runtime_resolver_allows_hf_id_to_reach_cache_resolution() {
+        let error = resolve_runtime_model_with_cache("org/model", &[], None).unwrap_err();
+
+        assert_eq!(
+            error,
+            "Hugging Face cache is not configured for 'org/model'"
+        );
     }
 
     #[test]
-    fn test_runtime_policy_allows_existing_directory_inside_root() {
-        assert!(runtime_load_path_allowed("src/.", &["src".to_owned()]).is_ok());
+    fn test_runtime_resolver_allows_existing_directory_inside_root() {
+        let resolved =
+            resolve_runtime_model_with_cache("src/.", &["src".to_owned()], None).unwrap();
+
+        assert_eq!(resolved, Path::new("src").canonicalize().unwrap());
     }
 
     #[test]
-    fn test_runtime_policy_reports_unresolvable_configured_root() {
+    fn test_runtime_resolver_reports_unresolvable_configured_root() {
         let model_root = tempfile::tempdir().unwrap();
         let missing_root = model_root.path().join("missing-root");
         let model = model_root.path().join("model");
         std::fs::create_dir(&model).unwrap();
         let roots = vec![missing_root.to_string_lossy().into_owned()];
 
-        let error = runtime_load_path_allowed(model.to_str().unwrap(), &roots).unwrap_err();
-        assert!(error.contains("configured local.runtime_model_roots entry"));
+        let error =
+            resolve_runtime_model_with_cache(model.to_str().unwrap(), &roots, None).unwrap_err();
+        assert!(error.starts_with(&format!(
+            "configured local.runtime_model_roots entry '{}' cannot be resolved:",
+            missing_root.display()
+        )));
+    }
+
+    #[test]
+    fn test_validate_runtime_model_root_rejects_blank_root() {
+        for root in ["", "  \t"] {
+            let error = validate_runtime_model_root(root).unwrap_err();
+            assert_eq!(
+                error,
+                "configured local.runtime_model_roots entry must not be blank"
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_runtime_model_root_rejects_file() {
+        let root = tempfile::tempdir().unwrap();
+        let file = root.path().join("model-file");
+        std::fs::write(&file, "not a directory").unwrap();
+
+        let error = validate_runtime_model_root(file.to_str().unwrap()).unwrap_err();
+        assert_eq!(
+            error,
+            format!(
+                "configured local.runtime_model_roots entry '{}' is not a directory",
+                file.display()
+            )
+        );
     }
 
     #[test]
@@ -407,17 +453,24 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn test_runtime_policy_rejects_symlink_escape_from_root() {
+    fn test_runtime_resolver_rejects_symlink_escape_from_root() {
         let root = tempfile::tempdir().unwrap();
         let outside = tempfile::tempdir().unwrap();
         let outside_model = outside.path().join("model");
         std::fs::create_dir(&outside_model).unwrap();
-        std::os::unix::fs::symlink(&outside_model, root.path().join("linked-model")).unwrap();
+        let linked_model = root.path().join("linked-model");
+        std::os::unix::fs::symlink(&outside_model, &linked_model).unwrap();
 
         let roots = vec![root.path().to_string_lossy().into_owned()];
-        assert!(
-            runtime_load_path_allowed(root.path().join("linked-model").to_str().unwrap(), &roots)
-                .is_err()
+        let error = resolve_runtime_model_with_cache(linked_model.to_str().unwrap(), &roots, None)
+            .unwrap_err();
+
+        assert_eq!(
+            error,
+            format!(
+                "path '{}' is outside all configured local.runtime_model_roots",
+                linked_model.display()
+            )
         );
     }
 

--- a/crates/higgs/src/model_resolver.rs
+++ b/crates/higgs/src/model_resolver.rs
@@ -36,6 +36,92 @@ pub fn is_hf_model_id(s: &str) -> bool {
     matches!(s.split_once('/'), Some((org, name)) if !org.is_empty() && !name.is_empty() && !name.contains('/'))
 }
 
+/// Policy gate for caller-supplied runtime-load paths.
+///
+/// Accepts Hugging Face model ids (which resolve through the local HF cache,
+/// not the caller's filesystem) unless the same string names an existing local
+/// directory. Local paths are accepted only when they resolve (after `~`
+/// expansion and symlink resolution) inside one of `roots`. Returns a reason
+/// string on rejection.
+#[cfg(test)]
+fn runtime_load_path_allowed(path: &str, roots: &[String]) -> Result<(), String> {
+    // A syntactically valid `org/name` can also be a relative local
+    // directory. `resolve` prefers existing directories, so do not let that
+    // local path bypass the filesystem allowlist.
+    if is_hf_model_id(path) && !Path::new(path).is_dir() {
+        return Ok(());
+    }
+    canonical_runtime_local_path(path, roots).map(|_| ())
+}
+
+/// Resolve and authorize one runtime-load request, returning the exact path
+/// that the loader must use.
+///
+/// HF-shaped inputs are resolved cache-only after the initial local-directory
+/// check; they are never passed back through `resolve`, which prefers
+/// caller-relative directories.
+pub fn resolve_runtime_model(path: &str, roots: &[String]) -> Result<PathBuf, String> {
+    resolve_runtime_model_with_cache(path, roots, default_hf_cache().as_deref())
+}
+
+fn resolve_runtime_model_with_cache(
+    path: &str,
+    roots: &[String],
+    cache_root: Option<&Path>,
+) -> Result<PathBuf, String> {
+    if is_hf_model_id(path) && !Path::new(path).is_dir() {
+        let (org, name) = path
+            .split_once('/')
+            .ok_or_else(|| format!("invalid Hugging Face model id '{path}'"))?;
+        let snapshot = cache_root
+            .ok_or_else(|| format!("Hugging Face cache is not configured for '{path}'"))
+            .and_then(|cache| resolve_hf_snapshot(cache, org, name))?;
+        return snapshot
+            .canonicalize()
+            .map_err(|e| format!("cached model '{path}' cannot be resolved: {e}"));
+    }
+
+    canonical_runtime_local_path(path, roots)
+}
+
+fn canonical_runtime_local_path(path: &str, roots: &[String]) -> Result<PathBuf, String> {
+    if roots.is_empty() {
+        return Err(format!(
+            "path '{path}' is not a Hugging Face model id and local.runtime_model_roots is empty; \
+             use an HF model id or configure local.runtime_model_roots"
+        ));
+    }
+    let expanded = expand_user_path(path);
+    let canonical = expanded
+        .canonicalize()
+        .map_err(|e| format!("path '{path}' cannot be resolved: {e}"))?;
+    for root in roots {
+        let root_expanded = expand_user_path(root);
+        let root_canonical = root_expanded.canonicalize().map_err(|e| {
+            format!(
+                "configured local.runtime_model_roots entry '{}' cannot be resolved: {e}",
+                root_expanded.display()
+            )
+        })?;
+        if canonical.starts_with(&root_canonical) {
+            return Ok(canonical);
+        }
+    }
+    Err(format!(
+        "path '{path}' is outside all configured local.runtime_model_roots"
+    ))
+}
+
+fn expand_user_path(path: &str) -> PathBuf {
+    path.strip_prefix("~/").map_or_else(
+        || PathBuf::from(path),
+        |rest| {
+            directories::BaseDirs::new()
+                .map_or_else(|| PathBuf::from(path), |d| d.home_dir().join(rest))
+        },
+    )
+}
+
 /// Testable resolver with explicit cache root.
 fn resolve_with_cache(path: &str, cache_root: Option<&Path>) -> Result<PathBuf, String> {
     let as_path = Path::new(path);
@@ -279,6 +365,60 @@ mod tests {
     #[test]
     fn test_is_hf_model_id_empty_name_is_false() {
         assert!(!is_hf_model_id("org/"));
+    }
+
+    #[test]
+    fn test_runtime_policy_does_not_treat_existing_relative_directory_as_hf_id() {
+        assert!(Path::new("src/.").is_dir());
+        assert!(runtime_load_path_allowed("src/.", &[]).is_err());
+    }
+
+    #[test]
+    fn test_runtime_policy_allows_hf_id_without_local_roots() {
+        assert!(runtime_load_path_allowed("org/model", &[]).is_ok());
+    }
+
+    #[test]
+    fn test_runtime_policy_allows_existing_directory_inside_root() {
+        assert!(runtime_load_path_allowed("src/.", &["src".to_owned()]).is_ok());
+    }
+
+    #[test]
+    fn test_runtime_policy_reports_unresolvable_configured_root() {
+        let model_root = tempfile::tempdir().unwrap();
+        let missing_root = model_root.path().join("missing-root");
+        let model = model_root.path().join("model");
+        std::fs::create_dir(&model).unwrap();
+        let roots = vec![missing_root.to_string_lossy().into_owned()];
+
+        let error = runtime_load_path_allowed(model.to_str().unwrap(), &roots).unwrap_err();
+        assert!(error.contains("configured local.runtime_model_roots entry"));
+    }
+
+    #[test]
+    fn test_runtime_resolver_returns_canonical_hf_snapshot() {
+        let cache = tempfile::tempdir().unwrap();
+        let snapshot = create_hf_cache(cache.path(), "org", "model", "abc123");
+        let resolved =
+            resolve_runtime_model_with_cache("org/model", &[], Some(cache.path())).unwrap();
+
+        assert_eq!(resolved, snapshot.canonicalize().unwrap());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_runtime_policy_rejects_symlink_escape_from_root() {
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let outside_model = outside.path().join("model");
+        std::fs::create_dir(&outside_model).unwrap();
+        std::os::unix::fs::symlink(&outside_model, root.path().join("linked-model")).unwrap();
+
+        let roots = vec![root.path().to_string_lossy().into_owned()];
+        assert!(
+            runtime_load_path_allowed(root.path().join("linked-model").to_str().unwrap(), &roots)
+                .is_err()
+        );
     }
 
     // --- tilde expansion error message test ---

--- a/crates/higgs/src/router.rs
+++ b/crates/higgs/src/router.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
+use std::sync::{Arc, PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use regex::Regex;
 use tracing::warn;
@@ -84,11 +84,17 @@ struct AutoRouteEntry {
 /// 3. Pattern matching (first match wins)
 /// 4. Default provider fallback
 pub struct Router {
-    local_engines: HashMap<String, Arc<Engine>>,
+    /// Loaded local engines, mutable at runtime via the load/unload endpoints.
+    /// Guarded by a `RwLock`: `resolve`/`list` take a read lock and clone the
+    /// `Arc` out, so an in-flight request is never tied to map membership.
+    local_engines: RwLock<HashMap<String, Arc<Engine>>>,
     compiled_routes: Vec<CompiledRoute>,
     auto_routes: Vec<AutoRouteEntry>,
     auto_candidates: Vec<RouteCandidate>,
     auto_router_engine: Option<Arc<Engine>>,
+    /// Map key bound to the auto-router model, if enabled. Unloading it is
+    /// refused because `auto_router_engine` keeps a separate `Arc` alive.
+    auto_router_model_name: Option<String>,
     auto_router_force: bool,
     auto_router_timeout_ms: u64,
     default_target: RouteTarget,
@@ -146,7 +152,7 @@ impl Router {
             }
         }
 
-        let auto_router_engine = if config.auto_router.enabled {
+        let (auto_router_engine, auto_router_model_name) = if config.auto_router.enabled {
             if config.auto_router.model.is_empty() {
                 return Err("auto_router.enabled is true but model is empty".to_owned());
             }
@@ -157,19 +163,20 @@ impl Router {
             let engine = engines.get(auto_model).cloned().ok_or_else(|| {
                 format!("auto_router model '{auto_model}' not found among loaded models")
             })?;
-            Some(engine)
+            (Some(engine), Some(auto_model.clone()))
         } else {
-            None
+            (None, None)
         };
 
         let default_target = build_route_target(&config.default.provider, None, config)?;
 
         Ok(Self {
-            local_engines: engines,
+            local_engines: RwLock::new(engines),
             compiled_routes,
             auto_routes,
             auto_candidates,
             auto_router_engine,
+            auto_router_model_name,
             auto_router_force: config.auto_router.force,
             auto_router_timeout_ms: config.auto_router.timeout_ms,
             default_target,
@@ -195,10 +202,13 @@ impl Router {
             // force mode: auto-routing returned nothing, fall through to normal resolution
         }
 
-        // Direct engine lookup
-        if let Some(engine) = self.local_engines.get(model) {
+        // Direct engine lookup. Clone the Arc out and drop the read guard
+        // immediately -- the in-flight request owns the engine independent of
+        // map membership, so a concurrent unload can never free it mid-request.
+        let direct = self.engines_read().get(model).cloned();
+        if let Some(engine) = direct {
             return Ok(ResolvedRoute::Higgs {
-                engine: Arc::clone(engine),
+                engine,
                 model_name: model.to_owned(),
                 routing_method: RoutingMethod::Direct,
             });
@@ -215,12 +225,55 @@ impl Router {
         self.resolve_target(&self.default_target, model, RoutingMethod::Default)
     }
 
-    /// Returns all loaded local engines.
-    pub const fn local_engines(&self) -> &HashMap<String, Arc<Engine>> {
-        &self.local_engines
+    /// Sorted names of all loaded local engines (snapshot under a read lock).
+    pub fn local_model_names(&self) -> Vec<String> {
+        let mut names: Vec<String> = self.engines_read().keys().cloned().collect();
+        names.sort_unstable();
+        names
+    }
+
+    /// Whether a local engine is currently registered under `name`.
+    pub fn contains_engine(&self, name: &str) -> bool {
+        self.engines_read().contains_key(name)
+    }
+
+    /// Register a freshly-loaded engine. Returns `Err(name)` if the name is
+    /// already taken (checked under the write lock, so it is race-free against
+    /// concurrent loads).
+    pub fn insert_engine(&self, name: String, engine: Arc<Engine>) -> Result<(), String> {
+        let mut engines = self.engines_write();
+        if engines.contains_key(&name) {
+            return Err(name);
+        }
+        engines.insert(name, engine);
+        drop(engines);
+        Ok(())
+    }
+
+    /// Remove an engine from the routing table, returning it if present. The
+    /// caller is responsible for dropping it once no request still holds a clone.
+    pub fn remove_engine(&self, name: &str) -> Option<Arc<Engine>> {
+        self.engines_write().remove(name)
+    }
+
+    /// Map key bound to the auto-router model, if the auto-router is enabled.
+    pub fn auto_router_model_name(&self) -> Option<&str> {
+        self.auto_router_model_name.as_deref()
     }
 
     // -- Private helpers ---------------------------------------------------
+
+    fn engines_read(&self) -> RwLockReadGuard<'_, HashMap<String, Arc<Engine>>> {
+        self.local_engines
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+    }
+
+    fn engines_write(&self) -> RwLockWriteGuard<'_, HashMap<String, Arc<Engine>>> {
+        self.local_engines
+            .write()
+            .unwrap_or_else(PoisonError::into_inner)
+    }
 
     async fn try_auto_route(
         &self,
@@ -265,21 +318,22 @@ impl Router {
         match target {
             RouteTarget::Higgs { model_rewrite } => {
                 let lookup_name = model_rewrite.as_deref().unwrap_or(model);
-                let (engine, resolved_name) =
-                    if let Some(engine) = self.local_engines.get(lookup_name) {
-                        (Arc::clone(engine), lookup_name.to_owned())
-                    } else if model == "auto" {
-                        // "auto" is a virtual model name; pick any loaded engine
-                        let (name, engine) =
-                            self.local_engines.iter().next().ok_or_else(|| {
-                                "no local models loaded for default route".to_owned()
-                            })?;
-                        (Arc::clone(engine), name.clone())
-                    } else {
-                        return Err(format!(
-                            "model '{lookup_name}' not found among loaded local models"
-                        ));
-                    };
+                let engines = self.engines_read();
+                let (engine, resolved_name) = if let Some(engine) = engines.get(lookup_name) {
+                    (Arc::clone(engine), lookup_name.to_owned())
+                } else if model == "auto" {
+                    // "auto" is a virtual model name; pick any loaded engine
+                    let (name, engine) = engines
+                        .iter()
+                        .next()
+                        .ok_or_else(|| "no local models loaded for default route".to_owned())?;
+                    (Arc::clone(engine), name.clone())
+                } else {
+                    return Err(format!(
+                        "model '{lookup_name}' not found among loaded local models"
+                    ));
+                };
+                drop(engines);
                 Ok(ResolvedRoute::Higgs {
                     engine,
                     model_name: resolved_name,
@@ -801,7 +855,7 @@ mod tests {
     }
 
     #[test]
-    fn local_engines_accessor_returns_engines() {
+    fn local_model_names_lists_engines() {
         let config = config_from_toml(
             r#"
             [[models]]
@@ -809,7 +863,51 @@ mod tests {
             "#,
         );
         let router = Router::from_config(&config, HashMap::new()).unwrap();
-        assert!(router.local_engines().is_empty());
+        assert!(router.local_model_names().is_empty());
+
+        let mut engines = HashMap::new();
+        engines.insert(
+            "b".to_owned(),
+            Arc::new(crate::state::Engine::test_stub("b")),
+        );
+        engines.insert(
+            "a".to_owned(),
+            Arc::new(crate::state::Engine::test_stub("a")),
+        );
+        let router = Router::from_config(&config, engines).unwrap();
+        assert_eq!(router.local_model_names(), vec!["a", "b"]);
+    }
+
+    #[test]
+    fn insert_remove_and_contains_engine() {
+        let config = config_from_toml(
+            r#"
+            [[models]]
+            path = "some/model"
+            "#,
+        );
+        let router = Router::from_config(&config, HashMap::new()).unwrap();
+
+        assert!(!router.contains_engine("x"));
+        router
+            .insert_engine(
+                "x".to_owned(),
+                Arc::new(crate::state::Engine::test_stub("x")),
+            )
+            .unwrap();
+        assert!(router.contains_engine("x"));
+
+        // Duplicate insert is rejected with the conflicting name.
+        let dup = router.insert_engine(
+            "x".to_owned(),
+            Arc::new(crate::state::Engine::test_stub("x")),
+        );
+        assert_eq!(dup, Err("x".to_owned()));
+
+        let removed = router.remove_engine("x");
+        assert!(removed.is_some());
+        assert!(!router.contains_engine("x"));
+        assert!(router.remove_engine("x").is_none());
     }
 
     #[tokio::test]

--- a/crates/higgs/src/router.rs
+++ b/crates/higgs/src/router.rs
@@ -77,6 +77,17 @@ struct AutoRouteEntry {
     target: RouteTarget,
 }
 
+/// Internal failures while acquiring runtime-model coordination permits.
+#[derive(Debug, thiserror::Error, PartialEq, Eq, Clone, Copy)]
+pub(crate) enum RuntimeLoadError {
+    #[error("runtime model budget reached; unload a runtime model before loading another")]
+    ResidentBudgetExhausted,
+    #[error("runtime load gate closed")]
+    LoadGateClosed,
+    #[error("runtime resident-model gate closed")]
+    ResidentGateClosed,
+}
+
 /// Owned coordination permits for one runtime load attempt.
 pub(crate) struct RuntimeLoadPermit {
     _load_permit: OwnedSemaphorePermit,
@@ -251,7 +262,7 @@ impl Router {
         messages: Option<&[serde_json::Value]>,
     ) -> Result<ResolvedRoute, String> {
         if self.auto_router_force || model == "auto" {
-            if let Some(resolved) = self.try_auto_route(messages).await {
+            if let Some(resolved) = self.try_auto_route(messages).await? {
                 return Ok(resolved);
             }
             if model == "auto" {
@@ -305,22 +316,19 @@ impl Router {
     }
 
     /// Acquire the attempt and resident permits for one runtime load.
-    pub(crate) async fn acquire_runtime_load(&self) -> Result<RuntimeLoadPermit, String> {
+    pub(crate) async fn acquire_runtime_load(&self) -> Result<RuntimeLoadPermit, RuntimeLoadError> {
         let load_permit = Arc::clone(&self.runtime_load_semaphore)
             .acquire_owned()
             .await
-            .map_err(|e| format!("runtime load gate closed: {e}"))?;
+            .map_err(|_| RuntimeLoadError::LoadGateClosed)?;
         let resident_permit = match &self.runtime_resident_semaphore {
             Some(semaphore) => match Arc::clone(semaphore).try_acquire_owned() {
                 Ok(permit) => Some(permit),
                 Err(TryAcquireError::NoPermits) => {
-                    return Err(
-                        "runtime model budget reached; unload a runtime model before loading another"
-                            .to_owned(),
-                    );
+                    return Err(RuntimeLoadError::ResidentBudgetExhausted);
                 }
                 Err(TryAcquireError::Closed) => {
-                    return Err("runtime resident-model gate closed".to_owned());
+                    return Err(RuntimeLoadError::ResidentGateClosed);
                 }
             },
             None => None,
@@ -368,13 +376,20 @@ impl Router {
         Ok(())
     }
 
-    /// Remove an engine from the routing table, returning it if present. The
-    /// caller is responsible for dropping it once no request still holds a
-    /// clone.
+    /// Non-draining removal for startup engines. Runtime engines must use
+    /// `remove_runtime_engine` so their resident quota permit remains held
+    /// while references drain.
     pub fn remove_engine(&self, name: &str) -> Option<Arc<Engine>> {
-        let (engine, resident_permit) = self.remove_engine_with_permit(name)?.into_parts();
-        drop(resident_permit);
-        Some(engine)
+        let mut engines = self.engines_write();
+        let runtime_names = self
+            .runtime_engine_names
+            .read()
+            .unwrap_or_else(PoisonError::into_inner);
+        if runtime_names.contains_key(name) {
+            return None;
+        }
+        drop(runtime_names);
+        engines.remove(name)
     }
 
     /// Remove a runtime engine while retaining its resident quota permit until
@@ -423,11 +438,15 @@ impl Router {
     async fn try_auto_route(
         &self,
         messages: Option<&[serde_json::Value]>,
-    ) -> Option<ResolvedRoute> {
-        let auto_engine = self.auto_router_engine.as_ref()?;
-        let msg_slice = messages?;
+    ) -> Result<Option<ResolvedRoute>, String> {
+        let Some(auto_engine) = self.auto_router_engine.as_ref() else {
+            return Ok(None);
+        };
+        let Some(msg_slice) = messages else {
+            return Ok(None);
+        };
         if self.auto_candidates.is_empty() || msg_slice.is_empty() {
-            return None;
+            return Ok(None);
         }
 
         let engine_clone = Arc::clone(auto_engine);
@@ -442,16 +461,23 @@ impl Router {
             }),
         )
         .await;
-        let name = if let Ok(join_result) = timeout_result {
-            join_result.ok()??
-        } else {
-            warn!("auto-router classification timed out after {timeout:?}");
-            return None;
+        let name = match timeout_result {
+            Ok(Ok(Some(name))) => name,
+            Ok(Ok(None) | Err(_)) => return Ok(None),
+            Err(_) => {
+                warn!("auto-router classification timed out after {timeout:?}");
+                return Ok(None);
+            }
         };
 
-        let entry = self.auto_routes.iter().find(|r| r.name == name)?;
+        let Some(entry) = self.auto_routes.iter().find(|r| r.name == name) else {
+            return Ok(None);
+        };
+        self.resolve_selected_auto_route(entry).map(Some)
+    }
+
+    fn resolve_selected_auto_route(&self, entry: &AutoRouteEntry) -> Result<ResolvedRoute, String> {
         self.resolve_target(&entry.target, "auto", RoutingMethod::Auto)
-            .ok()
     }
 
     fn resolve_target(
@@ -466,7 +492,7 @@ impl Router {
                 let engines = self.engines_read();
                 let (engine, resolved_name) = if let Some(engine) = engines.get(lookup_name) {
                     (Arc::clone(engine), lookup_name.to_owned())
-                } else if model == "auto" {
+                } else if model == "auto" && model_rewrite.is_none() {
                     // "auto" is a virtual model name; pick any loaded engine
                     let (name, engine) = engines
                         .iter()
@@ -1058,6 +1084,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn non_draining_remove_refuses_runtime_engine() {
+        let config = config_from_toml(
+            r#"
+            [provider.stub]
+            url = "http://127.0.0.1:1"
+            [local]
+            runtime_max_loaded_models = 1
+            "#,
+        );
+        let router = Router::from_config(&config, HashMap::new()).unwrap();
+        let load_permit = router.acquire_runtime_load().await.unwrap();
+        router
+            .insert_runtime_engine(
+                "runtime".to_owned(),
+                Arc::new(crate::state::Engine::test_stub("runtime")),
+                load_permit.into_resident_permit(),
+            )
+            .unwrap();
+
+        assert!(router.remove_engine("runtime").is_none());
+        assert!(router.contains_engine("runtime"));
+        assert_eq!(
+            router.acquire_runtime_load().await.err().unwrap(),
+            RuntimeLoadError::ResidentBudgetExhausted
+        );
+
+        drop(router.remove_runtime_engine("runtime"));
+    }
+
+    #[tokio::test]
     async fn runtime_engine_count_excludes_startup_engines() {
         let config = config_from_toml(
             r#"
@@ -1085,11 +1141,31 @@ mod tests {
             .unwrap();
         assert_eq!(router.runtime_engine_count(), 1);
         assert_eq!(router.local_model_names().len(), 2);
-        assert!(router.acquire_runtime_load().await.is_err());
+        assert_eq!(
+            router.acquire_runtime_load().await.err().unwrap(),
+            RuntimeLoadError::ResidentBudgetExhausted
+        );
         let removed = router.remove_runtime_engine("runtime").unwrap();
         assert!(router.acquire_runtime_load().await.is_err());
         drop(removed);
         assert!(router.acquire_runtime_load().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn closed_runtime_load_gate_returns_typed_error() {
+        let config = config_from_toml(
+            r#"
+            [provider.stub]
+            url = "http://127.0.0.1:1"
+            "#,
+        );
+        let router = Router::from_config(&config, HashMap::new()).unwrap();
+        router.runtime_load_semaphore.close();
+
+        assert_eq!(
+            router.acquire_runtime_load().await.err().unwrap(),
+            RuntimeLoadError::LoadGateClosed
+        );
     }
 
     #[tokio::test]
@@ -1156,6 +1232,46 @@ mod tests {
             Ok(ResolvedRoute::Remote { .. }) => panic!("expected Higgs route"),
             Err(e) => panic!("should resolve to first engine, got error: {e}"),
         }
+    }
+
+    #[tokio::test]
+    async fn selected_auto_route_with_missing_higgs_rewrite_returns_error() {
+        let config = config_from_toml(
+            r#"
+            [auto_router]
+            enabled = true
+            model = "router"
+
+            [[models]]
+            path = "router"
+            name = "router"
+
+            [[routes]]
+            name = "missing-local"
+            description = "route to a model that is not loaded"
+            provider = "higgs"
+            model = "missing"
+            "#,
+        );
+        let mut engines = HashMap::new();
+        engines.insert(
+            "router".to_owned(),
+            Arc::new(crate::state::Engine::test_stub_with_output(
+                "router",
+                r#"{"route":"missing-local"}"#,
+            )),
+        );
+        let router = Router::from_config(&config, engines).unwrap();
+        let messages = vec![serde_json::json!({
+            "role": "user",
+            "content": "route this request"
+        })];
+        let error = match router.resolve("auto", Some(&messages)).await {
+            Err(error) => error,
+            Ok(_) => panic!("expected missing explicit rewrite to fail"),
+        };
+
+        assert_eq!(error, "model 'missing' not found among loaded local models");
     }
 
     #[test]

--- a/crates/higgs/src/router.rs
+++ b/crates/higgs/src/router.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use regex::Regex;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore, TryAcquireError};
 use tracing::warn;
 
 use crate::config::{ApiFormat, HiggsConfig};
@@ -76,6 +77,33 @@ struct AutoRouteEntry {
     target: RouteTarget,
 }
 
+/// Owned coordination permits for one runtime load attempt.
+pub(crate) struct RuntimeLoadPermit {
+    _load_permit: OwnedSemaphorePermit,
+    resident_permit: Option<OwnedSemaphorePermit>,
+}
+
+impl RuntimeLoadPermit {
+    /// Release the load-attempt permit while retaining the resident-model
+    /// permit with the loaded engine.
+    pub(crate) fn into_resident_permit(self) -> Option<OwnedSemaphorePermit> {
+        self.resident_permit
+    }
+}
+
+/// Engine removed from routing, retaining its resident quota permit until the
+/// caller finishes draining all in-flight `Arc` references.
+pub(crate) struct RemovedEngine {
+    engine: Arc<Engine>,
+    resident_permit: Option<OwnedSemaphorePermit>,
+}
+
+impl RemovedEngine {
+    pub(crate) fn into_parts(self) -> (Arc<Engine>, Option<OwnedSemaphorePermit>) {
+        (self.engine, self.resident_permit)
+    }
+}
+
 /// Routes model names to local engines or remote providers.
 ///
 /// Resolution order:
@@ -88,6 +116,14 @@ pub struct Router {
     /// Guarded by a `RwLock`: `resolve`/`list` take a read lock and clone the
     /// `Arc` out, so an in-flight request is never tied to map membership.
     local_engines: RwLock<HashMap<String, Arc<Engine>>>,
+    /// Runtime engine names and their resident quota permits. Startup-configured
+    /// engines are intentionally excluded from this map.
+    runtime_engine_names: RwLock<HashMap<String, Option<OwnedSemaphorePermit>>>,
+    /// Bounds concurrent GPU- and memory-heavy runtime load attempts.
+    runtime_load_semaphore: Arc<Semaphore>,
+    /// Bounds resident runtime engines. A permit remains held through unload
+    /// draining, so the cap describes engine lifetime rather than map entries.
+    runtime_resident_semaphore: Option<Arc<Semaphore>>,
     compiled_routes: Vec<CompiledRoute>,
     auto_routes: Vec<AutoRouteEntry>,
     auto_candidates: Vec<RouteCandidate>,
@@ -106,6 +142,21 @@ impl Router {
         config: &HiggsConfig,
         engines: HashMap<String, Arc<Engine>>,
     ) -> Result<Self, String> {
+        let max_concurrent = config.local.runtime_max_concurrent_loads;
+        if max_concurrent == 0 || max_concurrent > Semaphore::MAX_PERMITS {
+            return Err(format!(
+                "runtime_max_concurrent_loads must be between 1 and {}",
+                Semaphore::MAX_PERMITS
+            ));
+        }
+        if let Some(max_loaded) = config.local.runtime_max_loaded_models
+            && (max_loaded == 0 || max_loaded > Semaphore::MAX_PERMITS)
+        {
+            return Err(format!(
+                "runtime_max_loaded_models must be between 1 and {}",
+                Semaphore::MAX_PERMITS
+            ));
+        }
         let mut compiled_routes = Vec::new();
         let mut auto_routes = Vec::new();
         let mut auto_candidates = Vec::new();
@@ -172,6 +223,13 @@ impl Router {
 
         Ok(Self {
             local_engines: RwLock::new(engines),
+            runtime_engine_names: RwLock::new(HashMap::new()),
+            runtime_load_semaphore: Arc::new(Semaphore::new(max_concurrent)),
+            runtime_resident_semaphore: config
+                .local
+                .runtime_max_loaded_models
+                .map(Semaphore::new)
+                .map(Arc::new),
             compiled_routes,
             auto_routes,
             auto_candidates,
@@ -237,6 +295,42 @@ impl Router {
         self.engines_read().contains_key(name)
     }
 
+    /// Number of engines inserted through the runtime-load API.
+    #[cfg(test)]
+    pub(crate) fn runtime_engine_count(&self) -> usize {
+        self.runtime_engine_names
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .len()
+    }
+
+    /// Acquire the attempt and resident permits for one runtime load.
+    pub(crate) async fn acquire_runtime_load(&self) -> Result<RuntimeLoadPermit, String> {
+        let load_permit = Arc::clone(&self.runtime_load_semaphore)
+            .acquire_owned()
+            .await
+            .map_err(|e| format!("runtime load gate closed: {e}"))?;
+        let resident_permit = match &self.runtime_resident_semaphore {
+            Some(semaphore) => match Arc::clone(semaphore).try_acquire_owned() {
+                Ok(permit) => Some(permit),
+                Err(TryAcquireError::NoPermits) => {
+                    return Err(
+                        "runtime model budget reached; unload a runtime model before loading another"
+                            .to_owned(),
+                    );
+                }
+                Err(TryAcquireError::Closed) => {
+                    return Err("runtime resident-model gate closed".to_owned());
+                }
+            },
+            None => None,
+        };
+        Ok(RuntimeLoadPermit {
+            _load_permit: load_permit,
+            resident_permit,
+        })
+    }
+
     /// Register a freshly-loaded engine. Returns `Err(name)` if the name is
     /// already taken (checked under the write lock, so it is race-free against
     /// concurrent loads).
@@ -250,10 +344,61 @@ impl Router {
         Ok(())
     }
 
+    /// Register an engine loaded through the runtime API, enforcing the
+    /// resident runtime-model budget while holding the write lock.
+    pub(crate) fn insert_runtime_engine(
+        &self,
+        name: String,
+        engine: Arc<Engine>,
+        resident_permit: Option<OwnedSemaphorePermit>,
+    ) -> Result<(), String> {
+        let mut engines = self.engines_write();
+        if engines.contains_key(&name) {
+            return Err(format!("model '{name}' is already loaded"));
+        }
+
+        let mut runtime_names = self
+            .runtime_engine_names
+            .write()
+            .unwrap_or_else(PoisonError::into_inner);
+        engines.insert(name.clone(), engine);
+        runtime_names.insert(name, resident_permit);
+        drop(runtime_names);
+        drop(engines);
+        Ok(())
+    }
+
     /// Remove an engine from the routing table, returning it if present. The
-    /// caller is responsible for dropping it once no request still holds a clone.
+    /// caller is responsible for dropping it once no request still holds a
+    /// clone.
     pub fn remove_engine(&self, name: &str) -> Option<Arc<Engine>> {
-        self.engines_write().remove(name)
+        let (engine, resident_permit) = self.remove_engine_with_permit(name)?.into_parts();
+        drop(resident_permit);
+        Some(engine)
+    }
+
+    /// Remove a runtime engine while retaining its resident quota permit until
+    /// all in-flight `Arc` references have drained.
+    pub(crate) fn remove_runtime_engine(&self, name: &str) -> Option<RemovedEngine> {
+        self.remove_engine_with_permit(name)
+    }
+
+    fn remove_engine_with_permit(&self, name: &str) -> Option<RemovedEngine> {
+        // Keep both locks in the same order used by insert_runtime_engine so
+        // a same-name load cannot insert between engine and quota removal.
+        let mut engines = self.engines_write();
+        let removed = engines.remove(name)?;
+        let mut runtime_names = self
+            .runtime_engine_names
+            .write()
+            .unwrap_or_else(PoisonError::into_inner);
+        let resident_permit = runtime_names.remove(name).flatten();
+        drop(runtime_names);
+        drop(engines);
+        Some(RemovedEngine {
+            engine: removed,
+            resident_permit,
+        })
     }
 
     /// Map key bound to the auto-router model, if the auto-router is enabled.
@@ -400,7 +545,8 @@ fn build_route_target(
     clippy::unwrap_used,
     clippy::expect_used,
     clippy::indexing_slicing,
-    clippy::shadow_unrelated
+    clippy::shadow_unrelated,
+    clippy::significant_drop_tightening
 )]
 mod tests {
     use super::*;
@@ -907,7 +1053,77 @@ mod tests {
         let removed = router.remove_engine("x");
         assert!(removed.is_some());
         assert!(!router.contains_engine("x"));
+        assert_eq!(router.runtime_engine_count(), 0);
         assert!(router.remove_engine("x").is_none());
+    }
+
+    #[tokio::test]
+    async fn runtime_engine_count_excludes_startup_engines() {
+        let config = config_from_toml(
+            r#"
+            [[models]]
+            path = "startup/model"
+            [local]
+            runtime_max_loaded_models = 1
+            "#,
+        );
+        let mut engines = HashMap::new();
+        engines.insert(
+            "startup".to_owned(),
+            Arc::new(crate::state::Engine::test_stub("startup")),
+        );
+        let router = Router::from_config(&config, engines).unwrap();
+
+        assert_eq!(router.runtime_engine_count(), 0);
+        let load_permit = router.acquire_runtime_load().await.unwrap();
+        router
+            .insert_runtime_engine(
+                "runtime".to_owned(),
+                Arc::new(crate::state::Engine::test_stub("runtime")),
+                load_permit.into_resident_permit(),
+            )
+            .unwrap();
+        assert_eq!(router.runtime_engine_count(), 1);
+        assert_eq!(router.local_model_names().len(), 2);
+        assert!(router.acquire_runtime_load().await.is_err());
+        let removed = router.remove_runtime_engine("runtime").unwrap();
+        assert!(router.acquire_runtime_load().await.is_err());
+        drop(removed);
+        assert!(router.acquire_runtime_load().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn runtime_load_permit_survives_outer_cancellation() {
+        let config = config_from_toml(
+            r#"
+            [provider.stub]
+            url = "http://127.0.0.1:1"
+            [local]
+            runtime_max_concurrent_loads = 1
+            "#,
+        );
+        let router = Arc::new(Router::from_config(&config, HashMap::new()).unwrap());
+        let permit = router.acquire_runtime_load().await.unwrap();
+        let blocking = tokio::task::spawn_blocking(move || {
+            std::thread::sleep(std::time::Duration::from_millis(120));
+            drop(permit);
+        });
+        let outer = tokio::spawn(async move {
+            let _ = blocking.await;
+        });
+        outer.abort();
+
+        assert!(
+            tokio::time::timeout(
+                std::time::Duration::from_millis(20),
+                router.acquire_runtime_load()
+            )
+            .await
+            .is_err(),
+            "permit was released while the blocking load task was still running"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(140)).await;
+        assert!(router.acquire_runtime_load().await.is_ok());
     }
 
     #[tokio::test]

--- a/crates/higgs/src/routes/models.rs
+++ b/crates/higgs/src/routes/models.rs
@@ -7,6 +7,7 @@ use axum::{
     http::StatusCode,
 };
 use bytes::Bytes;
+use tokio::sync::OwnedSemaphorePermit;
 
 use crate::{
     config::ModelConfig,
@@ -65,8 +66,8 @@ pub async fn load_model(
     }
 
     // Cheap collision pre-check when the caller named the model, so we don't pay
-    // for a full load just to reject it. `insert_engine` re-checks under the
-    // write lock, so this is an optimization, not the source of truth.
+    // for a full load just to reject it. `insert_runtime_engine` re-checks under
+    // the write lock, so this is an optimization, not the source of truth.
     if let Some(ref name) = model_cfg.name {
         if state.router.contains_engine(name) {
             return Err(ServerError::Conflict(format!(
@@ -75,32 +76,57 @@ pub async fn load_model(
         }
     }
 
-    // Resolve the path without prompting -- the server has no interactive stdin.
-    let resolved = model_resolver::resolve(&model_cfg.path).map_err(|e| {
+    // Resolve and authorize once without prompting -- the server has no
+    // interactive stdin. The returned canonical path is the exact path passed
+    // to the loader; arbitrary local directories are rejected.
+    let resolved = model_resolver::resolve_runtime_model(
+        &model_cfg.path,
+        &state.config.local.runtime_model_roots,
+    )
+    .map_err(|e| {
         ServerError::BadRequest(format!(
             "model '{}' not found locally: {e}; pre-download it (e.g. `huggingface-cli download {}`)",
             model_cfg.path, model_cfg.path
         ))
     })?;
 
+    // Serialize/bound concurrent loads: each load is GPU- and memory-heavy and
+    // concurrent large loads can OOM the host. The owned permits are captured
+    // by the blocking task so cancellation of this request cannot release them
+    // while the load continues.
+    let runtime_load_permit = state
+        .router
+        .acquire_runtime_load()
+        .await
+        .map_err(|message| {
+            if message.starts_with("runtime model budget reached") {
+                ServerError::BadRequest(message)
+            } else {
+                ServerError::InternalError(message)
+            }
+        })?;
+
     // The weight load is blocking and GPU-bound; keep it off the async runtime.
     let local = state.config.local.clone();
     let cfg = model_cfg.clone();
-    let (name, engine) = tokio::task::spawn_blocking(move || build_engine(&resolved, &cfg, &local))
-        .await
-        .map_err(|e| ServerError::InternalError(format!("model load task failed: {e}")))?
-        .map_err(ServerError::BadRequest)?;
+    let (name, engine, resident_permit) = tokio::task::spawn_blocking(move || {
+        build_engine(&resolved, &cfg, &local)
+            .map(|(name, engine)| (name, engine, runtime_load_permit.into_resident_permit()))
+    })
+    .await
+    .map_err(|e| ServerError::InternalError(format!("model load task failed: {e}")))?
+    .map_err(ServerError::BadRequest)?;
 
     state
         .router
-        .insert_engine(name.clone(), Arc::new(engine))
-        .map_err(|n| ServerError::Conflict(format!("model '{n}' is already loaded")))?;
+        .insert_runtime_engine(name.clone(), Arc::new(engine), resident_permit)
+        .map_err(ServerError::Conflict)?;
 
     tracing::info!(model_name = %name, "Model loaded at runtime");
     Ok(Json(model_object(name)))
 }
 
-/// `DELETE /v1/models/{name}` -- unload a model and free its GPU memory.
+/// `DELETE /v1/models/{name}` -- unload a model and release its engine resources.
 ///
 /// Returns `204` once the model is fully unloaded, `202` if a request was still
 /// in flight past the drain timeout (the final free is detached), `404` if no
@@ -109,22 +135,37 @@ pub async fn unload_model(
     State(state): State<SharedState>,
     Path(name): Path<String>,
 ) -> Result<StatusCode, ServerError> {
+    if !state.config.local.allow_runtime_model_load {
+        return Err(ServerError::Forbidden(
+            "runtime model loading is disabled; set local.allow_runtime_model_load = true to enable it"
+                .to_owned(),
+        ));
+    }
+
     if state.router.auto_router_model_name() == Some(name.as_str()) {
         return Err(ServerError::Conflict(format!(
             "model '{name}' is bound to the auto-router and cannot be unloaded"
         )));
     }
 
-    let engine = state
+    let (engine, resident_permit) = state
         .router
-        .remove_engine(&name)
-        .ok_or_else(|| ServerError::ModelNotFound(name.clone()))?;
+        .remove_runtime_engine(&name)
+        .ok_or_else(|| ServerError::ModelNotFound(name.clone()))?
+        .into_parts();
 
     // The map entry is gone, so no new request can take a reference and the
-    // strong count only decreases. Free GPU memory once the last in-flight
+    // strong count only decreases. Drop the engine once the last in-flight
     // request releases its clone; detach past the timeout so a long generation
-    // can't block the response.
-    if drain_and_drop(engine, DRAIN_TIMEOUT).await {
+    // cannot block the response. MLX may retain allocator/cache state after the
+    // engine drop, so this endpoint does not promise a full process-wide cache
+    // purge.
+    // Own the drain in a detached task so cancellation of this request cannot
+    // release the engine or its resident quota permit prematurely.
+    let drained = tokio::spawn(drain_and_drop(engine, resident_permit, DRAIN_TIMEOUT))
+        .await
+        .map_err(|e| ServerError::InternalError(format!("model unload task failed: {e}")))?;
+    if drained {
         tracing::info!(model_name = %name, "Model unloaded");
         Ok(StatusCode::NO_CONTENT)
     } else {
@@ -133,24 +174,29 @@ pub async fn unload_model(
     }
 }
 
-/// Wait until `engine` is solely owned here, then drop it (freeing GPU memory).
+/// Wait until `engine` is solely owned here, then drop it.
 ///
 /// Returns `true` if dropped within `timeout`; `false` if it timed out and the
 /// final drop was handed to a detached task. Dropping is intentionally not gated
 /// on the process-wide GPU gate: engine teardown frees MLX buffers but never
 /// runs an `eval`, so it cannot race the cross-model output-array table that the
 /// gate protects.
-async fn drain_and_drop(mut engine: Arc<Engine>, timeout: Duration) -> bool {
+async fn drain_and_drop(
+    mut engine: Arc<Engine>,
+    resident_permit: Option<OwnedSemaphorePermit>,
+    timeout: Duration,
+) -> bool {
     let start = Instant::now();
     loop {
         match Arc::try_unwrap(engine) {
             Ok(owned) => {
                 drop(owned);
+                drop(resident_permit);
                 return true;
             }
             Err(shared) => {
                 if start.elapsed() >= timeout {
-                    tokio::spawn(drain_in_background(shared));
+                    tokio::spawn(drain_in_background(shared, resident_permit));
                     return false;
                 }
                 engine = shared;
@@ -161,11 +207,15 @@ async fn drain_and_drop(mut engine: Arc<Engine>, timeout: Duration) -> bool {
 }
 
 /// Poll until the detached engine reference is sole-owned, then drop it.
-async fn drain_in_background(mut engine: Arc<Engine>) {
+async fn drain_in_background(
+    mut engine: Arc<Engine>,
+    resident_permit: Option<OwnedSemaphorePermit>,
+) {
     loop {
         match Arc::try_unwrap(engine) {
             Ok(owned) => {
                 drop(owned);
+                drop(resident_permit);
                 return;
             }
             Err(shared) => {
@@ -196,7 +246,11 @@ fn model_objects_sorted<'a>(names: impl Iterator<Item = &'a str>) -> Vec<ModelOb
 }
 
 #[cfg(test)]
-#[allow(clippy::panic, clippy::unwrap_used)]
+#[allow(
+    clippy::panic,
+    clippy::significant_drop_tightening,
+    clippy::unwrap_used
+)]
 mod tests {
     use super::*;
     use std::collections::HashMap;
@@ -277,6 +331,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn startup_engines_do_not_consume_runtime_model_budget() {
+        let state = build_state(
+            "[local]\nallow_runtime_model_load = true\nruntime_max_loaded_models = 1\n",
+            stub_engines(&["startup"]),
+        );
+        let body = Bytes::from_static(b"{\"path\":\"org/model\",\"name\":\"runtime\"}");
+        let err = load_model(State(state), body).await.unwrap_err();
+        assert!(matches!(
+            err,
+            ServerError::BadRequest(message)
+                if !message.contains("runtime model budget reached")
+        ));
+    }
+
+    #[tokio::test]
     async fn unload_unknown_returns_not_found() {
         let state = build_state("[local]\nallow_runtime_model_load = true\n", HashMap::new());
         let err = unload_model(State(state), Path("ghost".to_owned()))
@@ -295,6 +364,9 @@ mod tests {
             [auto_router]
             enabled = true
             model = "router"
+
+            [local]
+            allow_runtime_model_load = true
         "#;
         let state = build_state(toml, stub_engines(&["router"]));
         let err = unload_model(State(Arc::clone(&state)), Path("router".to_owned()))
@@ -322,7 +394,7 @@ mod tests {
     #[tokio::test]
     async fn drain_and_drop_drops_sole_owner_immediately() {
         let engine = Arc::new(Engine::test_stub("solo"));
-        assert!(drain_and_drop(engine, Duration::from_secs(1)).await);
+        assert!(drain_and_drop(engine, None, Duration::from_secs(1)).await);
     }
 
     #[tokio::test]
@@ -335,7 +407,7 @@ mod tests {
             drop(clone);
         });
         let start = Instant::now();
-        assert!(drain_and_drop(engine, Duration::from_secs(5)).await);
+        assert!(drain_and_drop(engine, None, Duration::from_secs(5)).await);
         assert!(
             start.elapsed() >= Duration::from_millis(100),
             "should have waited for the clone to drop"
@@ -346,8 +418,98 @@ mod tests {
     async fn drain_and_drop_times_out_and_detaches() {
         let engine = Arc::new(Engine::test_stub("stuck"));
         let clone = Arc::clone(&engine); // held past the timeout
-        let drained = drain_and_drop(engine, Duration::from_millis(80)).await;
+        let drained = drain_and_drop(engine, None, Duration::from_millis(80)).await;
         assert!(!drained, "should time out while a reference is held");
         drop(clone); // let the detached task finish
+    }
+
+    #[tokio::test]
+    async fn resident_permit_stays_held_until_unload_drain_finishes() {
+        let state = build_state(
+            "[local]\nallow_runtime_model_load = true\nruntime_max_loaded_models = 1\n",
+            HashMap::new(),
+        );
+        let load_permit = state.router.acquire_runtime_load().await.unwrap();
+        state
+            .router
+            .insert_runtime_engine(
+                "runtime".to_owned(),
+                Arc::new(Engine::test_stub("runtime")),
+                load_permit.into_resident_permit(),
+            )
+            .unwrap();
+        let removed = state.router.remove_runtime_engine("runtime").unwrap();
+        let (engine, resident_permit) = removed.into_parts();
+        let in_flight = Arc::clone(&engine);
+        let draining = tokio::spawn(drain_and_drop(
+            engine,
+            resident_permit,
+            Duration::from_secs(1),
+        ));
+
+        assert!(state.router.acquire_runtime_load().await.is_err());
+        drop(in_flight);
+        assert!(draining.await.unwrap());
+        assert!(state.router.acquire_runtime_load().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn canceled_unload_handler_keeps_resident_permit_until_drain() {
+        let state = build_state(
+            "[local]\nallow_runtime_model_load = true\nruntime_max_loaded_models = 1\n",
+            HashMap::new(),
+        );
+        let engine = Arc::new(Engine::test_stub("runtime"));
+        let in_flight = Arc::clone(&engine);
+        let load_permit = state.router.acquire_runtime_load().await.unwrap();
+        state
+            .router
+            .insert_runtime_engine(
+                "runtime".to_owned(),
+                engine,
+                load_permit.into_resident_permit(),
+            )
+            .unwrap();
+        assert!(state.router.acquire_runtime_load().await.is_err());
+
+        let unload = tokio::spawn(unload_model(
+            State(Arc::clone(&state)),
+            Path("runtime".to_owned()),
+        ));
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), async {
+                while state.router.contains_engine("runtime") {
+                    tokio::time::sleep(Duration::from_millis(5)).await;
+                }
+            })
+            .await
+            .is_ok(),
+            "unload should detach the engine promptly"
+        );
+        unload.abort();
+        let _ = unload.await;
+
+        assert!(
+            tokio::time::timeout(
+                Duration::from_millis(20),
+                state.router.acquire_runtime_load()
+            )
+            .await
+            .unwrap()
+            .is_err(),
+            "canceling unload released the resident permit too early"
+        );
+        drop(in_flight);
+        let acquired = tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if state.router.acquire_runtime_load().await.is_ok() {
+                    break true;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .unwrap();
+        assert!(acquired);
     }
 }

--- a/crates/higgs/src/routes/models.rs
+++ b/crates/higgs/src/routes/models.rs
@@ -13,6 +13,7 @@ use crate::{
     config::ModelConfig,
     error::ServerError,
     model_resolver,
+    router::RuntimeLoadError,
     state::{Engine, SharedState, build_engine},
     types::openai::{ModelList, ModelObject},
 };
@@ -23,6 +24,9 @@ const DRAIN_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Poll cadence while draining references to an unloaded model.
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Warning cadence while a detached unload is still waiting on references.
+const DRAIN_WARNING_INTERVAL: Duration = Duration::from_secs(30);
 
 /// `GET /v1/models` -- list the locally loaded models.
 pub async fn list_models(State(state): State<SharedState>) -> Json<ModelList> {
@@ -98,13 +102,7 @@ pub async fn load_model(
         .router
         .acquire_runtime_load()
         .await
-        .map_err(|message| {
-            if message.starts_with("runtime model budget reached") {
-                ServerError::BadRequest(message)
-            } else {
-                ServerError::InternalError(message)
-            }
-        })?;
+        .map_err(map_runtime_load_error)?;
 
     // The weight load is blocking and GPU-bound; keep it off the async runtime.
     let local = state.config.local.clone();
@@ -126,6 +124,16 @@ pub async fn load_model(
     Ok(Json(model_object(name)))
 }
 
+fn map_runtime_load_error(error: RuntimeLoadError) -> ServerError {
+    let message = error.to_string();
+    match error {
+        RuntimeLoadError::ResidentBudgetExhausted => ServerError::BadRequest(message),
+        RuntimeLoadError::LoadGateClosed | RuntimeLoadError::ResidentGateClosed => {
+            ServerError::InternalError(message)
+        }
+    }
+}
+
 /// `DELETE /v1/models/{name}` -- unload a model and release its engine resources.
 ///
 /// Returns `204` once the model is fully unloaded, `202` if a request was still
@@ -137,7 +145,7 @@ pub async fn unload_model(
 ) -> Result<StatusCode, ServerError> {
     if !state.config.local.allow_runtime_model_load {
         return Err(ServerError::Forbidden(
-            "runtime model loading is disabled; set local.allow_runtime_model_load = true to enable it"
+            "runtime model unloading is disabled; set local.allow_runtime_model_load = true to enable it"
                 .to_owned(),
         ));
     }
@@ -207,10 +215,18 @@ async fn drain_and_drop(
 }
 
 /// Poll until the detached engine reference is sole-owned, then drop it.
-async fn drain_in_background(
+async fn drain_in_background(engine: Arc<Engine>, resident_permit: Option<OwnedSemaphorePermit>) {
+    drain_in_background_with_warning_interval(engine, resident_permit, DRAIN_WARNING_INTERVAL)
+        .await;
+}
+
+async fn drain_in_background_with_warning_interval(
     mut engine: Arc<Engine>,
     resident_permit: Option<OwnedSemaphorePermit>,
+    warning_interval: Duration,
 ) {
+    let start = Instant::now();
+    let mut last_warning = start;
     loop {
         match Arc::try_unwrap(engine) {
             Ok(owned) => {
@@ -219,6 +235,19 @@ async fn drain_in_background(
                 return;
             }
             Err(shared) => {
+                let now = Instant::now();
+                if now.duration_since(last_warning) >= warning_interval {
+                    let elapsed_ms =
+                        u64::try_from(now.duration_since(start).as_millis()).unwrap_or(u64::MAX);
+                    let strong_count =
+                        u64::try_from(Arc::strong_count(&shared)).unwrap_or(u64::MAX);
+                    tracing::warn!(
+                        elapsed_ms,
+                        strong_count,
+                        "Model unload is still waiting for references to drain"
+                    );
+                    last_warning = now;
+                }
                 engine = shared;
                 tokio::time::sleep(POLL_INTERVAL).await;
             }
@@ -254,9 +283,53 @@ fn model_objects_sorted<'a>(names: impl Iterator<Item = &'a str>) -> Vec<ModelOb
 mod tests {
     use super::*;
     use std::collections::HashMap;
+    use std::sync::Mutex;
 
-    use crate::router::Router;
+    use crate::router::{Router, RuntimeLoadError};
     use crate::state::AppState;
+    use tracing::{Event, Subscriber, field::Visit};
+    use tracing_subscriber::{Layer, layer::Context, prelude::*};
+
+    #[derive(Clone, Default)]
+    struct DrainWarningCapture {
+        fields: Arc<Mutex<Vec<(u64, u64)>>>,
+    }
+
+    impl<S> Layer<S> for DrainWarningCapture
+    where
+        S: Subscriber,
+    {
+        fn on_event(&self, event: &Event<'_>, _context: Context<'_, S>) {
+            if *event.metadata().level() != tracing::Level::WARN {
+                return;
+            }
+            let mut visitor = DrainWarningVisitor::default();
+            event.record(&mut visitor);
+            if let (Some(elapsed_ms), Some(strong_count)) =
+                (visitor.elapsed_ms, visitor.strong_count)
+            {
+                self.fields.lock().unwrap().push((elapsed_ms, strong_count));
+            }
+        }
+    }
+
+    #[derive(Default)]
+    struct DrainWarningVisitor {
+        elapsed_ms: Option<u64>,
+        strong_count: Option<u64>,
+    }
+
+    impl Visit for DrainWarningVisitor {
+        fn record_debug(&mut self, _field: &tracing::field::Field, _value: &dyn std::fmt::Debug) {}
+
+        fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+            match field.name() {
+                "elapsed_ms" => self.elapsed_ms = Some(value),
+                "strong_count" => self.strong_count = Some(value),
+                _ => {}
+            }
+        }
+    }
 
     fn build_state(toml: &str, engines: HashMap<String, Arc<Engine>>) -> SharedState {
         let dir = tempfile::tempdir().unwrap();
@@ -318,11 +391,29 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn unload_disabled_returns_forbidden_with_unloading_message() {
+        let state = build_state(
+            "[local]\nallow_runtime_model_load = false\n",
+            HashMap::new(),
+        );
+
+        let err = unload_model(State(state), Path("model".to_owned()))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            ServerError::Forbidden(message)
+                if message == "runtime model unloading is disabled; set local.allow_runtime_model_load = true to enable it"
+        ));
+    }
+
+    #[tokio::test]
     async fn load_existing_name_conflicts() {
         // allow_runtime on + an already-loaded "llama"; naming it again is a
         // conflict caught before any (impossible, in-test) GPU load.
         let state = build_state(
-            "[local]\nallow_runtime_model_load = true\n",
+            "[server]\napi_key = \"test-api-key\"\n[local]\nallow_runtime_model_load = true\n",
             stub_engines(&["llama"]),
         );
         let body = Bytes::from_static(b"{\"path\":\"some/path\",\"name\":\"llama\"}");
@@ -333,21 +424,43 @@ mod tests {
     #[tokio::test]
     async fn startup_engines_do_not_consume_runtime_model_budget() {
         let state = build_state(
-            "[local]\nallow_runtime_model_load = true\nruntime_max_loaded_models = 1\n",
+            "[server]\napi_key = \"test-api-key\"\n[local]\nallow_runtime_model_load = true\nruntime_max_loaded_models = 1\n",
             stub_engines(&["startup"]),
         );
         let body = Bytes::from_static(b"{\"path\":\"org/model\",\"name\":\"runtime\"}");
         let err = load_model(State(state), body).await.unwrap_err();
+        let ServerError::BadRequest(message) = err else {
+            panic!("expected runtime resolver bad request, got: {err}");
+        };
+        assert_eq!(
+            message,
+            "model 'org/model' not found locally: could not read HF cache ref for 'org/model': No such file or directory (os error 2); pre-download it (e.g. `huggingface-cli download org/model`)"
+        );
+    }
+
+    #[test]
+    fn runtime_load_errors_map_by_typed_variant() {
         assert!(matches!(
-            err,
+            map_runtime_load_error(RuntimeLoadError::ResidentBudgetExhausted),
             ServerError::BadRequest(message)
-                if !message.contains("runtime model budget reached")
+                if message == "runtime model budget reached; unload a runtime model before loading another"
+        ));
+        assert!(matches!(
+            map_runtime_load_error(RuntimeLoadError::LoadGateClosed),
+            ServerError::InternalError(message) if message == "runtime load gate closed"
+        ));
+        assert!(matches!(
+            map_runtime_load_error(RuntimeLoadError::ResidentGateClosed),
+            ServerError::InternalError(message) if message == "runtime resident-model gate closed"
         ));
     }
 
     #[tokio::test]
     async fn unload_unknown_returns_not_found() {
-        let state = build_state("[local]\nallow_runtime_model_load = true\n", HashMap::new());
+        let state = build_state(
+            "[server]\napi_key = \"test-api-key\"\n[local]\nallow_runtime_model_load = true\n",
+            HashMap::new(),
+        );
         let err = unload_model(State(state), Path("ghost".to_owned()))
             .await
             .unwrap_err();
@@ -365,6 +478,9 @@ mod tests {
             enabled = true
             model = "router"
 
+            [server]
+            api_key = "test-api-key"
+
             [local]
             allow_runtime_model_load = true
         "#;
@@ -380,7 +496,7 @@ mod tests {
     #[tokio::test]
     async fn unload_removes_engine_and_frees_it() {
         let state = build_state(
-            "[local]\nallow_runtime_model_load = true\n",
+            "[server]\napi_key = \"test-api-key\"\n[local]\nallow_runtime_model_load = true\n",
             stub_engines(&["llama"]),
         );
         let status = unload_model(State(Arc::clone(&state)), Path("llama".to_owned()))
@@ -423,10 +539,41 @@ mod tests {
         drop(clone); // let the detached task finish
     }
 
+    #[tokio::test(flavor = "current_thread")]
+    async fn background_drain_warns_periodically_while_references_remain() {
+        let capture = DrainWarningCapture::default();
+        let captured_fields = Arc::clone(&capture.fields);
+        let subscriber = tracing_subscriber::registry().with(capture);
+        let _subscriber_guard = tracing::subscriber::set_default(subscriber);
+        let engine = Arc::new(Engine::test_stub("stuck"));
+        let in_flight = Arc::clone(&engine);
+
+        let draining = tokio::spawn(drain_in_background_with_warning_interval(
+            engine,
+            None,
+            Duration::from_millis(30),
+        ));
+        tokio::time::sleep(Duration::from_millis(125)).await;
+
+        let warnings = captured_fields.lock().unwrap().clone();
+        assert!(warnings.len() >= 2, "captured warnings: {warnings:?}");
+        assert!(
+            warnings
+                .iter()
+                .all(|(elapsed_ms, strong_count)| *elapsed_ms >= 30 && *strong_count == 2),
+            "captured warnings: {warnings:?}"
+        );
+        drop(in_flight);
+        tokio::time::timeout(Duration::from_secs(1), draining)
+            .await
+            .unwrap()
+            .unwrap();
+    }
+
     #[tokio::test]
     async fn resident_permit_stays_held_until_unload_drain_finishes() {
         let state = build_state(
-            "[local]\nallow_runtime_model_load = true\nruntime_max_loaded_models = 1\n",
+            "[server]\napi_key = \"test-api-key\"\n[local]\nallow_runtime_model_load = true\nruntime_max_loaded_models = 1\n",
             HashMap::new(),
         );
         let load_permit = state.router.acquire_runtime_load().await.unwrap();
@@ -456,7 +603,7 @@ mod tests {
     #[tokio::test]
     async fn canceled_unload_handler_keeps_resident_permit_until_drain() {
         let state = build_state(
-            "[local]\nallow_runtime_model_load = true\nruntime_max_loaded_models = 1\n",
+            "[server]\napi_key = \"test-api-key\"\n[local]\nallow_runtime_model_load = true\nruntime_max_loaded_models = 1\n",
             HashMap::new(),
         );
         let engine = Arc::new(Engine::test_stub("runtime"));

--- a/crates/higgs/src/routes/models.rs
+++ b/crates/higgs/src/routes/models.rs
@@ -1,16 +1,188 @@
-use axum::{Json, extract::State};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+};
+use bytes::Bytes;
 
 use crate::{
-    state::SharedState,
+    config::ModelConfig,
+    error::ServerError,
+    model_resolver,
+    state::{Engine, SharedState, build_engine},
     types::openai::{ModelList, ModelObject},
 };
 
+/// How long `DELETE /v1/models/{name}` waits for in-flight requests to release a
+/// model before detaching the final drop to a background task.
+const DRAIN_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Poll cadence while draining references to an unloaded model.
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// `GET /v1/models` -- list the locally loaded models.
 pub async fn list_models(State(state): State<SharedState>) -> Json<ModelList> {
-    let data = model_objects_sorted(state.router.local_engines().keys().map(String::as_str));
+    let names = state.router.local_model_names();
+    let data = model_objects_sorted(names.iter().map(String::as_str));
     Json(ModelList {
         object: "list",
         data,
     })
+}
+
+/// `POST /v1/models` -- load a model into GPU memory at runtime.
+///
+/// Opt-in via `local.allow_runtime_model_load`. The body mirrors a `[[models]]`
+/// config entry (`path` required; `name`, `batch`, `mlx_profile`, `kv_*`
+/// optional). Returns the created model object, `409` on a name collision, or
+/// `403` when runtime loading is disabled.
+pub async fn load_model(
+    State(state): State<SharedState>,
+    body: Bytes,
+) -> Result<Json<ModelObject>, ServerError> {
+    if !state.config.local.allow_runtime_model_load {
+        return Err(ServerError::Forbidden(
+            "runtime model loading is disabled; set local.allow_runtime_model_load = true to enable it"
+                .to_owned(),
+        ));
+    }
+
+    let model_cfg: ModelConfig = serde_json::from_slice(&body)
+        .map_err(|e| ServerError::BadRequest(format!("invalid model config: {e}")))?;
+
+    // Validate the KV-cache config up front, mirroring `doctor::check_models`.
+    model_cfg
+        .kv_cache_config()
+        .validate()
+        .map_err(|e| ServerError::BadRequest(format!("invalid KV cache config: {e}")))?;
+    if model_cfg.batch && model_cfg.kv_cache_config().is_turboquant() {
+        return Err(ServerError::BadRequest(
+            "unsupported combination: TurboQuant KV cache with batch=true".to_owned(),
+        ));
+    }
+
+    // Cheap collision pre-check when the caller named the model, so we don't pay
+    // for a full load just to reject it. `insert_engine` re-checks under the
+    // write lock, so this is an optimization, not the source of truth.
+    if let Some(ref name) = model_cfg.name {
+        if state.router.contains_engine(name) {
+            return Err(ServerError::Conflict(format!(
+                "model '{name}' is already loaded"
+            )));
+        }
+    }
+
+    // Resolve the path without prompting -- the server has no interactive stdin.
+    let resolved = model_resolver::resolve(&model_cfg.path).map_err(|e| {
+        ServerError::BadRequest(format!(
+            "model '{}' not found locally: {e}; pre-download it (e.g. `huggingface-cli download {}`)",
+            model_cfg.path, model_cfg.path
+        ))
+    })?;
+
+    // The weight load is blocking and GPU-bound; keep it off the async runtime.
+    let local = state.config.local.clone();
+    let cfg = model_cfg.clone();
+    let (name, engine) = tokio::task::spawn_blocking(move || build_engine(&resolved, &cfg, &local))
+        .await
+        .map_err(|e| ServerError::InternalError(format!("model load task failed: {e}")))?
+        .map_err(ServerError::BadRequest)?;
+
+    state
+        .router
+        .insert_engine(name.clone(), Arc::new(engine))
+        .map_err(|n| ServerError::Conflict(format!("model '{n}' is already loaded")))?;
+
+    tracing::info!(model_name = %name, "Model loaded at runtime");
+    Ok(Json(model_object(name)))
+}
+
+/// `DELETE /v1/models/{name}` -- unload a model and free its GPU memory.
+///
+/// Returns `204` once the model is fully unloaded, `202` if a request was still
+/// in flight past the drain timeout (the final free is detached), `404` if no
+/// such model is loaded, or `409` if the model backs the auto-router.
+pub async fn unload_model(
+    State(state): State<SharedState>,
+    Path(name): Path<String>,
+) -> Result<StatusCode, ServerError> {
+    if state.router.auto_router_model_name() == Some(name.as_str()) {
+        return Err(ServerError::Conflict(format!(
+            "model '{name}' is bound to the auto-router and cannot be unloaded"
+        )));
+    }
+
+    let engine = state
+        .router
+        .remove_engine(&name)
+        .ok_or_else(|| ServerError::ModelNotFound(name.clone()))?;
+
+    // The map entry is gone, so no new request can take a reference and the
+    // strong count only decreases. Free GPU memory once the last in-flight
+    // request releases its clone; detach past the timeout so a long generation
+    // can't block the response.
+    if drain_and_drop(engine, DRAIN_TIMEOUT).await {
+        tracing::info!(model_name = %name, "Model unloaded");
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        tracing::info!(model_name = %name, "Model unload deferred; request still in flight");
+        Ok(StatusCode::ACCEPTED)
+    }
+}
+
+/// Wait until `engine` is solely owned here, then drop it (freeing GPU memory).
+///
+/// Returns `true` if dropped within `timeout`; `false` if it timed out and the
+/// final drop was handed to a detached task. Dropping is intentionally not gated
+/// on the process-wide GPU gate: engine teardown frees MLX buffers but never
+/// runs an `eval`, so it cannot race the cross-model output-array table that the
+/// gate protects.
+async fn drain_and_drop(mut engine: Arc<Engine>, timeout: Duration) -> bool {
+    let start = Instant::now();
+    loop {
+        match Arc::try_unwrap(engine) {
+            Ok(owned) => {
+                drop(owned);
+                return true;
+            }
+            Err(shared) => {
+                if start.elapsed() >= timeout {
+                    tokio::spawn(drain_in_background(shared));
+                    return false;
+                }
+                engine = shared;
+                tokio::time::sleep(POLL_INTERVAL).await;
+            }
+        }
+    }
+}
+
+/// Poll until the detached engine reference is sole-owned, then drop it.
+async fn drain_in_background(mut engine: Arc<Engine>) {
+    loop {
+        match Arc::try_unwrap(engine) {
+            Ok(owned) => {
+                drop(owned);
+                return;
+            }
+            Err(shared) => {
+                engine = shared;
+                tokio::time::sleep(POLL_INTERVAL).await;
+            }
+        }
+    }
+}
+
+fn model_object(name: String) -> ModelObject {
+    ModelObject {
+        id: name,
+        object: "model",
+        created: chrono::Utc::now().timestamp(),
+        owned_by: "local".to_owned(),
+    }
 }
 
 /// Build a sorted, stable list of [`ModelObject`]s from an iterator of model names.
@@ -19,12 +191,7 @@ fn model_objects_sorted<'a>(names: impl Iterator<Item = &'a str>) -> Vec<ModelOb
     sorted.sort_unstable();
     sorted
         .into_iter()
-        .map(|name| ModelObject {
-            id: name.to_owned(),
-            object: "model",
-            created: chrono::Utc::now().timestamp(),
-            owned_by: "local".to_owned(),
-        })
+        .map(|name| model_object(name.to_owned()))
         .collect()
 }
 
@@ -32,6 +199,34 @@ fn model_objects_sorted<'a>(names: impl Iterator<Item = &'a str>) -> Vec<ModelOb
 #[allow(clippy::panic, clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
+
+    use crate::router::Router;
+    use crate::state::AppState;
+
+    fn build_state(toml: &str, engines: HashMap<String, Arc<Engine>>) -> SharedState {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        // A stub provider satisfies the "at least one [[models]] or [provider.*]"
+        // config rule; it does not affect direct local-engine routing.
+        let full = format!("[provider.stub]\nurl = \"http://127.0.0.1:1\"\n\n{toml}");
+        std::fs::write(&path, full).unwrap();
+        let config = crate::config::load_config_file(&path, None).unwrap();
+        let router = Router::from_config(&config, engines).unwrap();
+        Arc::new(AppState {
+            router,
+            config,
+            http_client: reqwest::Client::new(),
+            metrics: None,
+        })
+    }
+
+    fn stub_engines(names: &[&str]) -> HashMap<String, Arc<Engine>> {
+        names
+            .iter()
+            .map(|n| ((*n).to_owned(), Arc::new(Engine::test_stub(n))))
+            .collect()
+    }
 
     #[test]
     fn test_model_list_is_sorted_alphabetically() {
@@ -48,18 +243,111 @@ mod tests {
     }
 
     #[test]
-    fn test_model_list_single_entry() {
-        let data = model_objects_sorted(std::iter::once("only-model"));
-        assert_eq!(data.len(), 1);
-        assert_eq!(data.first().map(|m| m.id.as_str()), Some("only-model"));
-    }
-
-    #[test]
     fn test_model_objects_have_correct_fields() {
         let data = model_objects_sorted(std::iter::once("test-model"));
         let obj = data.first().unwrap();
         assert_eq!(obj.object, "model");
         assert_eq!(obj.owned_by, "local");
         assert!(obj.created > 0);
+    }
+
+    #[tokio::test]
+    async fn load_disabled_returns_forbidden() {
+        let state = build_state(
+            "[local]\nallow_runtime_model_load = false\n",
+            HashMap::new(),
+        );
+        let err = load_model(State(state), Bytes::from_static(b"{\"path\":\"x\"}"))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ServerError::Forbidden(_)));
+    }
+
+    #[tokio::test]
+    async fn load_existing_name_conflicts() {
+        // allow_runtime on + an already-loaded "llama"; naming it again is a
+        // conflict caught before any (impossible, in-test) GPU load.
+        let state = build_state(
+            "[local]\nallow_runtime_model_load = true\n",
+            stub_engines(&["llama"]),
+        );
+        let body = Bytes::from_static(b"{\"path\":\"some/path\",\"name\":\"llama\"}");
+        let err = load_model(State(state), body).await.unwrap_err();
+        assert!(matches!(err, ServerError::Conflict(_)));
+    }
+
+    #[tokio::test]
+    async fn unload_unknown_returns_not_found() {
+        let state = build_state("[local]\nallow_runtime_model_load = true\n", HashMap::new());
+        let err = unload_model(State(state), Path("ghost".to_owned()))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ServerError::ModelNotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn unload_auto_router_model_is_refused() {
+        let toml = r#"
+            [[models]]
+            path = "/models/Arch-Router-1.5B-4bit"
+            name = "router"
+
+            [auto_router]
+            enabled = true
+            model = "router"
+        "#;
+        let state = build_state(toml, stub_engines(&["router"]));
+        let err = unload_model(State(Arc::clone(&state)), Path("router".to_owned()))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ServerError::Conflict(_)));
+        // Still loaded.
+        assert!(state.router.contains_engine("router"));
+    }
+
+    #[tokio::test]
+    async fn unload_removes_engine_and_frees_it() {
+        let state = build_state(
+            "[local]\nallow_runtime_model_load = true\n",
+            stub_engines(&["llama"]),
+        );
+        let status = unload_model(State(Arc::clone(&state)), Path("llama".to_owned()))
+            .await
+            .unwrap();
+        assert_eq!(status, StatusCode::NO_CONTENT);
+        assert!(!state.router.contains_engine("llama"));
+        assert!(state.router.local_model_names().is_empty());
+    }
+
+    #[tokio::test]
+    async fn drain_and_drop_drops_sole_owner_immediately() {
+        let engine = Arc::new(Engine::test_stub("solo"));
+        assert!(drain_and_drop(engine, Duration::from_secs(1)).await);
+    }
+
+    #[tokio::test]
+    async fn drain_and_drop_waits_for_in_flight_clone() {
+        let engine = Arc::new(Engine::test_stub("busy"));
+        let clone = Arc::clone(&engine);
+        // Release the simulated in-flight reference after a short delay.
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(120)).await;
+            drop(clone);
+        });
+        let start = Instant::now();
+        assert!(drain_and_drop(engine, Duration::from_secs(5)).await);
+        assert!(
+            start.elapsed() >= Duration::from_millis(100),
+            "should have waited for the clone to drop"
+        );
+    }
+
+    #[tokio::test]
+    async fn drain_and_drop_times_out_and_detaches() {
+        let engine = Arc::new(Engine::test_stub("stuck"));
+        let clone = Arc::clone(&engine); // held past the timeout
+        let drained = drain_and_drop(engine, Duration::from_millis(80)).await;
+        assert!(!drained, "should time out while a reference is held");
+        drop(clone); // let the detached task finish
     }
 }

--- a/crates/higgs/src/state.rs
+++ b/crates/higgs/src/state.rs
@@ -48,6 +48,11 @@ pub enum Engine {
     Batch(Box<BatchEngine>),
     #[cfg(test)]
     Stub(String),
+    #[cfg(test)]
+    StubWithOutput {
+        name: String,
+        output: String,
+    },
 }
 
 impl Engine {
@@ -74,12 +79,22 @@ impl Engine {
         Self::Stub(name.to_owned())
     }
 
+    #[cfg(test)]
+    pub fn test_stub_with_output(name: &str, output: &str) -> Self {
+        Self::StubWithOutput {
+            name: name.to_owned(),
+            output: output.to_owned(),
+        }
+    }
+
     pub fn model_name(&self) -> &str {
         match self {
             Self::Simple(e) => e.model_name(),
             Self::Batch(e) => e.model_name(),
             #[cfg(test)]
             Self::Stub(name) => name,
+            #[cfg(test)]
+            Self::StubWithOutput { name, .. } => name,
         }
     }
 
@@ -89,7 +104,9 @@ impl Engine {
             Self::Simple(e) => e.tokenizer(),
             Self::Batch(e) => e.tokenizer(),
             #[cfg(test)]
-            Self::Stub(_) => panic!("Engine::test_stub has no tokenizer"),
+            Self::Stub(_) | Self::StubWithOutput { .. } => {
+                panic!("Engine::test_stub has no tokenizer")
+            }
         }
     }
 
@@ -98,7 +115,7 @@ impl Engine {
             Self::Simple(e) => e.eos_token_ids(),
             Self::Batch(e) => e.eos_token_ids(),
             #[cfg(test)]
-            Self::Stub(_) => &[],
+            Self::Stub(_) | Self::StubWithOutput { .. } => &[],
         }
     }
 
@@ -107,7 +124,7 @@ impl Engine {
             Self::Simple(e) => e.hidden_size(),
             Self::Batch(e) => e.hidden_size(),
             #[cfg(test)]
-            Self::Stub(_) => 0,
+            Self::Stub(_) | Self::StubWithOutput { .. } => 0,
         }
     }
 
@@ -116,7 +133,7 @@ impl Engine {
             Self::Simple(e) => e.enable_thinking(),
             Self::Batch(_) => false,
             #[cfg(test)]
-            Self::Stub(_) => false,
+            Self::Stub(_) | Self::StubWithOutput { .. } => false,
         }
     }
 
@@ -125,7 +142,7 @@ impl Engine {
             Self::Simple(e) => e.is_vlm(),
             Self::Batch(_) => false,
             #[cfg(test)]
-            Self::Stub(_) => false,
+            Self::Stub(_) | Self::StubWithOutput { .. } => false,
         }
     }
 
@@ -134,7 +151,7 @@ impl Engine {
             Self::Simple(e) => e.vlm_image_size(),
             Self::Batch(_) => None,
             #[cfg(test)]
-            Self::Stub(_) => None,
+            Self::Stub(_) | Self::StubWithOutput { .. } => None,
         }
     }
 
@@ -143,7 +160,7 @@ impl Engine {
             Self::Simple(e) => e.replace_image_tokens(tokens),
             Self::Batch(_) => {}
             #[cfg(test)]
-            Self::Stub(_) => {}
+            Self::Stub(_) | Self::StubWithOutput { .. } => {}
         }
     }
 
@@ -156,7 +173,7 @@ impl Engine {
             Self::Simple(e) => e.prepare_chat_prompt(messages, tools),
             Self::Batch(e) => e.prepare_chat_prompt(messages, tools),
             #[cfg(test)]
-            Self::Stub(_) => Ok(Vec::new()),
+            Self::Stub(_) | Self::StubWithOutput { .. } => Ok(Vec::new()),
         }
     }
 
@@ -172,7 +189,7 @@ impl Engine {
             }
             Self::Batch(e) => e.prepare_chat_prompt_with_thinking(messages, tools, enable_thinking),
             #[cfg(test)]
-            Self::Stub(_) => Ok(Vec::new()),
+            Self::Stub(_) | Self::StubWithOutput { .. } => Ok(Vec::new()),
         }
     }
 
@@ -240,6 +257,14 @@ impl Engine {
             ),
             #[cfg(test)]
             Self::Stub(_) => Err(EngineError::Generation("test stub".to_owned())),
+            #[cfg(test)]
+            Self::StubWithOutput { output, .. } => Ok(higgs_engine::engine::GenerationOutput {
+                text: output.clone(),
+                finish_reason: "stop".to_owned(),
+                prompt_tokens: 0,
+                completion_tokens: 0,
+                token_logprobs: None,
+            }),
         }
     }
 
@@ -311,7 +336,9 @@ impl Engine {
                 pixel_values,
             ),
             #[cfg(test)]
-            Self::Stub(_) => Err(EngineError::Generation("test stub".to_owned())),
+            Self::Stub(_) | Self::StubWithOutput { .. } => {
+                Err(EngineError::Generation("test stub".to_owned()))
+            }
         }
     }
 
@@ -321,7 +348,7 @@ impl Engine {
             Self::Simple(e) => e.embed(token_ids),
             Self::Batch(e) => e.embed(token_ids),
             #[cfg(test)]
-            Self::Stub(_) => Ok(Vec::new()),
+            Self::Stub(_) | Self::StubWithOutput { .. } => Ok(Vec::new()),
         }
     }
 }

--- a/crates/higgs/src/state.rs
+++ b/crates/higgs/src/state.rs
@@ -5,14 +5,14 @@ use higgs_engine::batch_engine::BatchEngine;
 use higgs_engine::chat_template::ChatMessage;
 use higgs_engine::engine::{GenerationOutput, StreamingOutput};
 use higgs_engine::error::EngineError;
-use higgs_engine::mlx_tuning::MlxRuntimeTuning;
+use higgs_engine::mlx_tuning::{MlxRuntimeTuning, resolve_runtime_tuning};
 use higgs_engine::simple::SimpleEngine;
 use higgs_engine::tokenizers::Tokenizer;
 use higgs_models::SamplingParams;
 use higgs_models::turboquant::KvCacheConfig;
 use mlx_rs::Array;
 
-use crate::config::HiggsConfig;
+use crate::config::{HiggsConfig, LocalConfig, ModelConfig, resolved_model_supports_batch};
 use crate::metrics::MetricsStore;
 use crate::router::Router;
 
@@ -36,7 +36,9 @@ static GPU_GATE: std::sync::Mutex<()> = std::sync::Mutex::new(());
 /// Acquire the global GPU gate, recovering from poisoning so a panic mid-eval
 /// cannot permanently wedge all inference.
 fn gpu_gate() -> std::sync::MutexGuard<'static, ()> {
-    GPU_GATE.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
+    GPU_GATE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
 /// Unified engine interface wrapping either the simple (serialized) or batch
@@ -322,6 +324,39 @@ impl Engine {
             Self::Stub(_) => Ok(Vec::new()),
         }
     }
+}
+
+/// Build an engine from an already-resolved model directory and its config.
+///
+/// Shared by startup loading (`load_engines` in the binary) and the runtime
+/// load endpoint (`POST /v1/models`). Path resolution and any download prompt
+/// are the caller's responsibility, so this never blocks on stdin. Returns the
+/// model's exposed name alongside the constructed engine.
+pub fn build_engine(
+    resolved: &Path,
+    model_cfg: &ModelConfig,
+    local: &LocalConfig,
+) -> Result<(String, Engine), String> {
+    if model_cfg.batch && !resolved_model_supports_batch(resolved)? {
+        return Err(format!(
+            "batch=true is only supported for transformer models (llama, mistral, qwen2, qwen3); '{}' is not supported",
+            model_cfg.path
+        ));
+    }
+    let kv_cache_config = model_cfg.kv_cache_config();
+    let engine = if model_cfg.batch {
+        Engine::load_batch(resolved, kv_cache_config, local.raise_wired_limit)
+            .map_err(|e| e.to_string())?
+    } else {
+        let tuning = resolve_runtime_tuning(resolved, model_cfg.requested_mlx_profile(local));
+        Engine::load_simple(resolved, kv_cache_config, tuning, local.raise_wired_limit)
+            .map_err(|e| e.to_string())?
+    };
+    let name = model_cfg
+        .name
+        .clone()
+        .unwrap_or_else(|| engine.model_name().to_owned());
+    Ok((name, engine))
 }
 
 /// Shared application state available to all route handlers.

--- a/crates/higgs/src/state.rs
+++ b/crates/higgs/src/state.rs
@@ -16,6 +16,29 @@ use crate::config::HiggsConfig;
 use crate::metrics::MetricsStore;
 use crate::router::Router;
 
+/// Process-wide GPU inference gate.
+///
+/// MLX's Metal backend keeps shared, non-stream-local state — notably the
+/// output-array table mutated in `metal::CommandEncoder::set_output_array`. Two
+/// co-resident models evaluating concurrently (each on its own `spawn_blocking`
+/// thread, each under a fresh `with_new_default_stream(Stream::new())`) race on
+/// that table and corrupt it → `EXC_BAD_ACCESS`/SIGSEGV inside
+/// `set_output_array`. The per-engine `Mutex<AnyModel>` only serializes a single
+/// model, not across the co-resident set (e.g. an SLM trio).
+///
+/// On a single-GPU host there is no real parallelism to lose, so all GPU eval is
+/// serialized through this one gate. Held only for the duration of a
+/// generate/embed call. NOTE: this also serializes concurrent requests to a
+/// single `Batch` engine; if per-model batch interleaving is reintroduced, this
+/// gate should be narrowed to cross-model boundaries.
+static GPU_GATE: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Acquire the global GPU gate, recovering from poisoning so a panic mid-eval
+/// cannot permanently wedge all inference.
+fn gpu_gate() -> std::sync::MutexGuard<'static, ()> {
+    GPU_GATE.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
 /// Unified engine interface wrapping either the simple (serialized) or batch
 /// (interleaved) engine. Route handlers interact with this enum exclusively.
 pub enum Engine {
@@ -189,6 +212,7 @@ impl Engine {
         constraint: Option<higgs_engine::constrained::ConstrainedGenerator>,
         pixel_values: Option<Array>,
     ) -> Result<GenerationOutput, EngineError> {
+        let _gpu = gpu_gate();
         match self {
             Self::Simple(e) => e.generate_with_thinking(
                 prompt_tokens,
@@ -258,6 +282,7 @@ impl Engine {
         constraint: Option<higgs_engine::constrained::ConstrainedGenerator>,
         pixel_values: Option<Array>,
     ) -> Result<(), EngineError> {
+        let _gpu = gpu_gate();
         match self {
             Self::Simple(e) => e.generate_streaming_with_thinking(
                 prompt_tokens,
@@ -289,6 +314,7 @@ impl Engine {
     }
 
     pub fn embed(&self, token_ids: &[u32]) -> Result<Vec<f32>, EngineError> {
+        let _gpu = gpu_gate();
         match self {
             Self::Simple(e) => e.embed(token_ids),
             Self::Batch(e) => e.embed(token_ids),

--- a/crates/higgs/tests/integration/api_contract.rs
+++ b/crates/higgs/tests/integration/api_contract.rs
@@ -5,7 +5,8 @@
     clippy::unwrap_used,
     clippy::indexing_slicing,
     clippy::tests_outside_test_module,
-    clippy::needless_pass_by_value
+    clippy::needless_pass_by_value,
+    clippy::significant_drop_tightening
 )]
 
 use std::collections::HashMap;
@@ -111,7 +112,7 @@ async fn load_model_disabled_returns_403() {
 }
 
 #[tokio::test]
-async fn unload_unknown_model_returns_404() {
+async fn unload_model_disabled_returns_403() {
     let app = build_router(build_test_state(None), 300.0, None, 0, 1024, None);
     let response = app
         .oneshot(
@@ -124,7 +125,7 @@ async fn unload_unknown_model_returns_404() {
         .await
         .unwrap();
 
-    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
 }
 
 #[tokio::test]

--- a/crates/higgs/tests/integration/api_contract.rs
+++ b/crates/higgs/tests/integration/api_contract.rs
@@ -92,6 +92,42 @@ async fn metrics_endpoint_returns_snapshot_json() {
 }
 
 #[tokio::test]
+async fn load_model_disabled_returns_403() {
+    // Default test config has no [local] section, so runtime loading is off.
+    let app = build_router(build_test_state(None), 300.0, None, 0, 1024, None);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/models")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"path":"some/model"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn unload_unknown_model_returns_404() {
+    let app = build_router(build_test_state(None), 300.0, None, 0, 1024, None);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri("/v1/models/ghost")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
 async fn request_body_limit_is_enforced() {
     let app = build_router(build_test_state(None), 300.0, None, 0, 64, None);
     let body = serde_json::json!({

--- a/crates/higgs/tests/integration/proxy_e2e.rs
+++ b/crates/higgs/tests/integration/proxy_e2e.rs
@@ -11,7 +11,8 @@
     clippy::tests_outside_test_module,
     clippy::needless_pass_by_value,
     clippy::unreadable_literal,
-    clippy::needless_borrows_for_generic_args
+    clippy::needless_borrows_for_generic_args,
+    clippy::significant_drop_tightening
 )]
 
 use std::collections::HashMap;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,10 +69,15 @@ port = 8000
 [local]
 mlx_profile = "auto"
 raise_wired_limit = false
-# Runtime POST/DELETE /v1/models requires server.api_key.
+# Runtime POST/DELETE /v1/models requires allow_runtime_model_load = true
+# and a non-empty server.api_key.
 # allow_runtime_model_load = false
+# Empty runtime_model_roots permits only cached Hugging Face model IDs;
+# configured roots constrain local runtime model paths to those directories.
 # runtime_model_roots = ["/models"]
+# Limits runtime-loaded models only; startup-configured [[models]] do not count.
 # runtime_max_loaded_models = 2
+# Limits simultaneous runtime model load attempts.
 # runtime_max_concurrent_loads = 1
 
 # --- Local models ---

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,6 +69,11 @@ port = 8000
 [local]
 mlx_profile = "auto"
 raise_wired_limit = false
+# Runtime POST/DELETE /v1/models requires server.api_key.
+# allow_runtime_model_load = false
+# runtime_model_roots = ["/models"]
+# runtime_max_loaded_models = 2
+# runtime_max_concurrent_loads = 1
 
 # --- Local models ---
 [[models]]


### PR DESCRIPTION
## What

Adds two opt-in admin endpoints so operators can change the set of loaded models **while the server runs**, without a restart:

| Method | Path | Behaviour |
|---|---|---|
| `POST` | `/v1/models` | Load a model (body mirrors a `[[models]]` entry; `path` required). `200` + model object, `409` on name collision, `400` if not cached locally, `403` when disabled. |
| `DELETE` | `/v1/models/{name}` | Unload and free GPU memory. `204` once freed, `202` if a request is still draining, `404` unknown, `409` for the auto-router model. |
| `GET` | `/v1/models` | Now a read-lock snapshot. |

Opt-in via `local.allow_runtime_model_load` (default **off**; gate behind `server.api_key`). Changes are **in-memory only** — the TOML config stays the source of truth.

## How

- `Router.local_engines` becomes a `RwLock<HashMap>`. `resolve()`/list take a read lock and clone the `Arc<Engine>` out, so an **in-flight request is decoupled from map membership** — a concurrent unload can never free a model mid-request.
- **Unload** removes the map entry, drains to sole ownership (`Arc::try_unwrap`), then drops; past a 30s timeout it detaches the final free and returns `202`. Drop is intentionally ungated — engine teardown frees MLX buffers but never runs an `eval`, so it can't race the cross-model output-array table.
- **Load** resolves the path non-interactively and runs the blocking weight load in `spawn_blocking`. A shared `state::build_engine` is reused by both startup loading and the endpoint.
- Unloading the auto-router model is refused (it holds a separate `Arc`).
- Adds `ServerError::{Conflict, Forbidden}`, a `doctor` capability warning, and `init`-template + README docs.

## Note on the base

This branch includes a cherry-pick of `fbdcd2f7` (*serialize GPU eval across models to stop SIGSEGV*) as a **prerequisite** — it is not yet on `main`, and runtime loading is all about co-resident models, which is exactly the case that fix makes safe.

## Testing

- `cargo fmt --check`, `cargo clippy -p higgs` (nursery) clean, `cargo test -p higgs -- --test-threads=1`: **583 passed / 0 failed** (13 new unit + 2 integration tests: guards, load→list→route→unload round-trip, drain-to-sole-ownership).
- **Live GPU run** (M-series): startup-load → runtime-load a 2nd model (RSS 493→860 MB) → co-resident → routed real inference to the loaded model → dup `409` → unauth `401` → unload `204` (memory released) → unknown `404` → server healthy with 0 models. No SIGSEGV under co-resident inference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime model listing, loading, and unloading through the `/v1/models` API.
  * Added configurable local model roots, resident-model capacity, and concurrent loading limits.
  * Added support for loading models from authorized local directories and existing Hugging Face caches.

* **Bug Fixes**
  * Added API-key protection and clear errors for unauthorized or conflicting operations.
  * Improved unloading behavior while models handle active requests.
  * Prevented unloading models managed by the auto-router.

* **Documentation**
  * Documented configuration, authentication, runtime model management, health, and metrics endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->