### PR TITLE
fix(bonsai): apply causal mask during prefill

### DIFF
--- a/crates/higgs-models/src/bonsai_q1.rs
+++ b/crates/higgs-models/src/bonsai_q1.rs
@@ -700,7 +700,10 @@ impl BonsaiQ1Gpu {
         h.eval()?;
         times.add("embed_rows", t0.elapsed().as_nanos());
 
-        let mask = create_attention_mask(&h, cache, None)?;
+        // Prefill (T>1) needs a causal mask. Request the Array form: the cached
+        // SDPA path below consumes Option<&Array> and applies no causal masking
+        // itself, so the Causal variant would be dropped to None (= no mask).
+        let mask = create_attention_mask(&h, cache, Some(true))?;
 
         let heads = i32::try_from(self.config.heads)
             .map_err(|_| Exception::custom("heads overflows i32"))?;
@@ -865,7 +868,10 @@ pub fn forward_trunk_free(
 
     let mut h = gpu.embed_rows(inputs)?; // [B, L, hidden]
 
-    let mask = create_attention_mask(&h, cache, None)?;
+    // Prefill (T>1) needs a causal mask. Request the Array form: the cached
+    // SDPA path below consumes Option<&Array> and applies no causal masking
+    // itself, so the Causal variant would be dropped to None (= no mask).
+    let mask = create_attention_mask(&h, cache, Some(true))?;
 
     let heads =
         i32::try_from(gpu.config.heads).map_err(|_| Exception::custom("heads overflows i32"))?;


### PR DESCRIPTION
## Problem

Both `forward_trunk` and `forward_trunk_free` in `bonsai_q1.rs` call `create_attention_mask(&h, cache, None)`, which returns `AttentionMask::Causal` for multi-token prefill (`T > 1`). The per-layer mask handling then matches only `Some(AttentionMask::Array(a))` and drops `Causal` to `None`:

```rust
let mask_arr = match &mask {
    Some(AttentionMask::Array(a)) => Some(a),
    _ => None,   // ← Causal silently dropped
};
```

Since `cached_scaled_dot_product_attention` takes `Option<&Array>` and applies no causal masking itself, **prefill ran with no mask at all** — every prompt token attended to future tokens, corrupting generation for any prompt longer than one token. Decode (`T = 1`) was unaffected (mask is correctly `None` there).

For contrast, `qwen3_moe` requests `None` too but intercepts `Causal` *before* the drop and applies `ScaledDotProductAttentionMask::Causal`; `transformer.rs` sidesteps it by requesting `Some(true)` and hard-erroring on `Causal`. Bonsai had neither.

## Fix

Request the `Array` form (`Some(true)`) so the existing `Some(Array(a))` arm picks it up and the dense prefill path applies it. The mask is offset-aware (`create_causal_mask(T, Some(offset))`), so chunked prefill works too.

## Testing

- `cargo build -p higgs-models` — clean
- `cargo clippy -p higgs-models` — clean
- `cargo test -p higgs-models` attention-mask + cached-SDPA suites pass, including `test_cached_scaled_dot_product_attention_matches_dense_turbo_prefill_masked` and `..._mask_with_offset`, which directly cover the array-mask prefill path bonsai now uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed attention mask handling in the forward-pass implementation to ensure proper alignment with downstream processing.

* **Documentation**
  * Added inline comments documenting mask representation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->