### PR TITLE
DFlash speculative decoding for Qwen3.6/3.5 (Rust + MLX)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1671,6 +1671,7 @@ dependencies = [
  "tokenizers 0.23.1",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/higgs-engine/Cargo.toml
+++ b/crates/higgs-engine/Cargo.toml
@@ -27,3 +27,4 @@ half = { version = "2.4", features = ["bytemuck"] }
 
 [dev-dependencies]
 tempfile = "3"
+tracing-subscriber = { workspace = true }

--- a/crates/higgs-engine/src/model_loader.rs
+++ b/crates/higgs-engine/src/model_loader.rs
@@ -1,7 +1,8 @@
 use std::path::{Path, PathBuf};
 
 use higgs_models::{
-    AnyModel, error::ModelError, load_tokenizer as shared_load_tokenizer, registry, transformer,
+    AnyModel, dflash, error::ModelError, load_tokenizer as shared_load_tokenizer, registry,
+    transformer,
 };
 
 use crate::error::EngineError;
@@ -148,6 +149,16 @@ fn is_bonsai_q1(dir: &Path) -> Result<bool, EngineError> {
 /// Load a tokenizer from a model directory.
 pub fn load_tokenizer<P: AsRef<Path>>(model_dir: P) -> Result<tokenizers::Tokenizer, EngineError> {
     shared_load_tokenizer(model_dir).map_err(|e| EngineError::Tokenization(e.to_string()))
+}
+
+/// Load a `DFlash` drafter from a model directory.
+///
+/// The drafter is a small block-diffusion model that the `SimpleEngine` uses to
+/// propose draft tokens which the target verifies in a single forward.
+pub fn load_dflash_drafter<P: AsRef<Path>>(
+    model_dir: P,
+) -> Result<dflash::DFlashDrafter, EngineError> {
+    dflash::load_dflash_drafter(model_dir.as_ref()).map_err(EngineError::Model)
 }
 
 #[cfg(test)]

--- a/crates/higgs-engine/src/simple.rs
+++ b/crates/higgs-engine/src/simple.rs
@@ -3648,6 +3648,155 @@ mod tests {
         );
     }
 
+    /// Localizes the pre-existing DFlash-vs-greedy prose divergence. The spec
+    /// round commits exactly the verify forward's per-position argmax
+    /// (`accept_prefix` is textbook-correct), so any divergence from AR greedy is
+    /// `verify_argmax[j] != ar_argmax[j]` — the S>1 batched verify flips an
+    /// argmax vs S=1 sequential AR. The GDN tape makes the SSM layers bit-exact,
+    /// but the full-attention layers run batched in verify and drift on near-ties.
+    /// Feeds the AR-correct tokens through the real verify path and reports which
+    /// positions flip + the top-2 logit gap there (small gap == near-tie ==
+    /// numerical, not a logic bug). Run with `--ignored --nocapture`.
+    #[test]
+    #[ignore = "p5: loads real 35B target; set HIGGS_DFLASH_TARGET_DIR + HIGGS_DFLASH_DRAFTER_DIR"]
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss
+    )]
+    fn dflash_verify_vs_ar_argmax_divergence() {
+        use super::{SimpleEngine, lock_or_recover};
+        use crate::chat_template::ChatMessage;
+        use crate::mlx_tuning::{MlxRuntimeTuning, RequestedMlxProfile};
+        use higgs_models::turboquant::KvCacheConfig;
+        use mlx_rs::{Array, Dtype, ops::indexing::IndexOp, transforms::eval};
+
+        let Ok(target) = std::env::var("HIGGS_DFLASH_TARGET_DIR") else {
+            eprintln!("skip: set HIGGS_DFLASH_TARGET_DIR");
+            return;
+        };
+        let drafter =
+            std::env::var("HIGGS_DFLASH_DRAFTER_DIR").expect("set HIGGS_DFLASH_DRAFTER_DIR");
+        let tuning =
+            MlxRuntimeTuning::from_model_dir(Path::new(&target), RequestedMlxProfile::Auto);
+        let engine = SimpleEngine::load_with_dflash(
+            &target,
+            KvCacheConfig::default(),
+            tuning,
+            false,
+            Some(Path::new(&drafter)),
+        )
+        .expect("load target + drafter");
+
+        let prompt = std::env::var("HIGGS_TEST_PROMPT").unwrap_or_else(|_| {
+            "Write several paragraphs about the history and cultural significance of tea across different civilizations.".to_owned()
+        });
+        let messages = [ChatMessage {
+            role: "user".to_owned(),
+            content: prompt,
+            tool_calls: None,
+        }];
+        let prompt_ids = engine
+            .prepare_chat_prompt_with_thinking(&messages, None, false)
+            .expect("chat prompt");
+        let prompt_i32: Vec<i32> = prompt_ids.iter().map(|&u| u as i32).collect();
+
+        let tap_layers = engine.dflash.as_ref().expect("dflash").tap_layers.clone();
+        let cfg = engine.kv_cache_config;
+        let mut model = lock_or_recover(&engine.model);
+
+        // top-1 token + (top1 - top2) logit gap from a [.., 1, vocab] tensor.
+        let argmax_gap = |logits: &Array| -> (u32, f32) {
+            let row = logits
+                .index((.., -1, ..))
+                .reshape(&[-1])
+                .unwrap()
+                .as_dtype(Dtype::Float32)
+                .unwrap();
+            eval([&row]).unwrap();
+            let h: Vec<f32> = row.as_slice::<f32>().to_vec();
+            let (mut i1, mut v1) = (0usize, f32::MIN);
+            for (i, &v) in h.iter().enumerate() {
+                if v > v1 {
+                    v1 = v;
+                    i1 = i;
+                }
+            }
+            let mut v2 = f32::MIN;
+            for (i, &v) in h.iter().enumerate() {
+                if i != i1 && v > v2 {
+                    v2 = v;
+                }
+            }
+            (i1 as u32, v1 - v2)
+        };
+
+        let k = 48usize;
+        let parr = Array::from_slice(&prompt_i32, &[1, prompt_i32.len() as i32]);
+
+        // Ground-truth sequential AR greedy: ar_seq[0..=k]; ar_gap[i] is the
+        // top-2 gap of the forward that predicts ar_seq[i+1].
+        let mut cache_ar = model.make_cache_with_config(cfg).expect("cache");
+        let l0 = model
+            .forward(&parr, None, &mut cache_ar)
+            .expect("prefill ar");
+        let (mut tok, _g0) = argmax_gap(&l0);
+        let mut ar_seq = vec![tok];
+        let mut ar_gap = Vec::with_capacity(k);
+        for _ in 0..k {
+            let single = Array::from_slice(&[tok as i32], &[1, 1]);
+            let l = model
+                .forward(&single, None, &mut cache_ar)
+                .expect("ar step");
+            let (t, g) = argmax_gap(&l);
+            ar_seq.push(t);
+            ar_gap.push(g);
+            tok = t;
+        }
+
+        // Verify path on a fresh cache: prefill the prompt, then ONE batched
+        // verify forward over the AR-correct tokens (anchor + ar_seq[0..k-1]),
+        // exactly as a fully-accepted spec round would see them.
+        let mut cache_v = model.make_cache_with_config(cfg).expect("cache");
+        let _ = model.forward(&parr, None, &mut cache_v).expect("prefill v");
+        let verify_in: Vec<i32> = ar_seq[..k].iter().map(|&u| u as i32).collect();
+        let vin = Array::from_slice(&verify_in, &[1, k as i32]);
+        let (vlogits, _taps, _tapes) = model
+            .forward_with_taps_tape(&vin, None, &mut cache_v, &tap_layers)
+            .expect("verify");
+        let vargmax = mlx_rs::argmax_axis!(vlogits, -1).expect("argmax");
+        eval([&vargmax]).expect("eval");
+        let vflat: Vec<u32> = vargmax
+            .reshape(&[-1])
+            .expect("reshape")
+            .as_slice::<u32>()
+            .to_vec();
+
+        // verify position i predicts the token after ar_seq[i] -> compare ar_seq[i+1].
+        let mut nmis = 0u32;
+        let mut first = None;
+        let (mut min_gap_mis, mut min_gap_match) = (f32::MAX, f32::MAX);
+        for i in 0..k {
+            let ar_next = ar_seq[i + 1];
+            if vflat[i] == ar_next {
+                min_gap_match = min_gap_match.min(ar_gap[i]);
+            } else {
+                nmis += 1;
+                if first.is_none() {
+                    first = Some(i);
+                }
+                min_gap_mis = min_gap_mis.min(ar_gap[i]);
+                eprintln!(
+                    "MISMATCH pos {i}: verify={} ar={ar_next} ar_top2_gap={:.4}",
+                    vflat[i], ar_gap[i]
+                );
+            }
+        }
+        eprintln!(
+            "verify-vs-AR over {k} positions: {nmis} mismatches, first at {first:?}; min top2-gap at mismatch={min_gap_mis:.4} vs match={min_gap_match:.4}"
+        );
+    }
+
     /// Gemma chat models stop on `<end_of_turn>`, which their `config.json` often
     /// omits from `eos_token_id`. It must be resolved from the tokenizer and added.
     #[test]

--- a/crates/higgs-engine/src/simple.rs
+++ b/crates/higgs-engine/src/simple.rs
@@ -1567,6 +1567,17 @@ impl SimpleEngine {
         const T_AR_CALIB: u32 = 3;
         let mut calibrated = false;
 
+        // Spec-side cold-start grace (symmetric to T_AR_CALIB). The first spec
+        // rounds after every (re-)entry are cold on two axes the warm t_ar is
+        // not: the verify/drafter/lm_head Metal kernels are kernel-cold
+        // (step_wall ~2x inflated until they JIT-warm) and the drafter KV cache
+        // is empty (accept length climbs from ~3 to its steady ~6 as it fills).
+        // Judging those rounds floored winning workloads (9B code: 1.53x->0.83x)
+        // and then death-spiralled (floored -> spec re-cools -> re-probe also
+        // looks bad). So don't update ratio_ema or floor until the burst warms.
+        const SPEC_WARMUP: u32 = 3;
+        let mut spec_warmup_left: u32 = 0;
+
         loop {
             let round_t0 = std::time::Instant::now();
             if gate && in_ar {
@@ -1617,6 +1628,13 @@ impl SimpleEngine {
                     in_ar = false;
                     ar_run = 0;
                     calibrated = true;
+                    // Grant the fresh spec burst its cold-start grace and re-seed
+                    // the EMA to the optimistic prior. Re-seeding (not blending)
+                    // is load-bearing: otherwise a re-probe inherits the stale
+                    // sub-1.0 ratio_ema and re-floors in one warm round, undoing
+                    // the grace. Mirrors the t_ar_ema map_or seed.
+                    spec_warmup_left = SPEC_WARMUP;
+                    ratio_ema = 2.0;
                 }
             } else {
                 // a. Build block: [anchor, mask, mask, ...]
@@ -1758,7 +1776,22 @@ impl SimpleEngine {
                 // slower than plain AR (or to calibrate T_ar if we have no sample).
                 if gate {
                     let step_wall = round_t0.elapsed().as_secs_f64().max(1e-9);
-                    if let Some(t_ar) = t_ar_ema {
+                    if spec_warmup_left > 0 {
+                        // Cold spec warm-up: stay in spec, don't judge or floor,
+                        // don't poison ratio_ema with the cold step_wall / low
+                        // cold-cache accept. The kernels warm and the drafter
+                        // cache fills over these rounds.
+                        spec_warmup_left -= 1;
+                        if std::env::var("HIGGS_DFLASH_TRACE").is_ok() && rounds <= 8 {
+                            tracing::info!(
+                                round = rounds,
+                                n_accepted,
+                                step_wall_ms = format!("{:.1}", step_wall * 1e3),
+                                warmup_left = spec_warmup_left,
+                                "GATE warmup (discarded)"
+                            );
+                        }
+                    } else if let Some(t_ar) = t_ar_ema {
                         let ratio = f64::from(n_accepted) * t_ar / step_wall;
                         ratio_ema = 0.6f64.mul_add(ratio_ema, 0.4 * ratio);
                         if std::env::var("HIGGS_DFLASH_TRACE").is_ok() && rounds <= 8 {

--- a/crates/higgs-engine/src/simple.rs
+++ b/crates/higgs-engine/src/simple.rs
@@ -10,7 +10,9 @@ use std::path::Path;
 use std::sync::{Mutex, MutexGuard};
 
 use higgs_models::{
-    AnyCache, AnyModel, LogprobArrays, SamplingParams, apply_penalties, sample,
+    AnyCache, AnyModel, LogprobArrays, SamplingParams, apply_penalties,
+    dflash::{DFlashDrafter, accept_prefix, crop_drafter_cache},
+    sample,
     turboquant::KvCacheConfig,
 };
 use mlx_rs::{
@@ -232,6 +234,15 @@ pub struct Session {
 /// Uses paged KV cache for efficient memory management during single-request
 /// generation. Session-based batched stepping APIs are not wired to real decode
 /// yet and return explicit errors instead of placeholder output.
+/// `DFlash` block-diffusion speculative decoding state, held alongside the
+/// target model when a drafter is loaded.
+struct DFlashState {
+    drafter: Mutex<DFlashDrafter>,
+    tap_layers: Vec<usize>,
+    block_size: i32,
+    mask_token_id: i32,
+}
+
 pub struct SimpleEngine {
     model: Mutex<AnyModel>,
     prefix_cache: Mutex<PagedPrefixCache>,
@@ -262,6 +273,9 @@ pub struct SimpleEngine {
     gen_prompt_suffix_len: usize,
     kv_cache_config: KvCacheConfig,
     tuning: MlxRuntimeTuning,
+    /// Optional `DFlash` block-diffusion speculative decoding state, enabled
+    /// when `HIGGS_DFLASH_PATH` points at a drafter checkpoint.
+    dflash: Option<DFlashState>,
 }
 
 /// Intermediate state after prefix cache lookup and model locking.
@@ -281,6 +295,22 @@ impl SimpleEngine {
         kv_cache_config: KvCacheConfig,
         tuning: MlxRuntimeTuning,
         raise_wired_limit: bool,
+    ) -> Result<Self, EngineError> {
+        Self::load_with_dflash(dir, kv_cache_config, tuning, raise_wired_limit, None)
+    }
+
+    /// Load a model with an optional `DFlash` speculative-decoding drafter.
+    ///
+    /// The drafter path is taken from `dflash_path` when `Some`, otherwise from
+    /// the `HIGGS_DFLASH_PATH` env var. When a drafter is present, `generate`
+    /// dispatches to the block-diffusion draft-verify loop.
+    #[allow(clippy::too_many_lines)]
+    pub fn load_with_dflash<P: AsRef<Path>>(
+        dir: P,
+        kv_cache_config: KvCacheConfig,
+        tuning: MlxRuntimeTuning,
+        raise_wired_limit: bool,
+        dflash_path: Option<&Path>,
     ) -> Result<Self, EngineError> {
         let model_dir = dir.as_ref();
         let model_name = derive_model_name(model_dir);
@@ -429,6 +459,46 @@ impl SimpleEngine {
             })
             .transpose()?;
 
+        // DFlash speculative decoding: load the drafter from the explicit path
+        // or HIGGS_DFLASH_PATH. generate_inner then dispatches to the
+        // draft-verify loop for unconstrained text generation.
+        let dflash = dflash_path
+            .map(Path::to_path_buf)
+            .or_else(|| {
+                std::env::var("HIGGS_DFLASH_PATH")
+                    .ok()
+                    .map(std::path::PathBuf::from)
+            })
+            .map(|dp| -> Result<DFlashState, EngineError> {
+                tracing::info!(drafter = %dp.display(), "Loading DFlash drafter");
+                let drafter = model_loader::load_dflash_drafter(&dp)?;
+                let tap_layers = drafter.config.target_layer_ids().to_vec();
+                // Decode block size: HIGGS_DFLASH_BLOCK_SIZE overrides the
+                // trained block_size, clamped to [1, trained]. Smaller blocks
+                // amortize the per-round verify + lm_head cost better when the
+                // accept length plateaus below the trained block.
+                let trained_block = drafter.config.block_size;
+                let block_size = std::env::var("HIGGS_DFLASH_BLOCK_SIZE")
+                    .ok()
+                    .and_then(|v| v.parse::<i32>().ok())
+                    .filter(|&v| v >= 1)
+                    .map_or(trained_block, |v| v.min(trained_block));
+                let mask_token_id = drafter.config.mask_token_id();
+                tracing::info!(
+                    tap_layers = ?tap_layers,
+                    block_size,
+                    mask_token_id,
+                    "DFlash drafter loaded — speculative decoding enabled"
+                );
+                Ok(DFlashState {
+                    drafter: Mutex::new(drafter),
+                    tap_layers,
+                    block_size,
+                    mask_token_id,
+                })
+            })
+            .transpose()?;
+
         Ok(Self {
             model: Mutex::new(model),
             prefix_cache: Mutex::new(PagedPrefixCache::new(
@@ -448,6 +518,7 @@ impl SimpleEngine {
             gen_prompt_suffix_len,
             kv_cache_config,
             tuning,
+            dflash,
         })
     }
 
@@ -1029,6 +1100,12 @@ impl SimpleEngine {
         mut constraint: Option<crate::constrained::ConstrainedGenerator>,
         pixel_values: Option<Array>,
     ) -> Result<GenerationOutput, EngineError> {
+        // DFlash speculative decoding: use the draft-verify loop when a drafter
+        // is loaded, no constraints active, and no multimodal input.
+        if self.dflash.is_some() && constraint.is_none() && pixel_values.is_none() {
+            return self.generate_dflash_inner(prompt_tokens, max_tokens, params, stop_sequences);
+        }
+
         let logprob_top_n = logprobs.then(|| top_logprobs.unwrap_or(0));
 
         let mut prepared = self.prepare_generation(prompt_tokens, pixel_values)?;
@@ -1348,6 +1425,300 @@ impl SimpleEngine {
                 next_token = following;
             }
             next_logprob_data = following_logprob_data;
+        }
+    }
+
+    /// `DFlash` block-diffusion speculative decode loop.
+    ///
+    /// Each round: drafter proposes a `block_size` block from the target's tap
+    /// hidden states, the target verifies the block in a single tape-recording
+    /// forward, `accept_prefix` takes the longest greedy-matching prefix, and a
+    /// GDN tape replay rolls partial-accept state back bit-exactly. Headline
+    /// metric for tuning is `accept_len` (mean accepted tokens per round).
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::as_conversions,
+        clippy::too_many_lines
+    )]
+    fn generate_dflash_inner(
+        &self,
+        prompt_tokens: &[u32],
+        max_tokens: u32,
+        params: &SamplingParams,
+        stop_sequences: &[String],
+    ) -> Result<GenerationOutput, EngineError> {
+        let dflash = self
+            .dflash
+            .as_ref()
+            .ok_or_else(|| EngineError::Generation("DFlash state missing".to_owned()))?;
+        let prompt_len = Self::prompt_len(prompt_tokens)?;
+        let has_stop_sequences = !stop_sequences.is_empty();
+
+        let mut model = lock_or_recover(&self.model);
+        let mut drafter = lock_or_recover(&dflash.drafter);
+
+        let mut cache = model
+            .make_cache_with_config(self.kv_cache_config)
+            .map_err(EngineError::Mlx)?;
+
+        // Prefill with taps.
+        let prompt_array = Array::from(prompt_tokens).index(NewAxis);
+        let (prefill_logits, taps) = model
+            .forward_with_taps(&prompt_array, None, &mut cache, &dflash.tap_layers)
+            .map_err(EngineError::Mlx)?;
+        eval([&prefill_logits]).map_err(EngineError::Mlx)?;
+
+        // Sample first token.
+        let last_logits = prefill_logits.index((.., -1, ..));
+        let first_token = sample(&last_logits, params).map_err(EngineError::Mlx)?;
+        eval([&first_token]).map_err(EngineError::Mlx)?;
+
+        let first_token_id: u32 = first_token.item();
+        let mut tokens: Vec<u32> = vec![first_token_id];
+
+        if self.eos_token_ids.contains(&first_token_id) || max_tokens <= 1 {
+            let finish_reason = if self.eos_token_ids.contains(&first_token_id) {
+                "stop"
+            } else {
+                "length"
+            };
+            return Ok(GenerationOutput {
+                text: self.decode_tokens(&tokens)?,
+                finish_reason: finish_reason.to_owned(),
+                prompt_tokens: prompt_len,
+                completion_tokens: 1,
+                token_logprobs: None,
+            });
+        }
+
+        let mut current_taps = taps;
+        let mut draft_cache = drafter.make_cache();
+        let mut last_token = i32::try_from(first_token_id)
+            .map_err(|_| EngineError::Generation("first_token_id overflow for i32".to_owned()))?;
+        let mut start = i32::try_from(prompt_len)
+            .map_err(|_| EngineError::Generation("prompt_len overflow for i32".to_owned()))?;
+        // Adaptive (entropy-gated) block size. Acceptance length is the entropy
+        // proxy: predictable/low-entropy regions accept long blocks (big win,
+        // byte-exact), uncertain/high-entropy regions reject them. So grow the
+        // block toward `block_max` when a block is fully accepted and shrink
+        // toward `block_min` (≈ plain decode) when drafts are rejected — this
+        // both recovers throughput and keeps the S>1 verify off high-entropy
+        // near-ties (where it would flip argmax). Disable with
+        // HIGGS_DFLASH_ADAPTIVE=0; floor via HIGGS_DFLASH_MIN_BLOCK.
+        let block_max = dflash.block_size;
+        let block_min = std::env::var("HIGGS_DFLASH_MIN_BLOCK")
+            .ok()
+            .and_then(|v| v.parse::<i32>().ok())
+            .filter(|&v| v >= 1)
+            .map_or(2, |v| v.min(block_max));
+        let adaptive = std::env::var("HIGGS_DFLASH_ADAPTIVE").map_or(true, |v| v != "0");
+        let mut block_size = block_max;
+        // Smoothed utilization: a single hard token inside otherwise-predictable
+        // text (code dip ~0.38 ≈ prose plateau ~0.36) shouldn't collapse the
+        // block — only a *persistently* low utilization should. EMA separates
+        // "occasional dip" from "sustained high entropy".
+        let mut ema_util = 1.0_f64;
+        let mask_id = dflash.mask_token_id;
+        let t_start = std::time::Instant::now();
+        // Acceptance-length aggregation: mean accepted tokens per round is the
+        // headline metric for DFlash tuning (see P5).
+        let mut total_accepted: u64 = 0;
+        let mut rounds: u64 = 0;
+
+        loop {
+            // a. Build block: [anchor, mask, mask, ...]
+            let block_size_us = usize::try_from(block_size)
+                .map_err(|_| EngineError::Generation("block_size overflow for usize".to_owned()))?;
+            let mut block_tokens = vec![mask_id; block_size_us];
+            if let Some(slot) = block_tokens.get_mut(0) {
+                *slot = last_token;
+            }
+            let block_ids = Array::from_slice(&block_tokens, &[1, block_size]);
+
+            // b. Embed through target's embedding layer.
+            let noise_embedding = model
+                .embed_token_ids(&block_ids)
+                .map_err(EngineError::Mlx)?;
+
+            // c. Drafter forward.
+            let draft_hidden = drafter
+                .forward(&noise_embedding, &current_taps, &mut draft_cache)
+                .map_err(EngineError::Mlx)?;
+            crop_drafter_cache(&mut draft_cache, start);
+
+            // d. Target lm_head on sliced hidden -> argmax draft tokens.
+            let draft_hidden_sliced = draft_hidden.index((.., 1.., ..));
+            let draft_logits = model
+                .forward_all_logits_from_hidden(&draft_hidden_sliced)
+                .map_err(EngineError::Mlx)?;
+            let draft_token_arr =
+                mlx_rs::argmax_axis!(draft_logits, -1).map_err(EngineError::Mlx)?;
+            eval([&draft_token_arr]).map_err(EngineError::Mlx)?;
+            let draft_u32: Vec<u32> = draft_token_arr
+                .reshape(&[-1])
+                .map_err(EngineError::Mlx)?
+                .as_slice::<u32>()
+                .to_vec();
+            let draft_i32: Vec<i32> = draft_u32
+                .iter()
+                .map(|&x| {
+                    i32::try_from(x)
+                        .map_err(|_| EngineError::Generation("draft token overflow i32".to_owned()))
+                })
+                .collect::<Result<_, _>>()?;
+
+            // e. Build verify input: [anchor, draft_0..draft_{N-2}].
+            let mut verify_tokens = vec![last_token];
+            verify_tokens.extend_from_slice(&draft_i32);
+            let verify_len = i32::try_from(verify_tokens.len())
+                .map_err(|_| EngineError::Generation("verify_len overflow".to_owned()))?;
+            let verify_input = Array::from_slice(&verify_tokens, &[1, verify_len]);
+
+            // f. Tape-recording verify: forward with taps + GDN innovation tapes.
+            //    The tape kernel's recurrence is bit-exact with sequential AR
+            //    steps, fixing the S>1 vs S=1 numerical drift that a full-rerun
+            //    verify exhibits, and lets partial accept replay only the SSM
+            //    recurrence for accepted positions instead of a full rerun.
+            let (verify_logits, verify_taps, layer_tapes) = model
+                .forward_with_taps_tape(&verify_input, None, &mut cache, &dflash.tap_layers)
+                .map_err(EngineError::Mlx)?;
+
+            // g. Accept prefix. One host barrier per round: eval'ing the argmax
+            //    pulls verify_logits + the whole verify forward through the
+            //    graph, so a separate eval([&verify_logits]) is redundant.
+            let verify_argmax =
+                mlx_rs::argmax_axis!(verify_logits, -1).map_err(EngineError::Mlx)?;
+            eval([&verify_argmax]).map_err(EngineError::Mlx)?;
+            let verify_flat: Vec<u32> = verify_argmax
+                .reshape(&[-1])
+                .map_err(EngineError::Mlx)?
+                .as_slice::<u32>()
+                .to_vec();
+            let accepted = accept_prefix(&draft_u32, &verify_flat);
+            let n_accepted = i32::try_from(accepted.len())
+                .map_err(|_| EngineError::Generation("n_accepted overflow".to_owned()))?;
+            rounds += 1;
+            total_accepted += accepted.len() as u64;
+
+            if std::env::var("HIGGS_DFLASH_TRACE").is_ok() && tokens.len() <= 32 {
+                tracing::info!(
+                    drafts = ?draft_u32,
+                    verify_argmax = ?verify_flat,
+                    n_accepted,
+                    accepted = ?accepted,
+                    "DFlash iter trace"
+                );
+            }
+
+            // h. Partial accept — GDN-only replay from tape. The verify
+            //    advanced state for ALL positions; on partial rejection we
+            //    restore each GDN layer's snapshot, replay the SSM kernel for
+            //    the n_accepted positions, and trim KV layers by the rejected
+            //    count. Issued lazily (no eval) so it folds into the next
+            //    verify's host barrier.
+            if n_accepted < block_size {
+                let kv_rollback = verify_len - n_accepted;
+                model
+                    .replay_tape_rollback(&layer_tapes, &mut cache, n_accepted, kv_rollback)
+                    .map_err(EngineError::Mlx)?;
+            }
+            // Slice verify taps to accepted positions (valid for both full and
+            // partial accept — earlier positions' hidden states are causally
+            // independent of later ones).
+            current_taps = verify_taps
+                .into_iter()
+                .map(|tap| tap.index((.., ..n_accepted, ..)))
+                .collect();
+
+            // i. Update state.
+            for &tok in &accepted {
+                tokens.push(tok);
+            }
+            last_token = i32::try_from(*accepted.last().ok_or_else(|| {
+                EngineError::Generation("accept_prefix returned empty vec".to_owned())
+            })?)
+            .map_err(|_| EngineError::Generation("accepted token overflow i32".to_owned()))?;
+            start += n_accepted;
+
+            // Adapt the next round's block size by block UTILIZATION
+            // (n_accepted / block_size) — the entropy proxy. On low-entropy text
+            // acceptance scales with the block (util stays high → grow toward
+            // block_max for the biggest win); on high-entropy text acceptance
+            // plateaus (util drops → shrink so the verify isn't wasted, and the
+            // S>1 verify stays off near-ties). Gating on util, not raw accept,
+            // keeps big blocks where they pay off. (all block_size uses above.)
+            if adaptive {
+                let util = f64::from(n_accepted) / f64::from(block_size);
+                ema_util = 0.5f64.mul_add(ema_util, 0.5 * util);
+                block_size = if ema_util >= 0.75 {
+                    (block_size * 2).min(block_max) // sustained high → grow
+                } else if ema_util <= 0.5 {
+                    (block_size / 2).max(block_min) // sustained low → shrink
+                } else {
+                    block_size
+                };
+            }
+
+            // j. Check termination.
+            let completion_len = Self::completion_len(&tokens)?;
+            let accept_len = total_accepted as f64 / rounds as f64;
+
+            if tokens.iter().any(|t| self.eos_token_ids.contains(t)) {
+                let secs = t_start.elapsed().as_secs_f64();
+                let tok_per_sec = if secs > 0.0 {
+                    tokens.len() as f64 / secs
+                } else {
+                    0.0
+                };
+                tracing::info!(
+                    tokens = tokens.len(),
+                    accept_len = format!("{accept_len:.2}"),
+                    tok_per_sec = format!("{tok_per_sec:.1}"),
+                    "DFlash generation complete"
+                );
+                return Ok(GenerationOutput {
+                    text: self.decode_tokens(&tokens)?,
+                    finish_reason: "stop".to_owned(),
+                    prompt_tokens: prompt_len,
+                    completion_tokens: completion_len,
+                    token_logprobs: None,
+                });
+            }
+
+            if has_stop_sequences {
+                let text = self.decode_tokens(&tokens)?;
+                if let Some(truncated) = check_stop_sequences(&text, stop_sequences) {
+                    return Ok(GenerationOutput {
+                        text: truncated,
+                        finish_reason: "stop".to_owned(),
+                        prompt_tokens: prompt_len,
+                        completion_tokens: completion_len,
+                        token_logprobs: None,
+                    });
+                }
+            }
+
+            if completion_len >= max_tokens {
+                let secs = t_start.elapsed().as_secs_f64();
+                let tok_per_sec = if secs > 0.0 {
+                    tokens.len() as f64 / secs
+                } else {
+                    0.0
+                };
+                tracing::info!(
+                    tokens = tokens.len(),
+                    accept_len = format!("{accept_len:.2}"),
+                    tok_per_sec = format!("{tok_per_sec:.1}"),
+                    "DFlash generation complete (length limit)"
+                );
+                return Ok(GenerationOutput {
+                    text: self.decode_tokens(&tokens)?,
+                    finish_reason: "length".to_owned(),
+                    prompt_tokens: prompt_len,
+                    completion_tokens: completion_len,
+                    token_logprobs: None,
+                });
+            }
         }
     }
 
@@ -2944,6 +3315,112 @@ mod tests {
     /// Write a config.json file into the given directory with the provided JSON content.
     fn write_config(dir: &std::path::Path, json: &str) {
         std::fs::write(dir.join("config.json"), json).unwrap();
+    }
+
+    /// P5: `DFlash` speculative decode must be byte-identical to plain AR greedy
+    /// decode (T=0) and reports acceptance length + tok/s. Loads the real 35B
+    /// target twice (AR then `DFlash`, sequentially to bound memory). Manual:
+    ///
+    /// ```text
+    /// HIGGS_DFLASH_TARGET_DIR=<target dir> \
+    /// HIGGS_DFLASH_DRAFTER_DIR=<modal drafter snapshot dir> \
+    /// cargo test -p higgs-engine dflash_matches_ar_greedy -- --ignored --nocapture
+    /// ```
+    #[test]
+    #[ignore = "p5: loads real 35B target; set HIGGS_DFLASH_TARGET_DIR + HIGGS_DFLASH_DRAFTER_DIR"]
+    fn dflash_matches_ar_greedy_and_reports_accept_len() {
+        use super::SimpleEngine;
+        use crate::chat_template::ChatMessage;
+        use crate::mlx_tuning::{MlxRuntimeTuning, RequestedMlxProfile};
+        use higgs_models::{SamplingParams, turboquant::KvCacheConfig};
+
+        // Surface the engine's accept_len / per-iter trace logs.
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter("info")
+            .with_test_writer()
+            .try_init();
+
+        let target = std::env::var("HIGGS_DFLASH_TARGET_DIR")
+            .expect("set HIGGS_DFLASH_TARGET_DIR to the 35B target model dir");
+        let drafter = std::env::var("HIGGS_DFLASH_DRAFTER_DIR")
+            .expect("set HIGGS_DFLASH_DRAFTER_DIR to the Modal drafter snapshot dir");
+
+        // Match the reference benchmark workload: chat template + thinking
+        // enabled, a code/reasoning prompt (DFlash is trained/measured on
+        // GSM8K/HumanEval/MT-Bench, not raw factual completions). Keep
+        // max_tokens under the 256-token thinking budget so the AR (MTP) path
+        // never force-closes </think> while DFlash wouldn't.
+        let user_prompt =
+            "Write a Python function that returns the n-th Fibonacci number iteratively.";
+        // Toggle with HIGGS_TEST_THINKING=0 to measure the thinking-disabled
+        // workload (default: enabled, matching the reference benchmark).
+        let enable_thinking = std::env::var("HIGGS_TEST_THINKING")
+            .map(|v| v != "0")
+            .unwrap_or(true);
+        let max_tokens = 200u32;
+        let greedy = SamplingParams {
+            temperature: 0.0,
+            ..SamplingParams::default()
+        };
+
+        let run = |with_drafter: bool| -> (String, f64) {
+            let drafter_path = with_drafter.then(|| Path::new(&drafter));
+            let tuning =
+                MlxRuntimeTuning::from_model_dir(Path::new(&target), RequestedMlxProfile::Auto);
+            let engine = SimpleEngine::load_with_dflash(
+                &target,
+                KvCacheConfig::default(),
+                tuning,
+                false,
+                drafter_path,
+            )
+            .expect("load target");
+            let messages = [ChatMessage {
+                role: "user".to_owned(),
+                content: user_prompt.to_owned(),
+                tool_calls: None,
+            }];
+            let toks = engine
+                .prepare_chat_prompt_with_thinking(&messages, None, enable_thinking)
+                .expect("chat prompt");
+            let t = std::time::Instant::now();
+            let out = engine
+                .generate_with_thinking(
+                    &toks,
+                    max_tokens,
+                    &greedy,
+                    &[],
+                    false,
+                    None,
+                    enable_thinking,
+                    None,
+                    None,
+                )
+                .expect("generate");
+            let tps = f64::from(out.completion_tokens) / t.elapsed().as_secs_f64();
+            (out.text, tps)
+        };
+
+        let (ar_text, ar_tps) = run(false);
+        let (df_text, df_tps) = run(true);
+
+        println!("AR     {ar_tps:.1} tok/s: {ar_text:?}");
+        println!("DFLASH {df_tps:.1} tok/s: {df_text:?}");
+        println!("speedup vs AR: {:.2}x", df_tps / ar_tps);
+
+        // Correctness gate: greedy outputs identical up to a block-overshoot tail
+        // (DFlash commits whole blocks, so it may emit a few extra trailing
+        // tokens past max_tokens — the shorter must be a prefix of the longer).
+        let (short, long) = if ar_text.len() <= df_text.len() {
+            (ar_text.as_str(), df_text.as_str())
+        } else {
+            (df_text.as_str(), ar_text.as_str())
+        };
+        assert!(!short.is_empty(), "empty generation");
+        assert!(
+            long.starts_with(short),
+            "DFlash diverged from AR greedy:\n AR={ar_text:?}\n DF={df_text:?}"
+        );
     }
 
     /// Gemma chat models stop on `<end_of_turn>`, which their `config.json` often

--- a/crates/higgs-engine/src/simple.rs
+++ b/crates/higgs-engine/src/simple.rs
@@ -1543,7 +1543,7 @@ impl SimpleEngine {
         // high-entropy region every probe is a wasted slow spec round (~4
         // decode-units for ~1-2 tokens), so a fixed cadence taxed the floor by
         // ~probe_cost/cadence (≈11% at 32 — the measured 0.89× prose gap; the
-        // per-step taps were free, see dflash_floor_tapless_vs_taps_per_step_cost).
+        // per-step taps were measured free, ~0% — they are lazy clones).
         // Each losing probe doubles the interval (amortizing the cost toward 0 on
         // sustained prose); a winning probe resets to base so a regime shift back
         // to spec-friendly text is caught within `AR_PROBE_BASE` tokens.
@@ -1654,12 +1654,6 @@ impl SimpleEngine {
                         // cooled over one AR step). need_taps was true, so
                         // current_taps is fresh for the next draft.
                         recal = false;
-                        if std::env::var("HIGGS_DFLASH_TRACE").is_ok() {
-                            tracing::info!(
-                                t_ar_ms = format!("{:.1}", t_ar_ema.unwrap_or(0.0) * 1e3),
-                                "GATE t_ar recal"
-                            );
-                        }
                     } else {
                         // Grant the fresh spec burst its cold-start grace and
                         // re-seed the EMA to the optimistic prior. Re-seeding (not
@@ -1816,15 +1810,6 @@ impl SimpleEngine {
                         // cold-cache accept. The kernels warm and the drafter
                         // cache fills over these rounds.
                         spec_warmup_left -= 1;
-                        if std::env::var("HIGGS_DFLASH_TRACE").is_ok() && rounds <= 8 {
-                            tracing::info!(
-                                round = rounds,
-                                n_accepted,
-                                step_wall_ms = format!("{:.1}", step_wall * 1e3),
-                                warmup_left = spec_warmup_left,
-                                "GATE warmup (discarded)"
-                            );
-                        }
                     } else if let Some(t_ar) = t_ar_ema {
                         let ratio = f64::from(n_accepted) * t_ar / step_wall;
                         ratio_ema = 0.6f64.mul_add(ratio_ema, 0.4 * ratio);
@@ -3642,238 +3627,6 @@ mod tests {
         assert!(
             long.starts_with(short),
             "DFlash diverged from AR greedy:\n AR={ar_text:?}\n DF={df_text:?}"
-        );
-    }
-
-    /// Isolates the per-step cost the gate's AR floor pays for taps. Floored
-    /// steps now call `forward` (tap-less) instead of `forward_with_taps`; this
-    /// interleaves the two over many single-token decodes so thermal drift
-    /// averages out (the end-to-end ratio is hopelessly thermally confounded on
-    /// this serial-load harness) and prints mean µs/token for each. If the delta
-    /// is ~0 the tap clones are lazy/dropped and the fast-decode path is a no-op;
-    /// a real delta is the prose-parity win. Run with `--ignored --nocapture`.
-    #[test]
-    #[ignore = "p5: loads real 35B target; set HIGGS_DFLASH_TARGET_DIR + HIGGS_DFLASH_DRAFTER_DIR"]
-    #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
-    fn dflash_floor_tapless_vs_taps_per_step_cost() {
-        use super::{SimpleEngine, lock_or_recover};
-        use crate::mlx_tuning::{MlxRuntimeTuning, RequestedMlxProfile};
-        use higgs_models::turboquant::KvCacheConfig;
-        use mlx_rs::{Array, ops::indexing::IndexOp, transforms::eval};
-
-        let Ok(target) = std::env::var("HIGGS_DFLASH_TARGET_DIR") else {
-            eprintln!("skip: set HIGGS_DFLASH_TARGET_DIR");
-            return;
-        };
-        let drafter =
-            std::env::var("HIGGS_DFLASH_DRAFTER_DIR").expect("set HIGGS_DFLASH_DRAFTER_DIR");
-        let tuning =
-            MlxRuntimeTuning::from_model_dir(Path::new(&target), RequestedMlxProfile::Auto);
-        let engine = SimpleEngine::load_with_dflash(
-            &target,
-            KvCacheConfig::default(),
-            tuning,
-            false,
-            Some(Path::new(&drafter)),
-        )
-        .expect("load target + drafter");
-        let tap_layers = engine.dflash.as_ref().expect("dflash").tap_layers.clone();
-        let cfg = engine.kv_cache_config;
-        let mut model = lock_or_recover(&engine.model);
-        let mut cache = model.make_cache_with_config(cfg).expect("cache");
-
-        // Prefill so decode steps run at a realistic cache offset.
-        let prompt: Vec<i32> = (1..=32).collect();
-        let parr = Array::from_slice(&prompt, &[1, prompt.len() as i32]);
-        let (logits, _t) = model
-            .forward_with_taps(&parr, None, &mut cache, &tap_layers)
-            .expect("prefill");
-        let am = mlx_rs::argmax_axis!(logits.index((.., -1, ..)), -1).expect("argmax");
-        eval([&am]).expect("eval");
-        let mut next: i32 = i32::try_from(am.item::<u32>()).expect("tok");
-
-        let (warm, iters) = (8u32, 160u32);
-        let (mut t_taps, mut n_taps, mut t_plain, mut n_plain) = (0f64, 0u32, 0f64, 0u32);
-        for i in 0..(warm + iters) {
-            let single = Array::from_slice(&[next], &[1, 1]);
-            let use_taps = i % 2 == 0;
-            let start = std::time::Instant::now();
-            let logits = if use_taps {
-                model
-                    .forward_with_taps(&single, None, &mut cache, &tap_layers)
-                    .expect("taps")
-                    .0
-            } else {
-                model.forward(&single, None, &mut cache).expect("plain")
-            };
-            let am = mlx_rs::argmax_axis!(logits.index((.., -1, ..)), -1).expect("argmax");
-            eval([&am]).expect("eval");
-            let dt = start.elapsed().as_secs_f64();
-            next = i32::try_from(am.item::<u32>()).expect("tok");
-            if i >= warm {
-                if use_taps {
-                    t_taps += dt;
-                    n_taps += 1;
-                } else {
-                    t_plain += dt;
-                    n_plain += 1;
-                }
-            }
-        }
-        let us_taps = t_taps / f64::from(n_taps) * 1e6;
-        let us_plain = t_plain / f64::from(n_plain) * 1e6;
-        eprintln!(
-            "floor step cost: forward_with_taps {us_taps:.0} µs/tok | forward(tap-less) {us_plain:.0} µs/tok | taps overhead {:.1}% ({n_taps} taps / {n_plain} plain)",
-            (us_taps - us_plain) / us_taps * 100.0
-        );
-    }
-
-    /// Localizes the pre-existing DFlash-vs-greedy prose divergence. The spec
-    /// round commits exactly the verify forward's per-position argmax
-    /// (`accept_prefix` is textbook-correct), so any divergence from AR greedy is
-    /// `verify_argmax[j] != ar_argmax[j]` — the S>1 batched verify flips an
-    /// argmax vs S=1 sequential AR. The GDN tape makes the SSM layers bit-exact,
-    /// but the full-attention layers run batched in verify and drift on near-ties.
-    /// Feeds the AR-correct tokens through the real verify path and reports which
-    /// positions flip + the top-2 logit gap there (small gap == near-tie ==
-    /// numerical, not a logic bug). Run with `--ignored --nocapture`.
-    #[test]
-    #[ignore = "p5: loads real 35B target; set HIGGS_DFLASH_TARGET_DIR + HIGGS_DFLASH_DRAFTER_DIR"]
-    #[allow(
-        clippy::cast_precision_loss,
-        clippy::cast_possible_truncation,
-        clippy::cast_sign_loss
-    )]
-    fn dflash_verify_vs_ar_argmax_divergence() {
-        use super::{SimpleEngine, lock_or_recover};
-        use crate::chat_template::ChatMessage;
-        use crate::mlx_tuning::{MlxRuntimeTuning, RequestedMlxProfile};
-        use higgs_models::turboquant::KvCacheConfig;
-        use mlx_rs::{Array, Dtype, ops::indexing::IndexOp, transforms::eval};
-
-        let Ok(target) = std::env::var("HIGGS_DFLASH_TARGET_DIR") else {
-            eprintln!("skip: set HIGGS_DFLASH_TARGET_DIR");
-            return;
-        };
-        let drafter =
-            std::env::var("HIGGS_DFLASH_DRAFTER_DIR").expect("set HIGGS_DFLASH_DRAFTER_DIR");
-        let tuning =
-            MlxRuntimeTuning::from_model_dir(Path::new(&target), RequestedMlxProfile::Auto);
-        let engine = SimpleEngine::load_with_dflash(
-            &target,
-            KvCacheConfig::default(),
-            tuning,
-            false,
-            Some(Path::new(&drafter)),
-        )
-        .expect("load target + drafter");
-
-        let prompt = std::env::var("HIGGS_TEST_PROMPT").unwrap_or_else(|_| {
-            "Write several paragraphs about the history and cultural significance of tea across different civilizations.".to_owned()
-        });
-        let messages = [ChatMessage {
-            role: "user".to_owned(),
-            content: prompt,
-            tool_calls: None,
-        }];
-        let prompt_ids = engine
-            .prepare_chat_prompt_with_thinking(&messages, None, false)
-            .expect("chat prompt");
-        let prompt_i32: Vec<i32> = prompt_ids.iter().map(|&u| u as i32).collect();
-
-        let tap_layers = engine.dflash.as_ref().expect("dflash").tap_layers.clone();
-        let cfg = engine.kv_cache_config;
-        let mut model = lock_or_recover(&engine.model);
-
-        // top-1 token + (top1 - top2) logit gap from a [.., 1, vocab] tensor.
-        let argmax_gap = |logits: &Array| -> (u32, f32) {
-            let row = logits
-                .index((.., -1, ..))
-                .reshape(&[-1])
-                .unwrap()
-                .as_dtype(Dtype::Float32)
-                .unwrap();
-            eval([&row]).unwrap();
-            let h: Vec<f32> = row.as_slice::<f32>().to_vec();
-            let (mut i1, mut v1) = (0usize, f32::MIN);
-            for (i, &v) in h.iter().enumerate() {
-                if v > v1 {
-                    v1 = v;
-                    i1 = i;
-                }
-            }
-            let mut v2 = f32::MIN;
-            for (i, &v) in h.iter().enumerate() {
-                if i != i1 && v > v2 {
-                    v2 = v;
-                }
-            }
-            (i1 as u32, v1 - v2)
-        };
-
-        let k = 48usize;
-        let parr = Array::from_slice(&prompt_i32, &[1, prompt_i32.len() as i32]);
-
-        // Ground-truth sequential AR greedy: ar_seq[0..=k]; ar_gap[i] is the
-        // top-2 gap of the forward that predicts ar_seq[i+1].
-        let mut cache_ar = model.make_cache_with_config(cfg).expect("cache");
-        let l0 = model
-            .forward(&parr, None, &mut cache_ar)
-            .expect("prefill ar");
-        let (mut tok, _g0) = argmax_gap(&l0);
-        let mut ar_seq = vec![tok];
-        let mut ar_gap = Vec::with_capacity(k);
-        for _ in 0..k {
-            let single = Array::from_slice(&[tok as i32], &[1, 1]);
-            let l = model
-                .forward(&single, None, &mut cache_ar)
-                .expect("ar step");
-            let (t, g) = argmax_gap(&l);
-            ar_seq.push(t);
-            ar_gap.push(g);
-            tok = t;
-        }
-
-        // Verify path on a fresh cache: prefill the prompt, then ONE batched
-        // verify forward over the AR-correct tokens (anchor + ar_seq[0..k-1]),
-        // exactly as a fully-accepted spec round would see them.
-        let mut cache_v = model.make_cache_with_config(cfg).expect("cache");
-        let _ = model.forward(&parr, None, &mut cache_v).expect("prefill v");
-        let verify_in: Vec<i32> = ar_seq[..k].iter().map(|&u| u as i32).collect();
-        let vin = Array::from_slice(&verify_in, &[1, k as i32]);
-        let (vlogits, _taps, _tapes) = model
-            .forward_with_taps_tape(&vin, None, &mut cache_v, &tap_layers)
-            .expect("verify");
-        let vargmax = mlx_rs::argmax_axis!(vlogits, -1).expect("argmax");
-        eval([&vargmax]).expect("eval");
-        let vflat: Vec<u32> = vargmax
-            .reshape(&[-1])
-            .expect("reshape")
-            .as_slice::<u32>()
-            .to_vec();
-
-        // verify position i predicts the token after ar_seq[i] -> compare ar_seq[i+1].
-        let mut nmis = 0u32;
-        let mut first = None;
-        let (mut min_gap_mis, mut min_gap_match) = (f32::MAX, f32::MAX);
-        for i in 0..k {
-            let ar_next = ar_seq[i + 1];
-            if vflat[i] == ar_next {
-                min_gap_match = min_gap_match.min(ar_gap[i]);
-            } else {
-                nmis += 1;
-                if first.is_none() {
-                    first = Some(i);
-                }
-                min_gap_mis = min_gap_mis.min(ar_gap[i]);
-                eprintln!(
-                    "MISMATCH pos {i}: verify={} ar={ar_next} ar_top2_gap={:.4}",
-                    vflat[i], ar_gap[i]
-                );
-            }
-        }
-        eprintln!(
-            "verify-vs-AR over {k} positions: {nmis} mismatches, first at {first:?}; min top2-gap at mismatch={min_gap_mis:.4} vs match={min_gap_match:.4}"
         );
     }
 

--- a/crates/higgs-engine/src/simple.rs
+++ b/crates/higgs-engine/src/simple.rs
@@ -1578,6 +1578,19 @@ impl SimpleEngine {
         const SPEC_WARMUP: u32 = 3;
         let mut spec_warmup_left: u32 = 0;
 
+        // Periodic t_ar re-calibration. t_ar is only measured during AR steps, so
+        // a long spec-winning streak never refreshes it — and t_ar drifts with
+        // thermal (measured 25ms cool vs 101ms throttled on the same model). A
+        // stale t_ar skews `ratio = n_acc*t_ar/step_wall` and the gate can miss a
+        // regime where spec started losing. So every RECAL_EVERY judged winning
+        // rounds, force ONE AR step to refresh t_ar at the current thermal state.
+        // ~1 AR token per ~240 generated (<0.5% overhead); unlike a probe it does
+        // not re-arm the warm-up grace or reset ratio_ema (1 AR step barely cools
+        // the drafter, and we want to keep the winning EMA).
+        const T_AR_RECAL_EVERY: u32 = 48;
+        let mut spec_since_recal: u32 = 0;
+        let mut recal = false;
+
         loop {
             let round_t0 = std::time::Instant::now();
             if gate && in_ar {
@@ -1592,7 +1605,14 @@ impl SimpleEngine {
                 // so logits + cache are byte-identical; the only thing dropped is a
                 // tap clone the next floored step would overwrite unused.
                 let calibrating = !calibrated;
-                let window = if calibrating { T_AR_CALIB } else { probe_every };
+                // recal: a single AR step to refresh a stale t_ar mid-streak.
+                let window = if recal {
+                    1
+                } else if calibrating {
+                    T_AR_CALIB
+                } else {
+                    probe_every
+                };
                 let leaving = ar_run + 1 >= window;
                 let need_taps = leaving;
                 let single = Array::from_slice(&[last_token], &[1, 1]);
@@ -1628,13 +1648,27 @@ impl SimpleEngine {
                     in_ar = false;
                     ar_run = 0;
                     calibrated = true;
-                    // Grant the fresh spec burst its cold-start grace and re-seed
-                    // the EMA to the optimistic prior. Re-seeding (not blending)
-                    // is load-bearing: otherwise a re-probe inherits the stale
-                    // sub-1.0 ratio_ema and re-floors in one warm round, undoing
-                    // the grace. Mirrors the t_ar_ema map_or seed.
-                    spec_warmup_left = SPEC_WARMUP;
-                    ratio_ema = 2.0;
+                    if recal {
+                        // Just refreshed t_ar mid-streak: resume spec with the
+                        // winning EMA intact and no warm-up (the drafter barely
+                        // cooled over one AR step). need_taps was true, so
+                        // current_taps is fresh for the next draft.
+                        recal = false;
+                        if std::env::var("HIGGS_DFLASH_TRACE").is_ok() {
+                            tracing::info!(
+                                t_ar_ms = format!("{:.1}", t_ar_ema.unwrap_or(0.0) * 1e3),
+                                "GATE t_ar recal"
+                            );
+                        }
+                    } else {
+                        // Grant the fresh spec burst its cold-start grace and
+                        // re-seed the EMA to the optimistic prior. Re-seeding (not
+                        // blending) is load-bearing: otherwise a re-probe inherits
+                        // the stale sub-1.0 ratio_ema and re-floors in one warm
+                        // round, undoing the grace. Mirrors the t_ar_ema map_or seed.
+                        spec_warmup_left = SPEC_WARMUP;
+                        ratio_ema = 2.0;
+                    }
                 }
             } else {
                 // a. Build block: [anchor, mask, mask, ...]
@@ -1815,6 +1849,15 @@ impl SimpleEngine {
                             // Winning: stay in spec, but reset the cadence so a
                             // later degradation is re-probed promptly, not lazily.
                             probe_every = AR_PROBE_BASE;
+                            // Refresh t_ar periodically so a long winning streak
+                            // can't run on a thermally-stale AR reference.
+                            spec_since_recal += 1;
+                            if spec_since_recal >= T_AR_RECAL_EVERY {
+                                in_ar = true;
+                                ar_run = 0;
+                                recal = true;
+                                spec_since_recal = 0;
+                            }
                         }
                     } else {
                         // No T_ar sample yet (initial calibration) — floor at base
@@ -3532,7 +3575,11 @@ mod tests {
         let enable_thinking = std::env::var("HIGGS_TEST_THINKING")
             .map(|v| v != "0")
             .unwrap_or(true);
-        let max_tokens = 200u32;
+        let max_tokens = std::env::var("HIGGS_TEST_MAX_TOKENS")
+            .ok()
+            .and_then(|v| v.parse::<u32>().ok())
+            .filter(|&n| n > 0)
+            .unwrap_or(200);
         let greedy = SamplingParams {
             temperature: 0.0,
             ..SamplingParams::default()

--- a/crates/higgs-engine/src/simple.rs
+++ b/crates/higgs-engine/src/simple.rs
@@ -1539,37 +1539,84 @@ impl SimpleEngine {
         let mut ratio_ema = 2.0_f64;
         let mut in_ar = true;
         let mut ar_run: u32 = 0;
-        // Re-probe spec sparsely: in a sustained high-entropy region each probe
-        // is a wasted slow spec round, so amortize it over many AR steps.
-        const AR_PROBE_EVERY: u32 = 32;
+        // Re-probe spec sparsely with exponential backoff. In a sustained
+        // high-entropy region every probe is a wasted slow spec round (~4
+        // decode-units for ~1-2 tokens), so a fixed cadence taxed the floor by
+        // ~probe_cost/cadence (≈11% at 32 — the measured 0.89× prose gap; the
+        // per-step taps were free, see dflash_floor_tapless_vs_taps_per_step_cost).
+        // Each losing probe doubles the interval (amortizing the cost toward 0 on
+        // sustained prose); a winning probe resets to base so a regime shift back
+        // to spec-friendly text is caught within `AR_PROBE_BASE` tokens.
+        const AR_PROBE_BASE: u32 = 32;
+        // ponytail: cap the backoff at 512 — residual probe tax <1% (≈0.99×),
+        // and recovery never lags a regime change by more than ~512 tokens.
+        const AR_PROBE_MAX: u32 = 512;
+        let mut probe_every = AR_PROBE_BASE;
+
+        // The first decode after prefill is kernel-cold on Metal (~8× steady
+        // state: measured t_ar=187ms vs ~23ms warm). Seeding the gate's AR
+        // reference from it froze t_ar high, so the realized-speedup ratio was
+        // always >1 and the gate NEVER floored — a dead no-op. Fix: spend a short
+        // warm-up window in AR, discard the cold sample, seed t_ar from the warm
+        // steps, then hand off to spec. These are real greedy tokens, not waste.
+        // ponytail: no periodic re-calibration — t_ar only updates on floored
+        // steps, so during a spec-winning streak it holds its last warm value
+        // (can't drift high to mask a loss); a real degradation re-floors and
+        // refreshes it. Add periodic recal only if AR-baseline thermal drift
+        // during long spec streaks ever proves to matter.
+        const T_AR_CALIB: u32 = 3;
+        let mut calibrated = false;
 
         loop {
             let round_t0 = std::time::Instant::now();
             if gate && in_ar {
-                // AR floor: plain S=1 decode (byte-exact). Measures T_ar live and
-                // produces the taps the drafter needs if we re-enter spec.
+                // AR floor: plain S=1 decode (byte-exact). Measures T_ar live.
+                //
+                // Taps are only consumed by the drafter when we re-enter spec next
+                // round, i.e. on the step that hands control back ("leaving"): the
+                // end of the initial calibration window, or a probe cooldown. Use
+                // the optimized tap-less `forward` for every other floored step.
+                // The two paths share `forward_raw_hidden` (identical layer loop,
+                // mask, and KV/GDN cache mutation) and the same `project_logits`,
+                // so logits + cache are byte-identical; the only thing dropped is a
+                // tap clone the next floored step would overwrite unused.
+                let calibrating = !calibrated;
+                let window = if calibrating { T_AR_CALIB } else { probe_every };
+                let leaving = ar_run + 1 >= window;
+                let need_taps = leaving;
                 let single = Array::from_slice(&[last_token], &[1, 1]);
-                let (ar_logits, ar_taps) = model
-                    .forward_with_taps(&single, None, &mut cache, &dflash.tap_layers)
-                    .map_err(EngineError::Mlx)?;
+                let ar_logits = if need_taps {
+                    let (logits, ar_taps) = model
+                        .forward_with_taps(&single, None, &mut cache, &dflash.tap_layers)
+                        .map_err(EngineError::Mlx)?;
+                    current_taps = ar_taps;
+                    logits
+                } else {
+                    model
+                        .forward(&single, None, &mut cache)
+                        .map_err(EngineError::Mlx)?
+                };
                 let ar_next =
                     sample(&ar_logits.index((.., -1, ..)), params).map_err(EngineError::Mlx)?;
                 eval([&ar_next]).map_err(EngineError::Mlx)?;
                 let dt = round_t0.elapsed().as_secs_f64();
-                let was_none = t_ar_ema.is_none();
-                t_ar_ema = Some(t_ar_ema.map_or(dt, |e| 0.7f64.mul_add(e, 0.3 * dt)));
-                current_taps = ar_taps;
+                // Skip the kernel-cold first decode (ar_run == 0 of the initial
+                // calibration window); every later floored step is warm.
+                if !(calibrating && ar_run == 0) {
+                    t_ar_ema = Some(t_ar_ema.map_or(dt, |e| 0.7f64.mul_add(e, 0.3 * dt)));
+                }
                 let ar_id: u32 = ar_next.item();
                 tokens.push(ar_id);
                 last_token = i32::try_from(ar_id)
                     .map_err(|_| EngineError::Generation("ar token overflow".to_owned()))?;
                 start += 1;
                 ar_run += 1;
-                // Leave AR after the initial T_ar calibration, or after a probe
-                // cooldown to re-test whether spec has become worthwhile again.
-                if was_none || ar_run >= AR_PROBE_EVERY {
+                // Hand back to spec once the warm calibration window completes, or
+                // after a probe cooldown re-tests whether spec is worthwhile again.
+                if leaving {
                     in_ar = false;
                     ar_run = 0;
+                    calibrated = true;
                 }
             } else {
                 // a. Build block: [anchor, mask, mask, ...]
@@ -1714,13 +1761,34 @@ impl SimpleEngine {
                     if let Some(t_ar) = t_ar_ema {
                         let ratio = f64::from(n_accepted) * t_ar / step_wall;
                         ratio_ema = 0.6f64.mul_add(ratio_ema, 0.4 * ratio);
+                        if std::env::var("HIGGS_DFLASH_TRACE").is_ok() && rounds <= 8 {
+                            tracing::info!(
+                                round = rounds,
+                                n_accepted,
+                                t_ar_ms = format!("{:.1}", t_ar * 1e3),
+                                step_wall_ms = format!("{:.1}", step_wall * 1e3),
+                                ratio = format!("{ratio:.2}"),
+                                ratio_ema = format!("{ratio_ema:.2}"),
+                                "GATE"
+                            );
+                        }
                         if ratio_ema < 1.0 {
+                            // Losing probe: floor and back off so the next probe
+                            // amortizes over a longer AR run (sustained prose).
                             in_ar = true;
                             ar_run = 0;
+                            probe_every = probe_every.saturating_mul(2).min(AR_PROBE_MAX);
+                        } else {
+                            // Winning: stay in spec, but reset the cadence so a
+                            // later degradation is re-probed promptly, not lazily.
+                            probe_every = AR_PROBE_BASE;
                         }
                     } else {
+                        // No T_ar sample yet (initial calibration) — floor at base
+                        // cadence; this isn't a losing probe, so don't back off.
                         in_ar = true;
                         ar_run = 0;
+                        probe_every = AR_PROBE_BASE;
                     }
                 }
             } // end spec-round branch
@@ -1778,6 +1846,8 @@ impl SimpleEngine {
                 tracing::info!(
                     tokens = tokens.len(),
                     accept_len = format!("{accept_len:.2}"),
+                    spec_rounds = rounds,
+                    probe_every = probe_every,
                     tok_per_sec = format!("{tok_per_sec:.1}"),
                     "DFlash generation complete (length limit)"
                 );
@@ -3492,6 +3562,89 @@ mod tests {
         assert!(
             long.starts_with(short),
             "DFlash diverged from AR greedy:\n AR={ar_text:?}\n DF={df_text:?}"
+        );
+    }
+
+    /// Isolates the per-step cost the gate's AR floor pays for taps. Floored
+    /// steps now call `forward` (tap-less) instead of `forward_with_taps`; this
+    /// interleaves the two over many single-token decodes so thermal drift
+    /// averages out (the end-to-end ratio is hopelessly thermally confounded on
+    /// this serial-load harness) and prints mean µs/token for each. If the delta
+    /// is ~0 the tap clones are lazy/dropped and the fast-decode path is a no-op;
+    /// a real delta is the prose-parity win. Run with `--ignored --nocapture`.
+    #[test]
+    #[ignore = "p5: loads real 35B target; set HIGGS_DFLASH_TARGET_DIR + HIGGS_DFLASH_DRAFTER_DIR"]
+    #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
+    fn dflash_floor_tapless_vs_taps_per_step_cost() {
+        use super::{SimpleEngine, lock_or_recover};
+        use crate::mlx_tuning::{MlxRuntimeTuning, RequestedMlxProfile};
+        use higgs_models::turboquant::KvCacheConfig;
+        use mlx_rs::{Array, ops::indexing::IndexOp, transforms::eval};
+
+        let Ok(target) = std::env::var("HIGGS_DFLASH_TARGET_DIR") else {
+            eprintln!("skip: set HIGGS_DFLASH_TARGET_DIR");
+            return;
+        };
+        let drafter =
+            std::env::var("HIGGS_DFLASH_DRAFTER_DIR").expect("set HIGGS_DFLASH_DRAFTER_DIR");
+        let tuning =
+            MlxRuntimeTuning::from_model_dir(Path::new(&target), RequestedMlxProfile::Auto);
+        let engine = SimpleEngine::load_with_dflash(
+            &target,
+            KvCacheConfig::default(),
+            tuning,
+            false,
+            Some(Path::new(&drafter)),
+        )
+        .expect("load target + drafter");
+        let tap_layers = engine.dflash.as_ref().expect("dflash").tap_layers.clone();
+        let cfg = engine.kv_cache_config;
+        let mut model = lock_or_recover(&engine.model);
+        let mut cache = model.make_cache_with_config(cfg).expect("cache");
+
+        // Prefill so decode steps run at a realistic cache offset.
+        let prompt: Vec<i32> = (1..=32).collect();
+        let parr = Array::from_slice(&prompt, &[1, prompt.len() as i32]);
+        let (logits, _t) = model
+            .forward_with_taps(&parr, None, &mut cache, &tap_layers)
+            .expect("prefill");
+        let am = mlx_rs::argmax_axis!(logits.index((.., -1, ..)), -1).expect("argmax");
+        eval([&am]).expect("eval");
+        let mut next: i32 = i32::try_from(am.item::<u32>()).expect("tok");
+
+        let (warm, iters) = (8u32, 160u32);
+        let (mut t_taps, mut n_taps, mut t_plain, mut n_plain) = (0f64, 0u32, 0f64, 0u32);
+        for i in 0..(warm + iters) {
+            let single = Array::from_slice(&[next], &[1, 1]);
+            let use_taps = i % 2 == 0;
+            let start = std::time::Instant::now();
+            let logits = if use_taps {
+                model
+                    .forward_with_taps(&single, None, &mut cache, &tap_layers)
+                    .expect("taps")
+                    .0
+            } else {
+                model.forward(&single, None, &mut cache).expect("plain")
+            };
+            let am = mlx_rs::argmax_axis!(logits.index((.., -1, ..)), -1).expect("argmax");
+            eval([&am]).expect("eval");
+            let dt = start.elapsed().as_secs_f64();
+            next = i32::try_from(am.item::<u32>()).expect("tok");
+            if i >= warm {
+                if use_taps {
+                    t_taps += dt;
+                    n_taps += 1;
+                } else {
+                    t_plain += dt;
+                    n_plain += 1;
+                }
+            }
+        }
+        let us_taps = t_taps / f64::from(n_taps) * 1e6;
+        let us_plain = t_plain / f64::from(n_plain) * 1e6;
+        eprintln!(
+            "floor step cost: forward_with_taps {us_taps:.0} µs/tok | forward(tap-less) {us_plain:.0} µs/tok | taps overhead {:.1}% ({n_taps} taps / {n_plain} plain)",
+            (us_taps - us_plain) / us_taps * 100.0
         );
     }
 

--- a/crates/higgs-engine/src/simple.rs
+++ b/crates/higgs-engine/src/simple.rs
@@ -276,6 +276,7 @@ pub struct SimpleEngine {
     /// Optional `DFlash` block-diffusion speculative decoding state, enabled
     /// when `HIGGS_DFLASH_PATH` points at a drafter checkpoint.
     dflash: Option<DFlashState>,
+    last_dflash_accepts: std::sync::Mutex<Vec<u32>>,
 }
 
 /// Intermediate state after prefix cache lookup and model locking.
@@ -519,6 +520,7 @@ impl SimpleEngine {
             kv_cache_config,
             tuning,
             dflash,
+            last_dflash_accepts: Mutex::new(Vec::new()),
         })
     }
 
@@ -540,6 +542,13 @@ impl SimpleEngine {
     /// Whether the engine has thinking mode enabled.
     pub const fn enable_thinking(&self) -> bool {
         self.enable_thinking
+    }
+
+    pub fn last_dflash_accepts(&self) -> Vec<u32> {
+        self.last_dflash_accepts
+            .lock()
+            .map(|v| v.clone())
+            .unwrap_or_default()
     }
 
     /// Apply chat template and tokenize messages with explicit thinking control.
@@ -1453,6 +1462,9 @@ impl SimpleEngine {
             .ok_or_else(|| EngineError::Generation("DFlash state missing".to_owned()))?;
         let prompt_len = Self::prompt_len(prompt_tokens)?;
         let has_stop_sequences = !stop_sequences.is_empty();
+        if let Ok(mut v) = self.last_dflash_accepts.lock() {
+            v.clear();
+        }
 
         let mut model = lock_or_recover(&self.model);
         let mut drafter = lock_or_recover(&dflash.drafter);
@@ -1736,6 +1748,9 @@ impl SimpleEngine {
                     .as_slice::<u32>()
                     .to_vec();
                 let accepted = accept_prefix(&draft_u32, &verify_flat);
+                if let Ok(mut v) = self.last_dflash_accepts.lock() {
+                    v.push(u32::try_from(accepted.len()).unwrap_or(0));
+                }
                 let n_accepted = i32::try_from(accepted.len())
                     .map_err(|_| EngineError::Generation("n_accepted overflow".to_owned()))?;
                 rounds += 1;
@@ -3507,9 +3522,16 @@ fn chat_template_mentions_enable_thinking(model_dir: &Path) -> bool {
 #[allow(clippy::panic, clippy::unwrap_used)]
 mod tests {
     use super::{
-        IncrementalDetok, Tokenizer, adaptive_draft_depth_for_cap, check_stop_sequences,
-        derive_model_name, detect_thinking_support, estimate_paged_kv_blocks, extract_eos_tokens,
-        find_stop_in_tail, parse_enabled_flag,
+        IncrementalDetok, SimpleEngine, Tokenizer, adaptive_draft_depth_for_cap,
+        check_stop_sequences, derive_model_name, detect_thinking_support, estimate_paged_kv_blocks,
+        extract_eos_tokens, find_stop_in_tail, lock_or_recover, parse_enabled_flag,
+    };
+    use crate::chat_template::ChatMessage;
+    use higgs_models::SamplingParams;
+    use mlx_rs::{
+        Array, Dtype,
+        ops::indexing::{IndexOp, NewAxis},
+        transforms::eval,
     };
     use std::path::Path;
 
@@ -3628,6 +3650,414 @@ mod tests {
             long.starts_with(short),
             "DFlash diverged from AR greedy:\n AR={ar_text:?}\n DF={df_text:?}"
         );
+    }
+
+    struct DFlashArMetrics {
+        h_bits: f64,
+        top1_prob: f64,
+        tokens: Vec<u32>,
+        text: String,
+    }
+
+    struct DFlashRunMetrics {
+        text: String,
+        accept_mean: f64,
+        p10: u32,
+        p50: u32,
+        p90: u32,
+        accept_frac: f64,
+    }
+
+    struct DFlashSweepRow {
+        task: String,
+        h_bits: f64,
+        top1_prob: f64,
+        accept_mean: f64,
+        p10: u32,
+        p50: u32,
+        p90: u32,
+        accept_frac: f64,
+        byte_exact: bool,
+    }
+
+    #[allow(unsafe_code)]
+    fn dflash_set_test_env(key: &str, value: &str) {
+        // SAFETY: This ignored manual harness mutates DFlash env knobs before
+        // model loading/generation and is intended to be run alone.
+        unsafe { std::env::set_var(key, value) };
+    }
+
+    fn dflash_set_fixed_block_env(block_size: u32) {
+        dflash_set_test_env("HIGGS_DFLASH_GATE", "0");
+        dflash_set_test_env("HIGGS_DFLASH_ADAPTIVE", "0");
+        dflash_set_test_env("HIGGS_DFLASH_BLOCK_SIZE", &block_size.to_string());
+    }
+
+    fn dflash_chat_tokens(engine: &SimpleEngine, prompt: &str) -> Vec<u32> {
+        let messages = [ChatMessage {
+            role: "user".to_owned(),
+            content: prompt.to_owned(),
+            tool_calls: None,
+        }];
+        engine
+            .prepare_chat_prompt_with_thinking(&messages, None, false)
+            .expect("chat prompt")
+    }
+
+    fn dflash_entropy_and_top1(row: &[f32]) -> (u32, f64, f64) {
+        assert!(!row.is_empty(), "empty logits row");
+        let mut ranked: Vec<(usize, f32)> = row.iter().copied().enumerate().collect();
+        ranked.sort_by(|a, b| b.1.total_cmp(&a.1));
+
+        let max_logit = f64::from(ranked[0].1);
+        let denom = row
+            .iter()
+            .map(|&v| (f64::from(v) - max_logit).exp())
+            .sum::<f64>();
+        let denom = denom.max(f64::MIN_POSITIVE);
+        let top_n = ranked.len().min(50);
+        let top_probs: Vec<f64> = ranked
+            .iter()
+            .take(top_n)
+            .map(|&(_, v)| (f64::from(v) - max_logit).exp() / denom)
+            .collect();
+        let top_mass = top_probs.iter().sum::<f64>().max(f64::MIN_POSITIVE);
+        let entropy = top_probs
+            .iter()
+            .map(|&p| {
+                let q = p / top_mass;
+                if q > 0.0 { -q * q.log2() } else { 0.0 }
+            })
+            .sum::<f64>();
+        let top1_prob = top_probs.first().copied().unwrap_or(0.0);
+        let token = u32::try_from(ranked[0].0).expect("vocab id overflow");
+        (token, entropy, top1_prob)
+    }
+
+    fn dflash_ar_entropy_pass(
+        engine: &SimpleEngine,
+        prompt: &str,
+        max_tokens: u32,
+    ) -> DFlashArMetrics {
+        let prompt_tokens = dflash_chat_tokens(engine, prompt);
+        let mut model = lock_or_recover(&engine.model);
+        let mut cache = model
+            .make_cache_with_config(engine.kv_cache_config)
+            .expect("cache");
+        let prompt_array = Array::from(prompt_tokens.as_slice()).index(NewAxis);
+        let seq_len = prompt_array.shape().get(1).copied().unwrap_or(0);
+        let mut logits = if seq_len > engine.tuning.chunked_prefill_threshold() {
+            model
+                .forward_chunked(
+                    &prompt_array,
+                    &mut cache,
+                    engine.tuning.chunked_prefill_chunk_size(),
+                )
+                .expect("chunked prefill")
+        } else {
+            model
+                .forward_last_token(&prompt_array, None, &mut cache)
+                .expect("prefill")
+        };
+
+        let max_tokens_usize = usize::try_from(max_tokens).expect("max_tokens overflow");
+        let mut tokens = Vec::with_capacity(max_tokens_usize);
+        let mut entropy_sum = 0.0_f64;
+        let mut top1_sum = 0.0_f64;
+
+        for step in 0..max_tokens_usize {
+            let row = logits
+                .index((.., -1, ..))
+                .reshape(&[-1])
+                .expect("reshape logits")
+                .as_dtype(Dtype::Float32)
+                .expect("f32 logits");
+            eval([&row]).expect("eval logits");
+            let (next_token, entropy, top1_prob) = dflash_entropy_and_top1(row.as_slice::<f32>());
+            entropy_sum += entropy;
+            top1_sum += top1_prob;
+            tokens.push(next_token);
+
+            if step + 1 < max_tokens_usize {
+                let next_token_i32 = i32::try_from(next_token).expect("token id overflow");
+                let single = Array::from_slice(&[next_token_i32], &[1, 1]);
+                logits = model
+                    .forward(&single, None, &mut cache)
+                    .expect("decode step");
+            }
+        }
+        drop(model);
+
+        let text = engine.decode_tokens(&tokens).expect("decode AR tokens");
+        let denom = f64::from(max_tokens);
+        DFlashArMetrics {
+            h_bits: entropy_sum / denom,
+            top1_prob: top1_sum / denom,
+            tokens,
+            text,
+        }
+    }
+
+    fn dflash_accept_metrics(accepts: &[u32], block_size: u32) -> (f64, u32, u32, u32, f64) {
+        if accepts.is_empty() {
+            return (0.0, 0, 0, 0, 0.0);
+        }
+        let mean = accepts.iter().map(|&n| f64::from(n)).sum::<f64>() / accepts.len() as f64;
+        let mut sorted = accepts.to_vec();
+        sorted.sort_unstable();
+        let last = sorted.len() - 1;
+        let p10 = sorted[last * 10 / 100];
+        let p50 = sorted[last * 50 / 100];
+        let p90 = sorted[last * 90 / 100];
+        let accept_frac = mean / f64::from(block_size.max(1));
+        (mean, p10, p50, p90, accept_frac)
+    }
+
+    fn dflash_generation_pass(
+        engine: &SimpleEngine,
+        prompt: &str,
+        max_tokens: u32,
+        block_size: u32,
+        greedy: &SamplingParams,
+    ) -> DFlashRunMetrics {
+        dflash_set_fixed_block_env(block_size);
+        let prompt_tokens = dflash_chat_tokens(engine, prompt);
+        let out = engine
+            .generate_with_thinking(
+                &prompt_tokens,
+                max_tokens,
+                greedy,
+                &[],
+                false,
+                None,
+                false,
+                None,
+                None,
+            )
+            .expect("DFlash generation");
+        let accepts = engine.last_dflash_accepts();
+        let (accept_mean, p10, p50, p90, accept_frac) = dflash_accept_metrics(&accepts, block_size);
+        DFlashRunMetrics {
+            text: out.text,
+            accept_mean,
+            p10,
+            p50,
+            p90,
+            accept_frac,
+        }
+    }
+
+    fn dflash_prefix_consistent(left: &str, right: &str) -> bool {
+        if left.len() <= right.len() {
+            right.starts_with(left)
+        } else {
+            left.starts_with(right)
+        }
+    }
+
+    fn dflash_row_from_metrics(
+        task: impl Into<String>,
+        ar: &DFlashArMetrics,
+        df: DFlashRunMetrics,
+    ) -> DFlashSweepRow {
+        DFlashSweepRow {
+            task: task.into(),
+            h_bits: ar.h_bits,
+            top1_prob: ar.top1_prob,
+            accept_mean: df.accept_mean,
+            p10: df.p10,
+            p50: df.p50,
+            p90: df.p90,
+            accept_frac: df.accept_frac,
+            byte_exact: !ar.tokens.is_empty() && dflash_prefix_consistent(&ar.text, &df.text),
+        }
+    }
+
+    fn dflash_sweep_row(
+        engine: &SimpleEngine,
+        task: impl Into<String>,
+        prompt: &str,
+        max_tokens: u32,
+        block_size: u32,
+        greedy: &SamplingParams,
+    ) -> DFlashSweepRow {
+        let ar = dflash_ar_entropy_pass(engine, prompt, max_tokens);
+        let df = dflash_generation_pass(engine, prompt, max_tokens, block_size, greedy);
+        dflash_row_from_metrics(task, &ar, df)
+    }
+
+    fn dflash_print_table(title: &str, rows: &[DFlashSweepRow]) {
+        println!("\n{title}");
+        println!(
+            "| task | H_bits | top1_prob | accept_mean | p10 | p50 | p90 | accept_frac | byte_exact |"
+        );
+        println!("| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |");
+        for row in rows {
+            println!(
+                "| {} | {:.3} | {:.3} | {:.2} | {} | {} | {} | {:.3} | {} |",
+                row.task,
+                row.h_bits,
+                row.top1_prob,
+                row.accept_mean,
+                row.p10,
+                row.p50,
+                row.p90,
+                row.accept_frac,
+                row.byte_exact
+            );
+        }
+    }
+
+    fn dflash_repeat_prompt_to_chat_tokens(
+        engine: &SimpleEngine,
+        prompt: &str,
+        target_tokens: usize,
+    ) -> String {
+        let base_len = dflash_chat_tokens(engine, prompt).len().max(1);
+        let reps = (target_tokens / base_len).max(1);
+        let mut padded = std::iter::repeat_n(prompt, reps)
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        while dflash_chat_tokens(engine, &padded).len() < target_tokens {
+            padded.push_str("\n\n");
+            padded.push_str(prompt);
+        }
+        padded
+    }
+
+    #[test]
+    #[ignore = "loads real DFlash target + drafter; set HIGGS_DFLASH_TARGET_DIR + HIGGS_DFLASH_DRAFTER_DIR"]
+    #[allow(
+        clippy::too_many_lines,
+        clippy::cast_precision_loss,
+        clippy::as_conversions
+    )]
+    fn dflash_entropy_sweep() {
+        use crate::mlx_tuning::{MlxRuntimeTuning, RequestedMlxProfile};
+        use higgs_models::turboquant::KvCacheConfig;
+
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter("info")
+            .with_test_writer()
+            .try_init();
+
+        let (target, drafter) = match (
+            std::env::var("HIGGS_DFLASH_TARGET_DIR"),
+            std::env::var("HIGGS_DFLASH_DRAFTER_DIR"),
+        ) {
+            (Ok(target), Ok(drafter)) => (target, drafter),
+            _ => {
+                println!(
+                    "skipping dflash_entropy_sweep: set HIGGS_DFLASH_TARGET_DIR + HIGGS_DFLASH_DRAFTER_DIR"
+                );
+                return;
+            }
+        };
+
+        const MAX_TOKENS: u32 = 160;
+        const DEFAULT_BLOCK_SIZE: u32 = 16;
+        const MULT_TABLES: &str = "Print the multiplication tables from 1 x 1 through 12 x 12 in ascending order. Use one equation per line.";
+        const COUNT_200: &str = "Count from 1 to 200. Print only the numbers separated by commas.";
+        const JSON_RECORDS: &str = "Emit 24 JSON objects, one per line, with schema {\"id\": number, \"name\": \"item-N\", \"active\": true, \"score\": number}. Use deterministic ascending ids.";
+        const CSV_TABLE: &str = "Create a CSV table with columns day,city,temperature_c,condition for 40 rows. Use predictable city names City01 through City40.";
+        const STRUCT_GETTERS: &str = "Write repetitive Rust code for a UserProfile struct with fields id, name, email, age, city, country, plan, created_at, and add simple getter methods for every field.";
+        const SORT_ALGORITHM: &str = "Write an iterative insertion sort implementation in Python, then walk through sorting [9, 4, 7, 1, 3, 8] step by step.";
+        const CAPITALS: &str = "List the capitals of these countries in order: France, Germany, Italy, Spain, Portugal, Netherlands, Belgium, Austria, Poland, Czechia, Denmark, Sweden, Norway, Finland, Ireland, Greece, Turkey, Egypt, Japan, Canada.";
+        const UNIT_CONVERSIONS: &str = "Create a unit conversion table for meters to feet from 1 through 40 meters. Use four decimal places.";
+        const TRANSLATION: &str = "Translate this paragraph from English to French: The research team tested a compact solar pump in three villages. During the dry season, farmers used it to irrigate tomato fields, compare fuel savings, and record maintenance issues.";
+        const GSM8K: &str = "Solve this word problem with clear arithmetic steps: A bakery made 186 muffins. It sold 48 before lunch, baked 3 more trays with 24 muffins each, then packed the rest equally into 7 boxes. How many muffins were in each box, and how many were left over?";
+        const PHOTOSYNTHESIS: &str = "Explain photosynthesis for a technically curious reader. Cover chlorophyll, light reactions, carbon fixation, water splitting, and why the process matters to ecosystems.";
+        const STORY: &str = "Write a vivid short story about an archivist who discovers that a city map changes every midnight. Include sensory detail and an unresolved final image.";
+
+        const PROMPTS: [(&str, &str); 12] = [
+            ("multiplication tables", MULT_TABLES),
+            ("count 1..200", COUNT_200),
+            ("fixed-schema JSON", JSON_RECORDS),
+            ("CSV table", CSV_TABLE),
+            ("struct getters", STRUCT_GETTERS),
+            ("iterative sort", SORT_ALGORITHM),
+            ("capitals list", CAPITALS),
+            ("unit conversion", UNIT_CONVERSIONS),
+            ("EN-FR translation", TRANSLATION),
+            ("GSM8K word problem", GSM8K),
+            ("photosynthesis", PHOTOSYNTHESIS),
+            ("short story", STORY),
+        ];
+
+        let greedy = SamplingParams {
+            temperature: 0.0,
+            ..SamplingParams::default()
+        };
+
+        let load_engine = |block_size: u32| -> SimpleEngine {
+            dflash_set_fixed_block_env(block_size);
+            let tuning =
+                MlxRuntimeTuning::from_model_dir(Path::new(&target), RequestedMlxProfile::Auto);
+            SimpleEngine::load_with_dflash(
+                &target,
+                KvCacheConfig::default(),
+                tuning,
+                false,
+                Some(Path::new(&drafter)),
+            )
+            .expect("load DFlash engine")
+        };
+
+        let engine = load_engine(DEFAULT_BLOCK_SIZE);
+
+        let mut entropy_rows = Vec::new();
+        for &(label, prompt) in &PROMPTS {
+            entropy_rows.push(dflash_sweep_row(
+                &engine,
+                label,
+                prompt,
+                MAX_TOKENS,
+                DEFAULT_BLOCK_SIZE,
+                &greedy,
+            ));
+        }
+        entropy_rows.sort_by(|a, b| a.h_bits.total_cmp(&b.h_bits));
+        dflash_print_table("## ENTROPY", &entropy_rows);
+
+        let mut context_rows = Vec::new();
+        for &(label, prompt) in &[
+            ("context multiplication", MULT_TABLES),
+            ("context story", STORY),
+        ] {
+            for target_tokens in [512_usize, 4096, 16_384] {
+                let padded = dflash_repeat_prompt_to_chat_tokens(&engine, prompt, target_tokens);
+                context_rows.push(dflash_sweep_row(
+                    &engine,
+                    format!("{label}-{target_tokens}"),
+                    &padded,
+                    MAX_TOKENS,
+                    DEFAULT_BLOCK_SIZE,
+                    &greedy,
+                ));
+            }
+        }
+        dflash_print_table("## CONTEXT", &context_rows);
+
+        let sort_ar = dflash_ar_entropy_pass(&engine, SORT_ALGORITHM, MAX_TOKENS);
+        drop(engine);
+
+        let mut block_rows = Vec::new();
+        for block_size in [4_u32, 8, 16] {
+            let block_engine = load_engine(block_size);
+            let df = dflash_generation_pass(
+                &block_engine,
+                SORT_ALGORITHM,
+                MAX_TOKENS,
+                block_size,
+                &greedy,
+            );
+            block_rows.push(dflash_row_from_metrics(
+                format!("iterative sort block {block_size}"),
+                &sort_ar,
+                df,
+            ));
+        }
+        dflash_print_table("## BLOCK", &block_rows);
     }
 
     /// Gemma chat models stop on `<end_of_turn>`, which their `config.json` often

--- a/crates/higgs-engine/src/simple.rs
+++ b/crates/higgs-engine/src/simple.rs
@@ -37,6 +37,7 @@ use crate::{
 /// Default maximum number of cached prefixes.
 const DEFAULT_PREFIX_CACHE_SIZE: usize = 8;
 const DEFAULT_PAGED_KV_BLOCK_SIZE: usize = 64;
+const THINKING_BUDGET: u32 = 256;
 
 /// Acquire a `Mutex` lock, recovering from poison by reusing the inner data.
 /// Used in this crate to keep session-management methods infallible while
@@ -60,6 +61,48 @@ fn experimental_paged_kv_enabled() -> bool {
 
 fn prompt_lookup_enabled() -> bool {
     parse_enabled_flag(std::env::var("HIGGS_PROMPT_LOOKUP").ok().as_deref()).unwrap_or(false)
+}
+
+#[allow(clippy::float_cmp)]
+fn dflash_supports_plain_greedy(
+    params: &SamplingParams,
+    logprobs: bool,
+    top_logprobs: Option<u32>,
+) -> bool {
+    !logprobs
+        && top_logprobs.unwrap_or(0) == 0
+        && params.temperature == 0.0
+        && params.top_p == 1.0
+        && params.top_k.is_none()
+        && params.min_p.is_none()
+        && !params.has_penalties()
+}
+
+fn enforce_thinking_budget_token(
+    token_id: &mut u32,
+    think_close_token: Option<u32>,
+    thinking_tokens: &mut u32,
+    seen_think_close: &mut bool,
+) -> bool {
+    if let Some(close_id) = think_close_token {
+        if !*seen_think_close {
+            if *token_id == close_id {
+                *seen_think_close = true;
+            } else {
+                *thinking_tokens += 1;
+                if *thinking_tokens >= THINKING_BUDGET {
+                    *token_id = close_id;
+                    *seen_think_close = true;
+                    tracing::info!(
+                        budget = THINKING_BUDGET,
+                        "Thinking budget reached, forcing </think>"
+                    );
+                    return true;
+                }
+            }
+        }
+    }
+    false
 }
 
 fn unchecked_prompt_lookup_enabled() -> bool {
@@ -1110,9 +1153,19 @@ impl SimpleEngine {
         pixel_values: Option<Array>,
     ) -> Result<GenerationOutput, EngineError> {
         // DFlash speculative decoding: use the draft-verify loop when a drafter
-        // is loaded, no constraints active, and no multimodal input.
-        if self.dflash.is_some() && constraint.is_none() && pixel_values.is_none() {
-            return self.generate_dflash_inner(prompt_tokens, max_tokens, params, stop_sequences);
+        // is loaded and the request is plain greedy text generation.
+        if self.dflash.is_some()
+            && constraint.is_none()
+            && pixel_values.is_none()
+            && dflash_supports_plain_greedy(params, logprobs, top_logprobs)
+        {
+            return self.generate_dflash_inner(
+                prompt_tokens,
+                max_tokens,
+                params,
+                stop_sequences,
+                enable_thinking,
+            );
         }
 
         let logprob_top_n = logprobs.then(|| top_logprobs.unwrap_or(0));
@@ -1256,7 +1309,6 @@ impl SimpleEngine {
         let mut step_count: u32 = 0;
 
         // Thinking budget: force </think> after N tokens if model hasn't closed it.
-        const THINKING_BUDGET: u32 = 256;
         let think_close_token = if enable_thinking {
             self.think_close_token
         } else {
@@ -1455,6 +1507,7 @@ impl SimpleEngine {
         max_tokens: u32,
         params: &SamplingParams,
         stop_sequences: &[String],
+        enable_thinking: bool,
     ) -> Result<GenerationOutput, EngineError> {
         let dflash = self
             .dflash
@@ -1487,6 +1540,14 @@ impl SimpleEngine {
 
         let first_token_id: u32 = first_token.item();
         let mut tokens: Vec<u32> = vec![first_token_id];
+        let think_close_token = if enable_thinking {
+            self.think_close_token
+        } else {
+            None
+        };
+        let mut thinking_tokens: u32 = u32::from(think_close_token.is_some());
+        let mut seen_think_close =
+            think_close_token.is_some_and(|close_id| first_token_id == close_id);
 
         if self.eos_token_ids.contains(&first_token_id) || max_tokens <= 1 {
             let finish_reason = if self.eos_token_ids.contains(&first_token_id) {
@@ -1648,7 +1709,13 @@ impl SimpleEngine {
                 if !(calibrating && ar_run == 0) {
                     t_ar_ema = Some(t_ar_ema.map_or(dt, |e| 0.7f64.mul_add(e, 0.3 * dt)));
                 }
-                let ar_id: u32 = ar_next.item();
+                let mut ar_id: u32 = ar_next.item();
+                enforce_thinking_budget_token(
+                    &mut ar_id,
+                    think_close_token,
+                    &mut thinking_tokens,
+                    &mut seen_think_close,
+                );
                 tokens.push(ar_id);
                 last_token = i32::try_from(ar_id)
                     .map_err(|_| EngineError::Generation("ar token overflow".to_owned()))?;
@@ -1747,7 +1814,38 @@ impl SimpleEngine {
                     .map_err(EngineError::Mlx)?
                     .as_slice::<u32>()
                     .to_vec();
-                let accepted = accept_prefix(&draft_u32, &verify_flat);
+                let mut accepted = accept_prefix(&draft_u32, &verify_flat);
+                let remaining_u32 = max_tokens.saturating_sub(Self::completion_len(&tokens)?);
+                let remaining = usize::try_from(remaining_u32).map_err(|_| {
+                    EngineError::Generation("remaining token budget overflow".to_owned())
+                })?;
+                accepted.truncate(remaining);
+                for idx in 0..accepted.len() {
+                    if enforce_thinking_budget_token(
+                        &mut accepted[idx],
+                        think_close_token,
+                        &mut thinking_tokens,
+                        &mut seen_think_close,
+                    ) {
+                        accepted.truncate(idx + 1);
+                        break;
+                    }
+                }
+                if let Some(eos_pos) = accepted
+                    .iter()
+                    .position(|tok| self.eos_token_ids.contains(tok))
+                {
+                    accepted.truncate(eos_pos + 1);
+                }
+                if accepted.is_empty() {
+                    return Ok(GenerationOutput {
+                        text: self.decode_tokens(&tokens)?,
+                        finish_reason: "length".to_owned(),
+                        prompt_tokens: prompt_len,
+                        completion_tokens: Self::completion_len(&tokens)?,
+                        token_logprobs: None,
+                    });
+                }
                 if let Ok(mut v) = self.last_dflash_accepts.lock() {
                     v.push(u32::try_from(accepted.len()).unwrap_or(0));
                 }
@@ -3594,16 +3692,26 @@ mod tests {
 
         let run = |with_drafter: bool| -> (String, f64) {
             let drafter_path = with_drafter.then(|| Path::new(&drafter));
+            let saved_dflash_path = if with_drafter {
+                None
+            } else {
+                let previous = std::env::var_os("HIGGS_DFLASH_PATH");
+                dflash_restore_test_env("HIGGS_DFLASH_PATH", None);
+                Some(previous)
+            };
             let tuning =
                 MlxRuntimeTuning::from_model_dir(Path::new(&target), RequestedMlxProfile::Auto);
-            let engine = SimpleEngine::load_with_dflash(
+            let engine_result = SimpleEngine::load_with_dflash(
                 &target,
                 KvCacheConfig::default(),
                 tuning,
                 false,
                 drafter_path,
-            )
-            .expect("load target");
+            );
+            if let Some(previous) = saved_dflash_path {
+                dflash_restore_test_env("HIGGS_DFLASH_PATH", previous);
+            }
+            let engine = engine_result.expect("load target");
             let messages = [ChatMessage {
                 role: "user".to_owned(),
                 content: user_prompt.to_owned(),
@@ -3685,6 +3793,16 @@ mod tests {
         // SAFETY: This ignored manual harness mutates DFlash env knobs before
         // model loading/generation and is intended to be run alone.
         unsafe { std::env::set_var(key, value) };
+    }
+
+    #[allow(unsafe_code)]
+    fn dflash_restore_test_env(key: &str, value: Option<std::ffi::OsString>) {
+        // SAFETY: These ignored manual DFlash harnesses mutate process env before
+        // model loading/generation and are intended to be run alone.
+        match value {
+            Some(value) => unsafe { std::env::set_var(key, value) },
+            None => unsafe { std::env::remove_var(key) },
+        }
     }
 
     fn dflash_set_fixed_block_env(block_size: u32) {

--- a/crates/higgs-engine/src/simple.rs
+++ b/crates/higgs-engine/src/simple.rs
@@ -1525,143 +1525,213 @@ impl SimpleEngine {
         let mut total_accepted: u64 = 0;
         let mut rounds: u64 = 0;
 
+        // Realized-speedup gate (auto-calibrated, no per-model knob). Measure
+        // T_ar (wall per AR token) live; each spec round compute the realized
+        // speedup ratio = n_accepted * T_ar / step_wall. If the EMA of that
+        // ratio falls below 1.0, spec is actually slower than plain AR for this
+        // text (MoE's fast AR raises the bar; a fixed entropy threshold can't
+        // see that), so floor to AR and re-probe periodically. Flooring also
+        // keeps the S>1 verify off high-entropy near-ties (where it both slows
+        // down and flips argmax), so AR regions stay byte-exact. Start in AR for
+        // one step to calibrate T_ar, then enter spec. Disable: HIGGS_DFLASH_GATE=0.
+        let gate = std::env::var("HIGGS_DFLASH_GATE").map_or(true, |v| v != "0");
+        let mut t_ar_ema: Option<f64> = None;
+        let mut ratio_ema = 2.0_f64;
+        let mut in_ar = true;
+        let mut ar_run: u32 = 0;
+        // Re-probe spec sparsely: in a sustained high-entropy region each probe
+        // is a wasted slow spec round, so amortize it over many AR steps.
+        const AR_PROBE_EVERY: u32 = 32;
+
         loop {
-            // a. Build block: [anchor, mask, mask, ...]
-            let block_size_us = usize::try_from(block_size)
-                .map_err(|_| EngineError::Generation("block_size overflow for usize".to_owned()))?;
-            let mut block_tokens = vec![mask_id; block_size_us];
-            if let Some(slot) = block_tokens.get_mut(0) {
-                *slot = last_token;
-            }
-            let block_ids = Array::from_slice(&block_tokens, &[1, block_size]);
-
-            // b. Embed through target's embedding layer.
-            let noise_embedding = model
-                .embed_token_ids(&block_ids)
-                .map_err(EngineError::Mlx)?;
-
-            // c. Drafter forward.
-            let draft_hidden = drafter
-                .forward(&noise_embedding, &current_taps, &mut draft_cache)
-                .map_err(EngineError::Mlx)?;
-            crop_drafter_cache(&mut draft_cache, start);
-
-            // d. Target lm_head on sliced hidden -> argmax draft tokens.
-            let draft_hidden_sliced = draft_hidden.index((.., 1.., ..));
-            let draft_logits = model
-                .forward_all_logits_from_hidden(&draft_hidden_sliced)
-                .map_err(EngineError::Mlx)?;
-            let draft_token_arr =
-                mlx_rs::argmax_axis!(draft_logits, -1).map_err(EngineError::Mlx)?;
-            eval([&draft_token_arr]).map_err(EngineError::Mlx)?;
-            let draft_u32: Vec<u32> = draft_token_arr
-                .reshape(&[-1])
-                .map_err(EngineError::Mlx)?
-                .as_slice::<u32>()
-                .to_vec();
-            let draft_i32: Vec<i32> = draft_u32
-                .iter()
-                .map(|&x| {
-                    i32::try_from(x)
-                        .map_err(|_| EngineError::Generation("draft token overflow i32".to_owned()))
-                })
-                .collect::<Result<_, _>>()?;
-
-            // e. Build verify input: [anchor, draft_0..draft_{N-2}].
-            let mut verify_tokens = vec![last_token];
-            verify_tokens.extend_from_slice(&draft_i32);
-            let verify_len = i32::try_from(verify_tokens.len())
-                .map_err(|_| EngineError::Generation("verify_len overflow".to_owned()))?;
-            let verify_input = Array::from_slice(&verify_tokens, &[1, verify_len]);
-
-            // f. Tape-recording verify: forward with taps + GDN innovation tapes.
-            //    The tape kernel's recurrence is bit-exact with sequential AR
-            //    steps, fixing the S>1 vs S=1 numerical drift that a full-rerun
-            //    verify exhibits, and lets partial accept replay only the SSM
-            //    recurrence for accepted positions instead of a full rerun.
-            let (verify_logits, verify_taps, layer_tapes) = model
-                .forward_with_taps_tape(&verify_input, None, &mut cache, &dflash.tap_layers)
-                .map_err(EngineError::Mlx)?;
-
-            // g. Accept prefix. One host barrier per round: eval'ing the argmax
-            //    pulls verify_logits + the whole verify forward through the
-            //    graph, so a separate eval([&verify_logits]) is redundant.
-            let verify_argmax =
-                mlx_rs::argmax_axis!(verify_logits, -1).map_err(EngineError::Mlx)?;
-            eval([&verify_argmax]).map_err(EngineError::Mlx)?;
-            let verify_flat: Vec<u32> = verify_argmax
-                .reshape(&[-1])
-                .map_err(EngineError::Mlx)?
-                .as_slice::<u32>()
-                .to_vec();
-            let accepted = accept_prefix(&draft_u32, &verify_flat);
-            let n_accepted = i32::try_from(accepted.len())
-                .map_err(|_| EngineError::Generation("n_accepted overflow".to_owned()))?;
-            rounds += 1;
-            total_accepted += accepted.len() as u64;
-
-            if std::env::var("HIGGS_DFLASH_TRACE").is_ok() && tokens.len() <= 32 {
-                tracing::info!(
-                    drafts = ?draft_u32,
-                    verify_argmax = ?verify_flat,
-                    n_accepted,
-                    accepted = ?accepted,
-                    "DFlash iter trace"
-                );
-            }
-
-            // h. Partial accept — GDN-only replay from tape. The verify
-            //    advanced state for ALL positions; on partial rejection we
-            //    restore each GDN layer's snapshot, replay the SSM kernel for
-            //    the n_accepted positions, and trim KV layers by the rejected
-            //    count. Issued lazily (no eval) so it folds into the next
-            //    verify's host barrier.
-            if n_accepted < block_size {
-                let kv_rollback = verify_len - n_accepted;
-                model
-                    .replay_tape_rollback(&layer_tapes, &mut cache, n_accepted, kv_rollback)
+            let round_t0 = std::time::Instant::now();
+            if gate && in_ar {
+                // AR floor: plain S=1 decode (byte-exact). Measures T_ar live and
+                // produces the taps the drafter needs if we re-enter spec.
+                let single = Array::from_slice(&[last_token], &[1, 1]);
+                let (ar_logits, ar_taps) = model
+                    .forward_with_taps(&single, None, &mut cache, &dflash.tap_layers)
                     .map_err(EngineError::Mlx)?;
-            }
-            // Slice verify taps to accepted positions (valid for both full and
-            // partial accept — earlier positions' hidden states are causally
-            // independent of later ones).
-            current_taps = verify_taps
-                .into_iter()
-                .map(|tap| tap.index((.., ..n_accepted, ..)))
-                .collect();
+                let ar_next =
+                    sample(&ar_logits.index((.., -1, ..)), params).map_err(EngineError::Mlx)?;
+                eval([&ar_next]).map_err(EngineError::Mlx)?;
+                let dt = round_t0.elapsed().as_secs_f64();
+                let was_none = t_ar_ema.is_none();
+                t_ar_ema = Some(t_ar_ema.map_or(dt, |e| 0.7f64.mul_add(e, 0.3 * dt)));
+                current_taps = ar_taps;
+                let ar_id: u32 = ar_next.item();
+                tokens.push(ar_id);
+                last_token = i32::try_from(ar_id)
+                    .map_err(|_| EngineError::Generation("ar token overflow".to_owned()))?;
+                start += 1;
+                ar_run += 1;
+                // Leave AR after the initial T_ar calibration, or after a probe
+                // cooldown to re-test whether spec has become worthwhile again.
+                if was_none || ar_run >= AR_PROBE_EVERY {
+                    in_ar = false;
+                    ar_run = 0;
+                }
+            } else {
+                // a. Build block: [anchor, mask, mask, ...]
+                let block_size_us = usize::try_from(block_size).map_err(|_| {
+                    EngineError::Generation("block_size overflow for usize".to_owned())
+                })?;
+                let mut block_tokens = vec![mask_id; block_size_us];
+                if let Some(slot) = block_tokens.get_mut(0) {
+                    *slot = last_token;
+                }
+                let block_ids = Array::from_slice(&block_tokens, &[1, block_size]);
 
-            // i. Update state.
-            for &tok in &accepted {
-                tokens.push(tok);
-            }
-            last_token = i32::try_from(*accepted.last().ok_or_else(|| {
-                EngineError::Generation("accept_prefix returned empty vec".to_owned())
-            })?)
-            .map_err(|_| EngineError::Generation("accepted token overflow i32".to_owned()))?;
-            start += n_accepted;
+                // b. Embed through target's embedding layer.
+                let noise_embedding = model
+                    .embed_token_ids(&block_ids)
+                    .map_err(EngineError::Mlx)?;
 
-            // Adapt the next round's block size by block UTILIZATION
-            // (n_accepted / block_size) — the entropy proxy. On low-entropy text
-            // acceptance scales with the block (util stays high → grow toward
-            // block_max for the biggest win); on high-entropy text acceptance
-            // plateaus (util drops → shrink so the verify isn't wasted, and the
-            // S>1 verify stays off near-ties). Gating on util, not raw accept,
-            // keeps big blocks where they pay off. (all block_size uses above.)
-            if adaptive {
-                let util = f64::from(n_accepted) / f64::from(block_size);
-                ema_util = 0.5f64.mul_add(ema_util, 0.5 * util);
-                block_size = if ema_util >= 0.75 {
-                    (block_size * 2).min(block_max) // sustained high → grow
-                } else if ema_util <= 0.5 {
-                    (block_size / 2).max(block_min) // sustained low → shrink
-                } else {
-                    block_size
-                };
-            }
+                // c. Drafter forward.
+                let draft_hidden = drafter
+                    .forward(&noise_embedding, &current_taps, &mut draft_cache)
+                    .map_err(EngineError::Mlx)?;
+                crop_drafter_cache(&mut draft_cache, start);
+
+                // d. Target lm_head on sliced hidden -> argmax draft tokens.
+                let draft_hidden_sliced = draft_hidden.index((.., 1.., ..));
+                let draft_logits = model
+                    .forward_all_logits_from_hidden(&draft_hidden_sliced)
+                    .map_err(EngineError::Mlx)?;
+                let draft_token_arr =
+                    mlx_rs::argmax_axis!(draft_logits, -1).map_err(EngineError::Mlx)?;
+                eval([&draft_token_arr]).map_err(EngineError::Mlx)?;
+                let draft_u32: Vec<u32> = draft_token_arr
+                    .reshape(&[-1])
+                    .map_err(EngineError::Mlx)?
+                    .as_slice::<u32>()
+                    .to_vec();
+                let draft_i32: Vec<i32> = draft_u32
+                    .iter()
+                    .map(|&x| {
+                        i32::try_from(x).map_err(|_| {
+                            EngineError::Generation("draft token overflow i32".to_owned())
+                        })
+                    })
+                    .collect::<Result<_, _>>()?;
+
+                // e. Build verify input: [anchor, draft_0..draft_{N-2}].
+                let mut verify_tokens = vec![last_token];
+                verify_tokens.extend_from_slice(&draft_i32);
+                let verify_len = i32::try_from(verify_tokens.len())
+                    .map_err(|_| EngineError::Generation("verify_len overflow".to_owned()))?;
+                let verify_input = Array::from_slice(&verify_tokens, &[1, verify_len]);
+
+                // f. Tape-recording verify: forward with taps + GDN innovation tapes.
+                //    The tape kernel's recurrence is bit-exact with sequential AR
+                //    steps, fixing the S>1 vs S=1 numerical drift that a full-rerun
+                //    verify exhibits, and lets partial accept replay only the SSM
+                //    recurrence for accepted positions instead of a full rerun.
+                let (verify_logits, verify_taps, layer_tapes) = model
+                    .forward_with_taps_tape(&verify_input, None, &mut cache, &dflash.tap_layers)
+                    .map_err(EngineError::Mlx)?;
+
+                // g. Accept prefix. One host barrier per round: eval'ing the argmax
+                //    pulls verify_logits + the whole verify forward through the
+                //    graph, so a separate eval([&verify_logits]) is redundant.
+                let verify_argmax =
+                    mlx_rs::argmax_axis!(verify_logits, -1).map_err(EngineError::Mlx)?;
+                eval([&verify_argmax]).map_err(EngineError::Mlx)?;
+                let verify_flat: Vec<u32> = verify_argmax
+                    .reshape(&[-1])
+                    .map_err(EngineError::Mlx)?
+                    .as_slice::<u32>()
+                    .to_vec();
+                let accepted = accept_prefix(&draft_u32, &verify_flat);
+                let n_accepted = i32::try_from(accepted.len())
+                    .map_err(|_| EngineError::Generation("n_accepted overflow".to_owned()))?;
+                rounds += 1;
+                total_accepted += accepted.len() as u64;
+
+                if std::env::var("HIGGS_DFLASH_TRACE").is_ok() && tokens.len() <= 32 {
+                    tracing::info!(
+                        drafts = ?draft_u32,
+                        verify_argmax = ?verify_flat,
+                        n_accepted,
+                        accepted = ?accepted,
+                        "DFlash iter trace"
+                    );
+                }
+
+                // h. Partial accept — GDN-only replay from tape. The verify
+                //    advanced state for ALL positions; on partial rejection we
+                //    restore each GDN layer's snapshot, replay the SSM kernel for
+                //    the n_accepted positions, and trim KV layers by the rejected
+                //    count. Issued lazily (no eval) so it folds into the next
+                //    verify's host barrier.
+                if n_accepted < block_size {
+                    let kv_rollback = verify_len - n_accepted;
+                    model
+                        .replay_tape_rollback(&layer_tapes, &mut cache, n_accepted, kv_rollback)
+                        .map_err(EngineError::Mlx)?;
+                }
+                // Slice verify taps to accepted positions (valid for both full and
+                // partial accept — earlier positions' hidden states are causally
+                // independent of later ones).
+                current_taps = verify_taps
+                    .into_iter()
+                    .map(|tap| tap.index((.., ..n_accepted, ..)))
+                    .collect();
+
+                // i. Update state.
+                for &tok in &accepted {
+                    tokens.push(tok);
+                }
+                last_token = i32::try_from(*accepted.last().ok_or_else(|| {
+                    EngineError::Generation("accept_prefix returned empty vec".to_owned())
+                })?)
+                .map_err(|_| EngineError::Generation("accepted token overflow i32".to_owned()))?;
+                start += n_accepted;
+
+                // Adapt the next round's block size by block UTILIZATION
+                // (n_accepted / block_size) — the entropy proxy. On low-entropy text
+                // acceptance scales with the block (util stays high → grow toward
+                // block_max for the biggest win); on high-entropy text acceptance
+                // plateaus (util drops → shrink so the verify isn't wasted, and the
+                // S>1 verify stays off near-ties). Gating on util, not raw accept,
+                // keeps big blocks where they pay off. (all block_size uses above.)
+                if adaptive {
+                    let util = f64::from(n_accepted) / f64::from(block_size);
+                    ema_util = 0.5f64.mul_add(ema_util, 0.5 * util);
+                    block_size = if ema_util >= 0.75 {
+                        (block_size * 2).min(block_max) // sustained high → grow
+                    } else if ema_util <= 0.5 {
+                        (block_size / 2).max(block_min) // sustained low → shrink
+                    } else {
+                        block_size
+                    };
+                }
+
+                // Realized-speedup gate: floor to AR next round if spec has become
+                // slower than plain AR (or to calibrate T_ar if we have no sample).
+                if gate {
+                    let step_wall = round_t0.elapsed().as_secs_f64().max(1e-9);
+                    if let Some(t_ar) = t_ar_ema {
+                        let ratio = f64::from(n_accepted) * t_ar / step_wall;
+                        ratio_ema = 0.6f64.mul_add(ratio_ema, 0.4 * ratio);
+                        if ratio_ema < 1.0 {
+                            in_ar = true;
+                            ar_run = 0;
+                        }
+                    } else {
+                        in_ar = true;
+                        ar_run = 0;
+                    }
+                }
+            } // end spec-round branch
 
             // j. Check termination.
             let completion_len = Self::completion_len(&tokens)?;
-            let accept_len = total_accepted as f64 / rounds as f64;
+            let accept_len = if rounds > 0 {
+                total_accepted as f64 / rounds as f64
+            } else {
+                0.0
+            };
 
             if tokens.iter().any(|t| self.eos_token_ids.contains(t)) {
                 let secs = t_start.elapsed().as_secs_f64();
@@ -3350,8 +3420,10 @@ mod tests {
         // GSM8K/HumanEval/MT-Bench, not raw factual completions). Keep
         // max_tokens under the 256-token thinking budget so the AR (MTP) path
         // never force-closes </think> while DFlash wouldn't.
-        let user_prompt =
-            "Write a Python function that returns the n-th Fibonacci number iteratively.";
+        let user_prompt = std::env::var("HIGGS_TEST_PROMPT").unwrap_or_else(|_| {
+            "Write a Python function that returns the n-th Fibonacci number iteratively.".to_owned()
+        });
+        let user_prompt = user_prompt.as_str();
         // Toggle with HIGGS_TEST_THINKING=0 to measure the thinking-disabled
         // workload (default: enabled, matching the reference benchmark).
         let enable_thinking = std::env::var("HIGGS_TEST_THINKING")

--- a/crates/higgs-models/src/dflash.rs
+++ b/crates/higgs-models/src/dflash.rs
@@ -514,21 +514,6 @@ impl GdnStateBackup {
     }
 }
 
-/// Rollback only KV cache layers by `rollback` positions. GDN layers are
-/// left untouched. Used with stateless GDN verify where GDN state was never
-/// corrupted by speculative tokens.
-pub fn rollback_kv_only(kv_cache: &mut [Option<crate::qwen3_next::LayerCache>], rollback: i32) {
-    if rollback <= 0 {
-        return;
-    }
-    for kv in kv_cache.iter_mut().filter_map(|lc| match lc {
-        Some(crate::qwen3_next::LayerCache::KV(kv)) => Some(kv),
-        _ => None,
-    }) {
-        kv.trim_by(rollback.unsigned_abs().try_into().unwrap_or(usize::MAX));
-    }
-}
-
 /// Crop the drafter KV cache to `keep_len` along the sequence dim.
 ///
 /// Called after verify to discard rejected positions.
@@ -538,22 +523,6 @@ pub fn crop_drafter_cache(cache: &mut [Option<(Array, Array)>], keep_len: i32) {
     for (k, v) in cache.iter_mut().filter_map(Option::as_mut) {
         *k = k.index((.., .., ..keep_len, ..));
         *v = v.index((.., .., ..keep_len, ..));
-    }
-}
-
-/// Trim `n` entries from the END of the drafter KV cache.
-///
-/// Reference: `trim_draft_cache(draft_cache, block_size)` in `dflash-mlx`.
-/// After each draft forward, the cache has `prev + ctx_len + block_size` entries.
-/// Trimming `block_size` removes the noise K/V while keeping the accumulated
-/// target context K/V that conditions future rounds.
-pub fn trim_drafter_cache(cache: &mut [Option<(Array, Array)>], n: i32) {
-    use mlx_rs::ops::indexing::IndexOp;
-    for (k, v) in cache.iter_mut().filter_map(Option::as_mut) {
-        let seq_len = k.shape().get(2).copied().unwrap_or(0);
-        let keep = (seq_len - n).max(0);
-        *k = k.index((.., .., ..keep, ..));
-        *v = v.index((.., .., ..keep, ..));
     }
 }
 

--- a/crates/higgs-models/src/dflash.rs
+++ b/crates/higgs-models/src/dflash.rs
@@ -1,14 +1,15 @@
 //! `DFlash` block-diffusion drafter for speculative decoding.
 //!
 //! A 0.5B drafter that produces 16 draft tokens per round via a single
-//! non-causal forward pass. Conditions on hidden states tapped from 5
-//! target model layers during the previous verify step.
+//! non-causal forward pass. The Modal drafter checkpoints verified by the
+//! loader tests use 8 target-layer taps: `[1, 6, 11, 16, 22, 27, 32, 37]`.
 //!
-//! Architecture: 8 decoder layers with dual-stream attention —
+//! Architecture: 6 decoder layers with dual-stream attention —
 //! Q from noise embedding, K/V from `concat(target_hidden, noise)`.
 //! No `embed_tokens` or `lm_head` — uses the target model's `lm_head`.
 //!
-//! Reference: `dflash.py` in `z-lab/Qwen3.5-35B-A3B-DFlash`.
+//! Reference checkpoints: `modal-labs/Qwen3.6-35B-A3B-DFlash` and
+//! `modal-labs/Qwen3.5-9B-DFlash`.
 use std::path::Path;
 
 use mlx_rs::{

--- a/crates/higgs-models/src/dflash.rs
+++ b/crates/higgs-models/src/dflash.rs
@@ -45,6 +45,10 @@ pub struct DFlashConfig {
     #[serde(default = "default_block_size")]
     pub block_size: i32,
     pub vocab_size: i32,
+    #[serde(default)]
+    pub layer_types: Option<Vec<String>>,
+    #[serde(default)]
+    pub sliding_window: Option<i32>,
     dflash_config: DFlashSubConfig,
 }
 
@@ -146,14 +150,22 @@ struct DFlashAttention {
     num_key_value_heads: i32,
     head_dim: i32,
     scale: f32,
+    is_sliding: bool,
+    sliding_window: i32,
 }
 
 impl DFlashAttention {
-    fn new(config: &DFlashConfig) -> Result<Self, Exception> {
+    fn new(config: &DFlashConfig, layer_idx: usize) -> Result<Self, Exception> {
         let head_dim = config.head_dim;
         let n_heads = config.num_attention_heads;
         let n_kv_heads = config.num_key_value_heads;
         let hidden = config.hidden_size;
+        let is_sliding = config
+            .layer_types
+            .as_ref()
+            .and_then(|lt| lt.get(layer_idx))
+            .is_some_and(|t| t == "sliding_attention");
+        let sliding_window = config.sliding_window.unwrap_or(0);
 
         Ok(Self {
             q_proj: nn::LinearBuilder::new(hidden, n_heads * head_dim)
@@ -189,6 +201,8 @@ impl DFlashAttention {
             )
             .sqrt()
             .recip(),
+            is_sliding,
+            sliding_window,
         })
     }
 
@@ -207,6 +221,8 @@ impl DFlashAttention {
         cache: &mut Option<(Array, Array)>,
         cache_offset: i32,
     ) -> Result<Array, Exception> {
+        use mlx_rs::ops::indexing::IndexOp;
+
         let B = *noise
             .shape()
             .first()
@@ -261,6 +277,21 @@ impl DFlashAttention {
         } else {
             (ctx_k, ctx_v)
         };
+        let (ctx_k, ctx_v) = if self.is_sliding && self.sliding_window > 1 {
+            let keep = self.sliding_window - 1;
+            let len = ctx_k.shape().get(2).copied().unwrap_or(0);
+            if len > keep {
+                let skip = len - keep;
+                (
+                    ctx_k.index((.., .., skip.., ..)),
+                    ctx_v.index((.., .., skip.., ..)),
+                )
+            } else {
+                (ctx_k, ctx_v)
+            }
+        } else {
+            (ctx_k, ctx_v)
+        };
         *cache = Some((ctx_k.clone(), ctx_v.clone()));
 
         // Attention over cached_context + fresh_noise
@@ -301,9 +332,9 @@ struct DFlashDecoderLayer {
 }
 
 impl DFlashDecoderLayer {
-    fn new(config: &DFlashConfig) -> Result<Self, Exception> {
+    fn new(config: &DFlashConfig, layer_idx: usize) -> Result<Self, Exception> {
         Ok(Self {
-            self_attn: DFlashAttention::new(config)?,
+            self_attn: DFlashAttention::new(config, layer_idx)?,
             mlp: DFlashMLP::new(config.hidden_size, config.intermediate_size)?,
             input_layernorm: nn::RmsNormBuilder::new(config.hidden_size)
                 .eps(config.rms_norm_eps)
@@ -359,7 +390,7 @@ impl DFlashDrafter {
             .map_err(|e| Exception::custom(format!("num_taps too large for i32: {e}")))?
             * config.hidden_size;
         let layers = (0..config.num_hidden_layers)
-            .map(|_| DFlashDecoderLayer::new(&config))
+            .map(|i| DFlashDecoderLayer::new(&config, usize::try_from(i).unwrap_or(0)))
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Self {
@@ -406,11 +437,12 @@ impl DFlashDrafter {
             )));
         }
 
-        // Cache offset = current cached seq length (0 on first round)
+        // Cache offset = max cached seq length (0 on first round)
         let cache_offset = cache
-            .first()
-            .and_then(|c| c.as_ref())
-            .and_then(|(k, _)| k.shape().get(2).copied())
+            .iter()
+            .filter_map(|c| c.as_ref())
+            .filter_map(|(k, _)| k.shape().get(2).copied())
+            .max()
             .unwrap_or(0);
 
         // Concatenate tap hidden states: [B, T, num_taps * hidden_size]
@@ -627,6 +659,68 @@ mod tests {
         let draft = vec![1, 2, 3];
         let verify = vec![1, 2]; // wrong length
         let _ = accept_prefix(&draft, &verify);
+    }
+
+    /// Sliding-window eviction: a tiny random drafter with layer 0 = sliding
+    /// (window 4) and layer 1 = full. Driving several rounds must cap the
+    /// sliding layer's context KV at `sliding_window - 1` while the full layer
+    /// accumulates all context — and the rope offset (max cache length across
+    /// layers) must keep advancing absolutely. No weights needed.
+    #[test]
+    fn sliding_layer_cache_caps_while_full_layer_grows() {
+        use super::{DFlashConfig, DFlashDrafter, DFlashSubConfig};
+        use mlx_rs::Array;
+
+        let hidden = 8i32;
+        let config = DFlashConfig {
+            hidden_size: hidden,
+            num_hidden_layers: 2,
+            num_attention_heads: 2,
+            num_key_value_heads: 1,
+            head_dim: 4,
+            intermediate_size: 16,
+            rms_norm_eps: 1e-6,
+            rope_theta: 1e7,
+            block_size: 4,
+            vocab_size: 32,
+            layer_types: Some(vec![
+                "sliding_attention".to_owned(),
+                "full_attention".to_owned(),
+            ]),
+            sliding_window: Some(4),
+            dflash_config: DFlashSubConfig {
+                target_layer_ids: vec![0],
+                mask_token_id: Some(1),
+            },
+        };
+        let mut drafter = DFlashDrafter::new(config).unwrap();
+        let mut cache = drafter.make_cache();
+
+        let ctx_len = 2i32; // context positions added per round
+        let rounds = 6;
+        let zeros = |t: i32| Array::from_slice(&vec![0f32; (t * hidden) as usize], &[1, t, hidden]);
+        for _ in 0..rounds {
+            let taps = vec![zeros(ctx_len)]; // num_taps = 1
+            let noise = zeros(4); // block_size noise positions
+            drafter.forward(&noise, &taps, &mut cache).unwrap();
+        }
+
+        let sliding_len = cache[0].as_ref().unwrap().0.shape()[2];
+        let full_len = cache[1].as_ref().unwrap().0.shape()[2];
+        assert!(
+            sliding_len <= 3,
+            "sliding cache must cap at window-1=3, got {sliding_len}"
+        );
+        assert_eq!(
+            full_len,
+            ctx_len * rounds,
+            "full-attn cache must accumulate all {} context positions, got {full_len}",
+            ctx_len * rounds
+        );
+        assert!(
+            full_len > sliding_len,
+            "eviction must make the sliding cache shorter than the full one"
+        );
     }
 
     /// The "drop-in drafter, no MLX port" claim: the config-driven loader must

--- a/crates/higgs-models/src/dflash.rs
+++ b/crates/higgs-models/src/dflash.rs
@@ -1,0 +1,663 @@
+//! `DFlash` block-diffusion drafter for speculative decoding.
+//!
+//! A 0.5B drafter that produces 16 draft tokens per round via a single
+//! non-causal forward pass. Conditions on hidden states tapped from 5
+//! target model layers during the previous verify step.
+//!
+//! Architecture: 8 decoder layers with dual-stream attention —
+//! Q from noise embedding, K/V from `concat(target_hidden, noise)`.
+//! No `embed_tokens` or `lm_head` — uses the target model's `lm_head`.
+//!
+//! Reference: `dflash.py` in `z-lab/Qwen3.5-35B-A3B-DFlash`.
+use std::path::Path;
+
+use mlx_rs::{
+    Array, builder::Builder, error::Exception, macros::ModuleParameters, module::Module, nn, ops,
+};
+use serde::Deserialize;
+
+use crate::{error::ModelError, utils::apply_rope};
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Deserialize)]
+struct DFlashSubConfig {
+    target_layer_ids: Vec<usize>,
+    #[serde(default)]
+    mask_token_id: Option<i32>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DFlashConfig {
+    pub hidden_size: i32,
+    pub num_hidden_layers: i32,
+    pub num_attention_heads: i32,
+    pub num_key_value_heads: i32,
+    #[serde(default = "default_head_dim")]
+    pub head_dim: i32,
+    pub intermediate_size: i32,
+    #[serde(default = "default_rms_norm_eps")]
+    pub rms_norm_eps: f32,
+    #[serde(default = "default_rope_theta")]
+    pub rope_theta: f32,
+    #[serde(default = "default_block_size")]
+    pub block_size: i32,
+    pub vocab_size: i32,
+    dflash_config: DFlashSubConfig,
+}
+
+impl DFlashConfig {
+    pub fn target_layer_ids(&self) -> &[usize] {
+        &self.dflash_config.target_layer_ids
+    }
+
+    pub const fn num_taps(&self) -> usize {
+        self.dflash_config.target_layer_ids.len()
+    }
+
+    pub fn mask_token_id(&self) -> i32 {
+        self.dflash_config.mask_token_id.unwrap_or(248_070)
+    }
+}
+
+const fn default_head_dim() -> i32 {
+    128
+}
+
+const fn default_rms_norm_eps() -> f32 {
+    1e-6
+}
+
+const fn default_rope_theta() -> f32 {
+    1e7
+}
+
+const fn default_block_size() -> i32 {
+    16
+}
+
+/// Runtime decode `block_size` used at inference.
+///
+/// Overridable via `HIGGS_DFLASH_BLOCK_SIZE`. Diverges from the drafter's
+/// trained `block_size` (16) because acceptance rate plateaus at ~3 tokens
+/// and smaller blocks amortize verify cost better.
+pub const DEFAULT_DECODE_BLOCK_SIZE: i32 = 4;
+
+// ---------------------------------------------------------------------------
+// SwiGLU MLP (non-quantized)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, ModuleParameters)]
+struct DFlashMLP {
+    #[param]
+    gate_proj: nn::Linear,
+    #[param]
+    up_proj: nn::Linear,
+    #[param]
+    down_proj: nn::Linear,
+}
+
+impl DFlashMLP {
+    fn new(hidden_size: i32, intermediate_size: i32) -> Result<Self, Exception> {
+        Ok(Self {
+            gate_proj: nn::LinearBuilder::new(hidden_size, intermediate_size)
+                .bias(false)
+                .build()?,
+            up_proj: nn::LinearBuilder::new(hidden_size, intermediate_size)
+                .bias(false)
+                .build()?,
+            down_proj: nn::LinearBuilder::new(intermediate_size, hidden_size)
+                .bias(false)
+                .build()?,
+        })
+    }
+
+    fn forward(&mut self, x: &Array) -> Result<Array, Exception> {
+        let gate = self.gate_proj.forward(x)?;
+        let up = self.up_proj.forward(x)?;
+        let activated = nn::sigmoid(&gate)?.multiply(&gate)?.multiply(&up)?;
+        self.down_proj.forward(&activated)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DFlash dual-stream attention
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, ModuleParameters)]
+struct DFlashAttention {
+    #[param]
+    q_proj: nn::Linear,
+    #[param]
+    k_proj: nn::Linear,
+    #[param]
+    v_proj: nn::Linear,
+    #[param]
+    o_proj: nn::Linear,
+    #[param]
+    q_norm: nn::RmsNorm,
+    #[param]
+    k_norm: nn::RmsNorm,
+    #[param]
+    rope: nn::Rope,
+    num_attention_heads: i32,
+    num_key_value_heads: i32,
+    head_dim: i32,
+    scale: f32,
+}
+
+impl DFlashAttention {
+    fn new(config: &DFlashConfig) -> Result<Self, Exception> {
+        let head_dim = config.head_dim;
+        let n_heads = config.num_attention_heads;
+        let n_kv_heads = config.num_key_value_heads;
+        let hidden = config.hidden_size;
+
+        Ok(Self {
+            q_proj: nn::LinearBuilder::new(hidden, n_heads * head_dim)
+                .bias(false)
+                .build()?,
+            k_proj: nn::LinearBuilder::new(hidden, n_kv_heads * head_dim)
+                .bias(false)
+                .build()?,
+            v_proj: nn::LinearBuilder::new(hidden, n_kv_heads * head_dim)
+                .bias(false)
+                .build()?,
+            o_proj: nn::LinearBuilder::new(n_heads * head_dim, hidden)
+                .bias(false)
+                .build()?,
+            q_norm: nn::RmsNormBuilder::new(head_dim)
+                .eps(config.rms_norm_eps)
+                .build()?,
+            k_norm: nn::RmsNormBuilder::new(head_dim)
+                .eps(config.rms_norm_eps)
+                .build()?,
+            rope: nn::RopeBuilder::new(head_dim)
+                .traditional(false)
+                .base(config.rope_theta)
+                .scale(1.0)
+                .build()
+                .map_err(|e| Exception::custom(format!("Failed to build RoPE: {e}")))?,
+            num_attention_heads: n_heads,
+            num_key_value_heads: n_kv_heads,
+            head_dim,
+            scale: f32::from(
+                i16::try_from(head_dim)
+                    .map_err(|_| Exception::custom("head_dim out of i16 range"))?,
+            )
+            .sqrt()
+            .recip(),
+        })
+    }
+
+    /// Dual-stream attention: Q from noise, K/V from `concat(target, noise)`.
+    ///
+    /// `noise`: `[B, block_size, hidden]` — the 16 draft positions.
+    /// `target_hidden`: `[B, ctx_len, hidden]` — projected+normed tap states.
+    /// `cache`: optional (K, V) from prior rounds, shape `[B, n_kv, cached_len, head_dim]`.
+    ///   Post-RoPE K and raw V. Updated in-place with the new K/V appended.
+    /// `cache_offset`: absolute position offset for `RoPE` (= cached seq length).
+    #[allow(non_snake_case, clippy::shadow_reuse)]
+    fn forward(
+        &mut self,
+        noise: &Array,
+        target_hidden: &Array,
+        cache: &mut Option<(Array, Array)>,
+        cache_offset: i32,
+    ) -> Result<Array, Exception> {
+        let B = *noise
+            .shape()
+            .first()
+            .ok_or_else(|| Exception::custom("need 3D"))?;
+        let q_len = *noise
+            .shape()
+            .get(1)
+            .ok_or_else(|| Exception::custom("need 3D"))?;
+        let ctx_len = *target_hidden
+            .shape()
+            .get(1)
+            .ok_or_else(|| Exception::custom("need 3D"))?;
+        // Q from noise only
+        let q = self.q_proj.forward(noise)?;
+        let q = q.reshape(&[B, q_len, self.num_attention_heads, self.head_dim])?;
+        let q = self.q_norm.forward(&q)?.transpose_axes(&[0, 2, 1, 3])?;
+
+        // K/V from context (target_hidden) — SEPARATE from noise
+        let ctx_k = self.k_proj.forward(target_hidden)?;
+        let ctx_v = self.v_proj.forward(target_hidden)?;
+        let ctx_k = ctx_k.reshape(&[B, ctx_len, self.num_key_value_heads, self.head_dim])?;
+        let ctx_k = self.k_norm.forward(&ctx_k)?.transpose_axes(&[0, 2, 1, 3])?;
+        let ctx_v = ctx_v
+            .reshape(&[B, ctx_len, self.num_key_value_heads, self.head_dim])?
+            .transpose_axes(&[0, 2, 1, 3])?;
+
+        // K/V from noise — freshly computed every round, never cached
+        let noise_k = self.k_proj.forward(noise)?;
+        let noise_v = self.v_proj.forward(noise)?;
+        let noise_k = noise_k.reshape(&[B, q_len, self.num_key_value_heads, self.head_dim])?;
+        let noise_k = self
+            .k_norm
+            .forward(&noise_k)?
+            .transpose_axes(&[0, 2, 1, 3])?;
+        let noise_v = noise_v
+            .reshape(&[B, q_len, self.num_key_value_heads, self.head_dim])?
+            .transpose_axes(&[0, 2, 1, 3])?;
+
+        // RoPE with absolute positions:
+        // Context K: [cache_offset .. cache_offset + ctx_len]
+        // Noise K + Q: [cache_offset + ctx_len .. cache_offset + ctx_len + q_len]
+        let q = apply_rope(&q, &self.rope, cache_offset + ctx_len)?;
+        let ctx_k = apply_rope(&ctx_k, &self.rope, cache_offset)?;
+        let noise_k = apply_rope(&noise_k, &self.rope, cache_offset + ctx_len)?;
+
+        // Cache stores ONLY context K/V (append to prior rounds)
+        let (ctx_k, ctx_v) = if let Some((k_cached, v_cached)) = cache.as_ref() {
+            (
+                ops::concatenate_axis(&[k_cached, &ctx_k], 2)?,
+                ops::concatenate_axis(&[v_cached, &ctx_v], 2)?,
+            )
+        } else {
+            (ctx_k, ctx_v)
+        };
+        *cache = Some((ctx_k.clone(), ctx_v.clone()));
+
+        // Attention over cached_context + fresh_noise
+        let k = ops::concatenate_axis(&[&ctx_k, &noise_k], 2)?;
+        let v = ops::concatenate_axis(&[&ctx_v, &noise_v], 2)?;
+
+        // Non-causal SDPA (no mask)
+        let output = mlx_rs::fast::scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            self.scale,
+            None::<mlx_rs::fast::ScaledDotProductAttentionMask>,
+            None::<&Array>,
+        )?;
+
+        // [B, n_heads, q_len, head_dim] -> [B, q_len, n_heads * head_dim]
+        let output = output.transpose_axes(&[0, 2, 1, 3])?;
+        let output = output.reshape(&[B, q_len, -1])?;
+        self.o_proj.forward(&output)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DFlash decoder layer
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, ModuleParameters)]
+struct DFlashDecoderLayer {
+    #[param]
+    self_attn: DFlashAttention,
+    #[param]
+    mlp: DFlashMLP,
+    #[param]
+    input_layernorm: nn::RmsNorm,
+    #[param]
+    post_attention_layernorm: nn::RmsNorm,
+}
+
+impl DFlashDecoderLayer {
+    fn new(config: &DFlashConfig) -> Result<Self, Exception> {
+        Ok(Self {
+            self_attn: DFlashAttention::new(config)?,
+            mlp: DFlashMLP::new(config.hidden_size, config.intermediate_size)?,
+            input_layernorm: nn::RmsNormBuilder::new(config.hidden_size)
+                .eps(config.rms_norm_eps)
+                .build()?,
+            post_attention_layernorm: nn::RmsNormBuilder::new(config.hidden_size)
+                .eps(config.rms_norm_eps)
+                .build()?,
+        })
+    }
+
+    fn forward(
+        &mut self,
+        noise: &Array,
+        target_hidden: &Array,
+        cache: &mut Option<(Array, Array)>,
+        cache_offset: i32,
+    ) -> Result<Array, Exception> {
+        let normed = self.input_layernorm.forward(noise)?;
+        let attn_out = self
+            .self_attn
+            .forward(&normed, target_hidden, cache, cache_offset)?;
+        let h = noise.add(attn_out)?;
+        let normed_post = self.post_attention_layernorm.forward(&h)?;
+        let mlp_out = self.mlp.forward(&normed_post)?;
+        h.add(mlp_out)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DFlash drafter (top-level)
+// ---------------------------------------------------------------------------
+
+/// `DFlash` block-diffusion drafter.
+///
+/// Produces `block_size` (16) draft tokens per round. Does NOT have its own
+/// `embed_tokens` or `lm_head` — uses the target model's `lm_head` on the output.
+#[derive(Debug, ModuleParameters)]
+pub struct DFlashDrafter {
+    #[param]
+    fc: nn::Linear,
+    #[param]
+    hidden_norm: nn::RmsNorm,
+    #[param]
+    layers: Vec<DFlashDecoderLayer>,
+    #[param]
+    norm: nn::RmsNorm,
+    pub config: DFlashConfig,
+}
+
+impl DFlashDrafter {
+    pub fn new(config: DFlashConfig) -> Result<Self, Exception> {
+        let fc_in = i32::try_from(config.num_taps())
+            .map_err(|e| Exception::custom(format!("num_taps too large for i32: {e}")))?
+            * config.hidden_size;
+        let layers = (0..config.num_hidden_layers)
+            .map(|_| DFlashDecoderLayer::new(&config))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Self {
+            fc: nn::LinearBuilder::new(fc_in, config.hidden_size)
+                .bias(false)
+                .build()?,
+            hidden_norm: nn::RmsNormBuilder::new(config.hidden_size)
+                .eps(config.rms_norm_eps)
+                .build()?,
+            layers,
+            norm: nn::RmsNormBuilder::new(config.hidden_size)
+                .eps(config.rms_norm_eps)
+                .build()?,
+            config,
+        })
+    }
+
+    /// Create an empty per-layer KV cache for the drafter.
+    pub fn make_cache(&self) -> Vec<Option<(Array, Array)>> {
+        vec![None; self.layers.len()]
+    }
+
+    /// Run the drafter forward pass.
+    ///
+    /// - `noise`: `[B, block_size, hidden_size]` — embedded block tokens.
+    /// - `taps`: slice of hidden states from the target model at tap layers,
+    ///   each `[B, T, target_hidden_size]`. Concatenated along the last dim,
+    ///   projected via `fc`, then normalized.
+    /// - `cache`: per-layer KV cache. Grows each round; crop after verify.
+    ///
+    /// Returns `[B, block_size, hidden_size]` — pass to target's `lm_head` for logits.
+    #[allow(non_snake_case)]
+    pub fn forward(
+        &mut self,
+        noise: &Array,
+        taps: &[Array],
+        cache: &mut [Option<(Array, Array)>],
+    ) -> Result<Array, Exception> {
+        if taps.len() != self.config.num_taps() {
+            return Err(Exception::custom(format!(
+                "expected {} taps, got {}",
+                self.config.num_taps(),
+                taps.len()
+            )));
+        }
+
+        // Cache offset = current cached seq length (0 on first round)
+        let cache_offset = cache
+            .first()
+            .and_then(|c| c.as_ref())
+            .and_then(|(k, _)| k.shape().get(2).copied())
+            .unwrap_or(0);
+
+        // Concatenate tap hidden states: [B, T, num_taps * hidden_size]
+        let tap_refs: Vec<&Array> = taps.iter().collect();
+        let target_cat = ops::concatenate_axis(&tap_refs, -1)?;
+
+        // Project + norm: [B, T, hidden_size]
+        let target_projected = self.fc.forward(&target_cat)?;
+        let target_hidden = self.hidden_norm.forward(&target_projected)?;
+
+        let mut h = noise.clone();
+        for (layer, lc) in self.layers.iter_mut().zip(cache.iter_mut()) {
+            h = layer.forward(&h, &target_hidden, lc, cache_offset)?;
+        }
+
+        self.norm.forward(&h)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GDN state save/restore for hybrid models (Qwen3.5)
+// ---------------------------------------------------------------------------
+
+/// Saved state for all GDN/linear-attention layers in the target model.
+///
+/// Much smaller than cloning the full KV cache — only stores `conv_state`,
+/// `ssm_state`, and offset for each `ArraysCache` layer.
+pub struct GdnStateBackup {
+    states: Vec<(Option<Array>, Option<Array>, i32)>,
+}
+
+impl GdnStateBackup {
+    /// Save GDN (`ArraysCache`) state from all layers. Call BEFORE verify forward.
+    /// KV layers are not saved — they use cheap offset-based rollback instead.
+    pub fn save(kv_cache: &[Option<crate::qwen3_next::LayerCache>]) -> Result<Self, Exception> {
+        let mut states = Vec::with_capacity(kv_cache.len());
+        for lc in kv_cache {
+            match lc {
+                Some(crate::qwen3_next::LayerCache::Arrays(ac)) => {
+                    ac.eval_arrays()?;
+                    states.push((ac.conv_state.clone(), ac.ssm_state.clone(), ac.offset));
+                }
+                _ => states.push((None, None, 0)),
+            }
+        }
+        Ok(Self { states })
+    }
+
+    /// Restore GDN state and rollback KV offsets. On rejection, call this
+    /// BEFORE re-running the accepted tokens.
+    pub fn restore_and_rollback(
+        &self,
+        kv_cache: &mut [Option<crate::qwen3_next::LayerCache>],
+        rollback: i32,
+    ) {
+        for (lc, (conv, ssm, offset)) in kv_cache.iter_mut().zip(self.states.iter()) {
+            match lc {
+                Some(crate::qwen3_next::LayerCache::Arrays(ac)) => {
+                    ac.conv_state.clone_from(conv);
+                    ac.ssm_state.clone_from(ssm);
+                    ac.offset = *offset;
+                }
+                Some(crate::qwen3_next::LayerCache::KV(kv)) if rollback > 0 => {
+                    kv.trim_by(rollback.unsigned_abs().try_into().unwrap_or(usize::MAX));
+                }
+                Some(crate::qwen3_next::LayerCache::KV(_)) | None => {}
+            }
+        }
+    }
+}
+
+/// Rollback only KV cache layers by `rollback` positions. GDN layers are
+/// left untouched. Used with stateless GDN verify where GDN state was never
+/// corrupted by speculative tokens.
+pub fn rollback_kv_only(kv_cache: &mut [Option<crate::qwen3_next::LayerCache>], rollback: i32) {
+    if rollback <= 0 {
+        return;
+    }
+    for kv in kv_cache.iter_mut().filter_map(|lc| match lc {
+        Some(crate::qwen3_next::LayerCache::KV(kv)) => Some(kv),
+        _ => None,
+    }) {
+        kv.trim_by(rollback.unsigned_abs().try_into().unwrap_or(usize::MAX));
+    }
+}
+
+/// Crop the drafter KV cache to `keep_len` along the sequence dim.
+///
+/// Called after verify to discard rejected positions.
+/// Cache tensors have shape `[B, n_kv_heads, seq_len, head_dim]`.
+pub fn crop_drafter_cache(cache: &mut [Option<(Array, Array)>], keep_len: i32) {
+    use mlx_rs::ops::indexing::IndexOp;
+    for (k, v) in cache.iter_mut().filter_map(Option::as_mut) {
+        *k = k.index((.., .., ..keep_len, ..));
+        *v = v.index((.., .., ..keep_len, ..));
+    }
+}
+
+/// Trim `n` entries from the END of the drafter KV cache.
+///
+/// Reference: `trim_draft_cache(draft_cache, block_size)` in `dflash-mlx`.
+/// After each draft forward, the cache has `prev + ctx_len + block_size` entries.
+/// Trimming `block_size` removes the noise K/V while keeping the accumulated
+/// target context K/V that conditions future rounds.
+pub fn trim_drafter_cache(cache: &mut [Option<(Array, Array)>], n: i32) {
+    use mlx_rs::ops::indexing::IndexOp;
+    for (k, v) in cache.iter_mut().filter_map(Option::as_mut) {
+        let seq_len = k.shape().get(2).copied().unwrap_or(0);
+        let keep = (seq_len - n).max(0);
+        *k = k.index((.., .., ..keep, ..));
+        *v = v.index((.., .., ..keep, ..));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Loading
+// ---------------------------------------------------------------------------
+
+/// Load a `DFlash` drafter from a directory containing `config.json` + `model.safetensors`.
+pub fn load_dflash_drafter(model_path: &Path) -> Result<DFlashDrafter, ModelError> {
+    let config_path = model_path.join("config.json");
+    let config_str = std::fs::read_to_string(&config_path)
+        .map_err(|e| ModelError::Io(std::io::Error::other(format!("reading config.json: {e}"))))?;
+    let config: DFlashConfig = serde_json::from_str(&config_str)
+        .map_err(|e| ModelError::Io(std::io::Error::other(format!("parsing config.json: {e}"))))?;
+
+    let mut drafter = DFlashDrafter::new(config)
+        .map_err(|e| ModelError::Io(std::io::Error::other(e.to_string())))?;
+
+    crate::load_safetensors_weights(&mut drafter, model_path)?;
+
+    Ok(drafter)
+}
+
+// ---------------------------------------------------------------------------
+// Speculative-decode acceptance helper
+// ---------------------------------------------------------------------------
+
+/// Greedy speculative-decode acceptance.
+///
+/// Compares each drafted token to the target's verified argmax. Accepts the
+/// longest matching prefix and appends one bonus token (the target's argmax at
+/// the position immediately after the rejected draft, or after the last accept
+/// if all tokens accepted).
+///
+/// Returns at least 1 token, at most `draft.len() + 1`.
+///
+/// # Panics in debug
+/// Panics if `verify_argmax.len() != draft.len() + 1`.
+pub fn accept_prefix(draft: &[u32], verify_argmax: &[u32]) -> Vec<u32> {
+    debug_assert_eq!(verify_argmax.len(), draft.len() + 1);
+
+    let accepted = draft
+        .iter()
+        .zip(verify_argmax.iter())
+        .take_while(|(d, v)| **d == **v)
+        .count();
+    let mut out: Vec<u32> = draft.get(..accepted).unwrap_or_default().to_vec();
+    if let Some(&bonus) = verify_argmax.get(accepted) {
+        out.push(bonus);
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+//
+// The full DFlash test suite (~3.8K lines, 30+ end-to-end tests covering the
+// draft-verify loop against a real target model) lives on `feat/magic-canvas`
+// and will be ported in a follow-up PR alongside the engine glue
+// (`SimpleEngine::generate_dflash_inner`).
+//
+// What's tested here: only the pure helpers (`accept_prefix`) — the
+// rest depends on MLX-loaded model weights which aren't part of unit-test
+// surface.
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::accept_prefix;
+
+    #[test]
+    fn accept_prefix_full_match_returns_draft_plus_bonus() {
+        let draft = vec![1, 2, 3];
+        let verify = vec![1, 2, 3, 4];
+        assert_eq!(accept_prefix(&draft, &verify), vec![1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn accept_prefix_first_token_rejects_returns_correction() {
+        let draft = vec![1, 2, 3];
+        let verify = vec![9, 5, 5, 5];
+        assert_eq!(accept_prefix(&draft, &verify), vec![9]);
+    }
+
+    #[test]
+    fn accept_prefix_partial_match_returns_prefix_plus_correction() {
+        let draft = vec![1, 2, 3];
+        let verify = vec![1, 2, 9, 0];
+        assert_eq!(accept_prefix(&draft, &verify), vec![1, 2, 9]);
+    }
+
+    #[test]
+    fn accept_prefix_empty_draft_returns_single_verify_token() {
+        let draft: Vec<u32> = vec![];
+        let verify = vec![42];
+        assert_eq!(accept_prefix(&draft, &verify), vec![42]);
+    }
+
+    #[test]
+    #[should_panic(expected = "left == right")]
+    fn accept_prefix_mismatched_lengths_panic_in_debug() {
+        let draft = vec![1, 2, 3];
+        let verify = vec![1, 2]; // wrong length
+        let _ = accept_prefix(&draft, &verify);
+    }
+
+    /// The "drop-in drafter, no MLX port" claim: the config-driven loader must
+    /// parse Modal's config.json and populate every module from Modal's bf16
+    /// safetensors by key name. Gated on the real weights dir.
+    #[test]
+    #[ignore = "load: set HIGGS_DFLASH_DRAFTER_DIR to the Modal drafter snapshot dir"]
+    #[allow(clippy::print_stderr)]
+    fn loads_modal_drafter_against_real_weights() {
+        let Ok(dir) = std::env::var("HIGGS_DFLASH_DRAFTER_DIR") else {
+            eprintln!("skip: set HIGGS_DFLASH_DRAFTER_DIR");
+            return;
+        };
+        let d = super::load_dflash_drafter(std::path::Path::new(&dir))
+            .expect("load Modal DFlash drafter");
+        let c = &d.config;
+        assert_eq!(c.num_hidden_layers, 6, "layers");
+        assert_eq!(c.hidden_size, 2048, "hidden");
+        assert_eq!(c.num_taps(), 8, "taps");
+        assert_eq!(
+            c.target_layer_ids(),
+            &[1, 6, 11, 16, 22, 27, 32, 37],
+            "tap ids"
+        );
+        assert_eq!(c.mask_token_id(), 248_077, "mask token");
+        eprintln!(
+            "Modal drafter loaded OK: {} layers, hidden {}, {} taps, fc_in {}",
+            c.num_hidden_layers,
+            c.hidden_size,
+            c.num_taps(),
+            c.num_taps() as i32 * c.hidden_size
+        );
+    }
+}

--- a/crates/higgs-models/src/lib.rs
+++ b/crates/higgs-models/src/lib.rs
@@ -859,7 +859,7 @@ impl AnyModel {
         }
     }
 
-    /// DFlash: forward returning logits + hidden states at `tap_layers` (drafter input).
+    /// `DFlash`: forward returning logits + hidden states at `tap_layers` (drafter input).
     pub fn forward_with_taps(
         &mut self,
         inputs: &Array,
@@ -877,7 +877,7 @@ impl AnyModel {
         }
     }
 
-    /// DFlash verify: forward returning logits + tap hiddens + per-layer GDN tape (for cheap rollback).
+    /// `DFlash` verify: forward returning logits + tap hiddens + per-layer GDN tape (for cheap rollback).
     pub fn forward_with_taps_tape(
         &mut self,
         inputs: &Array,
@@ -895,21 +895,62 @@ impl AnyModel {
         }
     }
 
+    /// Replay GDN innovation tape for accepted prefix on partial accept.
+    ///
+    /// Used by `DFlash` verify path: after partial acceptance, restore each
+    /// GDN layer's state from the tape's initial snapshot, replay only the
+    /// SSM recurrence kernel for `n_accepted` accepted positions, and roll
+    /// KV layers back by `kv_rollback`. Avoids the cost of a full rerun.
+    pub fn replay_tape_rollback(
+        &self,
+        layer_tapes: &[Option<qwen3_next::GdnLayerTape>],
+        cache: &mut AnyCache,
+        n_accepted: i32,
+        kv_rollback: i32,
+    ) -> Result<(), Exception> {
+        match (self, cache) {
+            (Self::Qwen3Next(m), AnyCache::Hybrid(c)) => {
+                m.replay_tape_rollback(layer_tapes, c, n_accepted, kv_rollback)
+            }
+            _ => Err(Exception::custom(
+                "replay_tape_rollback requires Qwen3Next + Hybrid cache",
+            )),
+        }
+    }
+
     /// Embed raw token IDs through the target model's embedding layer.
     pub fn embed_token_ids(&self, token_ids: &Array) -> Result<Array, Exception> {
         match self {
             Self::Qwen3Next(m) => m.embed_token_ids(token_ids),
-            _ => Err(Exception::custom(
+            Self::Transformer(_)
+            | Self::Qwen3Moe(_)
+            | Self::Gemma2(_)
+            | Self::Gemma3(_)
+            | Self::Gemma4(_)
+            | Self::Phi3(_)
+            | Self::Starcoder2(_)
+            | Self::LlavaQwen2(_)
+            | Self::DeepSeekV2(_)
+            | Self::BonsaiQ1(_) => Err(Exception::custom(
                 "embed_token_ids only implemented for Qwen3Next",
             )),
         }
     }
 
-    /// Apply only the lm_head to pre-computed hidden states.
+    /// Apply only the `lm_head` to pre-computed hidden states.
     pub fn forward_all_logits_from_hidden(&self, hidden: &Array) -> Result<Array, Exception> {
         match self {
             Self::Qwen3Next(m) => m.forward_all_logits_from_hidden(hidden),
-            _ => Err(Exception::custom(
+            Self::Transformer(_)
+            | Self::Qwen3Moe(_)
+            | Self::Gemma2(_)
+            | Self::Gemma3(_)
+            | Self::Gemma4(_)
+            | Self::Phi3(_)
+            | Self::Starcoder2(_)
+            | Self::LlavaQwen2(_)
+            | Self::DeepSeekV2(_)
+            | Self::BonsaiQ1(_) => Err(Exception::custom(
                 "forward_all_logits_from_hidden only implemented for Qwen3Next",
             )),
         }

--- a/crates/higgs-models/src/lib.rs
+++ b/crates/higgs-models/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod bonsai_q1;
 pub mod cache;
 pub mod deepseek_v2;
+pub mod dflash;
 pub mod error;
 pub mod gemma2;
 pub mod gemma3;

--- a/crates/higgs-models/src/lib.rs
+++ b/crates/higgs-models/src/lib.rs
@@ -151,6 +151,22 @@ impl AnyCache {
             ),
         }
     }
+
+    /// Borrow the inner hybrid (KV+SSM) cache slice; errors on a KV-only cache.
+    pub fn as_hybrid(&self) -> Result<&[Option<LayerCache>], Exception> {
+        match self {
+            Self::Hybrid(c) => Ok(c),
+            Self::KV(_) => Err(Exception::custom("expected Hybrid cache, got KV")),
+        }
+    }
+
+    /// Mutably borrow the inner hybrid cache vec; errors on a KV-only cache.
+    pub fn as_hybrid_mut(&mut self) -> Result<&mut Vec<Option<LayerCache>>, Exception> {
+        match self {
+            Self::Hybrid(c) => Ok(c),
+            Self::KV(_) => Err(Exception::custom("expected Hybrid cache, got KV")),
+        }
+    }
 }
 
 /// Independent deep copy of an MTP head cache (`Vec<SteppingKeyValueCache>`).
@@ -258,6 +274,9 @@ fn make_turboquant_kv_cache(
     }
     Ok(AnyCache::KV(caches))
 }
+
+/// Output of [`AnyModel::forward_with_taps_tape`]: logits, tap hiddens, per-layer GDN tape.
+pub type TapsTapeOutput = (Array, Vec<Array>, Vec<Option<qwen3_next::GdnLayerTape>>);
 
 impl AnyModel {
     pub fn forward(
@@ -836,6 +855,62 @@ impl AnyModel {
             }
             _ => Err(Exception::custom(
                 "Model does not support multimodal forward",
+            )),
+        }
+    }
+
+    /// DFlash: forward returning logits + hidden states at `tap_layers` (drafter input).
+    pub fn forward_with_taps(
+        &mut self,
+        inputs: &Array,
+        mask: Option<&Array>,
+        cache: &mut AnyCache,
+        tap_layers: &[usize],
+    ) -> Result<(Array, Vec<Array>), Exception> {
+        match (self, cache) {
+            (Self::Qwen3Next(m), AnyCache::Hybrid(c)) => {
+                m.forward_with_taps(inputs, mask, c, tap_layers)
+            }
+            _ => Err(Exception::custom(
+                "forward_with_taps requires Qwen3Next + Hybrid cache",
+            )),
+        }
+    }
+
+    /// DFlash verify: forward returning logits + tap hiddens + per-layer GDN tape (for cheap rollback).
+    pub fn forward_with_taps_tape(
+        &mut self,
+        inputs: &Array,
+        mask: Option<&Array>,
+        cache: &mut AnyCache,
+        tap_layers: &[usize],
+    ) -> Result<TapsTapeOutput, Exception> {
+        match (self, cache) {
+            (Self::Qwen3Next(m), AnyCache::Hybrid(c)) => {
+                m.forward_with_taps_tape(inputs, mask, c, tap_layers)
+            }
+            _ => Err(Exception::custom(
+                "forward_with_taps_tape requires Qwen3Next + Hybrid cache",
+            )),
+        }
+    }
+
+    /// Embed raw token IDs through the target model's embedding layer.
+    pub fn embed_token_ids(&self, token_ids: &Array) -> Result<Array, Exception> {
+        match self {
+            Self::Qwen3Next(m) => m.embed_token_ids(token_ids),
+            _ => Err(Exception::custom(
+                "embed_token_ids only implemented for Qwen3Next",
+            )),
+        }
+    }
+
+    /// Apply only the lm_head to pre-computed hidden states.
+    pub fn forward_all_logits_from_hidden(&self, hidden: &Array) -> Result<Array, Exception> {
+        match self {
+            Self::Qwen3Next(m) => m.forward_all_logits_from_hidden(hidden),
+            _ => Err(Exception::custom(
+                "forward_all_logits_from_hidden only implemented for Qwen3Next",
             )),
         }
     }

--- a/crates/higgs-models/src/qwen3_next.rs
+++ b/crates/higgs-models/src/qwen3_next.rs
@@ -5277,31 +5277,6 @@ impl Qwen3NextCausalLM {
         };
         Ok((h_raw, logits))
     }
-}
-
-const PREFILL_LAYER_EVAL_INTERVAL: usize = 8;
-const PREFILL_LAYER_EVAL_MIN_SEQ_LEN: i32 = 17;
-
-const fn should_eval_between_prefill_layers(seq_len: i32, layer_idx: usize) -> bool {
-    seq_len >= PREFILL_LAYER_EVAL_MIN_SEQ_LEN
-        && (layer_idx + 1).is_multiple_of(PREFILL_LAYER_EVAL_INTERVAL)
-}
-
-#[cfg(test)]
-mod prefill_eval_tests {
-    use super::should_eval_between_prefill_layers;
-
-    #[test]
-    fn skips_layer_eval_barriers_for_short_speculative_windows() {
-        assert!(!should_eval_between_prefill_layers(3, 7));
-        assert!(!should_eval_between_prefill_layers(8, 7));
-    }
-
-    #[test]
-    fn keeps_layer_eval_barriers_for_long_prefill_chunks() {
-        assert!(should_eval_between_prefill_layers(128, 7));
-        assert!(!should_eval_between_prefill_layers(128, 6));
-    }
 
     pub fn forward_with_taps(
         &mut self,
@@ -5884,6 +5859,31 @@ mod prefill_eval_tests {
             || self.model.embed_tokens.as_linear(hidden),
             |head| head.forward(hidden),
         )
+    }
+}
+
+const PREFILL_LAYER_EVAL_INTERVAL: usize = 8;
+const PREFILL_LAYER_EVAL_MIN_SEQ_LEN: i32 = 17;
+
+const fn should_eval_between_prefill_layers(seq_len: i32, layer_idx: usize) -> bool {
+    seq_len >= PREFILL_LAYER_EVAL_MIN_SEQ_LEN
+        && (layer_idx + 1).is_multiple_of(PREFILL_LAYER_EVAL_INTERVAL)
+}
+
+#[cfg(test)]
+mod prefill_eval_tests {
+    use super::should_eval_between_prefill_layers;
+
+    #[test]
+    fn skips_layer_eval_barriers_for_short_speculative_windows() {
+        assert!(!should_eval_between_prefill_layers(3, 7));
+        assert!(!should_eval_between_prefill_layers(8, 7));
+    }
+
+    #[test]
+    fn keeps_layer_eval_barriers_for_long_prefill_chunks() {
+        assert!(should_eval_between_prefill_layers(128, 7));
+        assert!(!should_eval_between_prefill_layers(128, 6));
     }
 }
 

--- a/crates/higgs-models/src/qwen3_next.rs
+++ b/crates/higgs-models/src/qwen3_next.rs
@@ -84,6 +84,8 @@ impl Drop for CachedMetalKernel {
 
 /// Cached `GatedDeltaNet` Metal kernel -- created once, reused for all layers.
 static GATED_DELTA_KERNEL: OnceLock<CachedMetalKernel> = OnceLock::new();
+static GATED_DELTA_TAPE_KERNEL: OnceLock<CachedMetalKernel> = OnceLock::new();
+static TAPE_REPLAY_KERNEL: OnceLock<CachedMetalKernel> = OnceLock::new();
 
 use crate::{
     cache::{KeyValueCache, SteppingKeyValueCache},
@@ -985,6 +987,539 @@ fn gated_delta_kernel_ffi(
 /// vectorized weight loads for peak bandwidth, vs MLX's `uint16` (2-byte) loads.
 ///
 /// Single packed buffer `wb` = [`weight_u32` | `scales_f32_as_u32` | `biases_f32_as_u32`].
+/// receive `state_in.clone()` so they can verify without mutating the cache.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn gated_delta_kernel_ffi_stateless(
+    q: &Array,
+    k: &Array,
+    v: &Array,
+    a_log: &Array,
+    a: &Array,
+    dt_bias: &Array,
+    b: &Array,
+    state_in: &Array,
+    batch: i32,
+    seq_len: i32,
+    num_k_heads: i32,
+    head_k_dim: i32,
+    num_v_heads: i32,
+    head_v_dim: i32,
+) -> Result<(Array, Array), Exception> {
+    let (y, _new_state) = gated_delta_kernel_ffi(
+        q,
+        k,
+        v,
+        a_log,
+        a,
+        dt_bias,
+        b,
+        state_in,
+        batch,
+        seq_len,
+        num_k_heads,
+        head_k_dim,
+        num_v_heads,
+        head_v_dim,
+    )?;
+    Ok((y, state_in.clone()))
+}
+
+// ---------------------------------------------------------------------------
+// Tape-recording GDN kernel: same recurrence, also outputs innovation delta
+// ---------------------------------------------------------------------------
+
+/// Tape-recording variant of the GDN kernel. Identical computation but also
+/// outputs `innovation_tape[B, T, Hv, Dv]` -- the delta residual at each step.
+/// Used for `DFlash` verify: on partial rejection, we replay only accepted steps
+/// from the tape instead of re-running the full forward.
+const GATED_DELTA_TAPE_KERNEL_SOURCE: &str = r"
+auto n = thread_position_in_grid.z;
+auto b_idx = n / Hv;
+auto hv_idx = n % Hv;
+auto hk_idx = hv_idx / (Hv / Hk);
+constexpr int n_per_t = Dk / 32;
+
+auto q_ = q + b_idx * T * Hk * Dk + hk_idx * Dk;
+auto k_ = k + b_idx * T * Hk * Dk + hk_idx * Dk;
+
+auto v_ = v + b_idx * T * Hv * Dv + hv_idx * Dv;
+y += b_idx * T * Hv * Dv + hv_idx * Dv;
+auto tape_ = innovation_tape + b_idx * T * Hv * Dv + hv_idx * Dv;
+
+auto dk_idx = thread_position_in_threadgroup.x;
+auto dv_idx = thread_position_in_grid.y;
+
+auto i_state = state_in + (n * Dv + dv_idx) * Dk;
+auto o_state = state_out + (n * Dv + dv_idx) * Dk;
+
+float state[n_per_t];
+for (int i = 0; i < n_per_t; ++i) {
+  auto s_idx = n_per_t * dk_idx + i;
+  state[i] = static_cast<float>(i_state[s_idx]);
+}
+
+float a_log_val = static_cast<float>(a_log[hv_idx]);
+float dt_bias_val = static_cast<float>(dt_bias[hv_idx]);
+
+auto a_ = a + b_idx * T * Hv;
+auto b_ = b + b_idx * T * Hv;
+
+for (int t = 0; t < T; ++t) {
+  float x = static_cast<float>(a_[hv_idx]) + dt_bias_val;
+  float sp = fmax(x, 0.0f) + log1p(exp(-fabs(x)));
+  float g_val = exp(-exp(a_log_val) * sp);
+
+  float beta_val = 1.0f / (1.0f + exp(-static_cast<float>(b_[hv_idx])));
+
+  {
+    float kv_mem = 0.0f;
+    for (int i = 0; i < n_per_t; ++i) {
+      auto s_idx = n_per_t * dk_idx + i;
+      state[i] = state[i] * g_val;
+      kv_mem += state[i] * k_[s_idx];
+    }
+    kv_mem = simd_sum(kv_mem);
+
+    auto delta = (v_[dv_idx] - kv_mem) * beta_val;
+
+    float out = 0.0f;
+    for (int i = 0; i < n_per_t; ++i) {
+      auto s_idx = n_per_t * dk_idx + i;
+      state[i] = state[i] + k_[s_idx] * delta;
+      out += state[i] * q_[s_idx];
+    }
+    out = simd_sum(out);
+    if (thread_index_in_simdgroup == 0) {
+      y[dv_idx] = static_cast<InT>(out);
+      tape_[dv_idx] = delta;
+    }
+  }
+  // Match mlx-lm precision: cast state to InT between timesteps
+  for (int i = 0; i < n_per_t; ++i) {
+    state[i] = static_cast<float>(static_cast<InT>(state[i]));
+  }
+  q_ += Hk * Dk;
+  k_ += Hk * Dk;
+  v_ += Hv * Dv;
+  y += Hv * Dv;
+  tape_ += Hv * Dv;
+  a_ += Hv;
+  b_ += Hv;
+}
+for (int i = 0; i < n_per_t; ++i) {
+  auto s_idx = n_per_t * dk_idx + i;
+  o_state[s_idx] = static_cast<InT>(state[i]);
+}
+";
+
+#[allow(unsafe_code)]
+fn create_gated_delta_tape_kernel() -> mlx_sys::mlx_fast_metal_kernel {
+    let input_names: [&std::ffi::CStr; 9] = [
+        c"q",
+        c"k",
+        c"v",
+        c"a_log",
+        c"a",
+        c"dt_bias",
+        c"b",
+        c"state_in",
+        c"T",
+    ];
+    let output_names: [&std::ffi::CStr; 3] = [c"y", c"state_out", c"innovation_tape"];
+
+    let input_ptrs: Vec<*const c_char> = input_names.iter().map(|s| s.as_ptr()).collect();
+    let output_ptrs: Vec<*const c_char> = output_names.iter().map(|s| s.as_ptr()).collect();
+
+    let source =
+        CString::new(GATED_DELTA_TAPE_KERNEL_SOURCE).unwrap_or_else(|_| CString::default());
+
+    unsafe {
+        let in_vec =
+            mlx_sys::mlx_vector_string_new_data(input_ptrs.as_ptr().cast_mut(), input_ptrs.len());
+        let out_vec =
+            mlx_sys::mlx_vector_string_new_data(output_ptrs.as_ptr().cast_mut(), output_ptrs.len());
+        let kernel = mlx_sys::mlx_fast_metal_kernel_new(
+            c"gated_delta_tape".as_ptr(),
+            in_vec,
+            out_vec,
+            source.as_ptr(),
+            c"".as_ptr(),
+            true,
+            false,
+        );
+        mlx_sys::mlx_vector_string_free(in_vec);
+        mlx_sys::mlx_vector_string_free(out_vec);
+        kernel
+    }
+}
+
+#[allow(unsafe_code)]
+fn configure_gated_delta_tape_kernel(
+    in_dtype: mlx_sys::mlx_dtype,
+    batch: i32,
+    seq_len: i32,
+    num_k_heads: i32,
+    head_k_dim: i32,
+    num_v_heads: i32,
+    head_v_dim: i32,
+) -> mlx_sys::mlx_fast_metal_kernel_config {
+    unsafe {
+        let config = mlx_sys::mlx_fast_metal_kernel_config_new();
+
+        mlx_sys::mlx_fast_metal_kernel_config_add_template_arg_dtype(
+            config,
+            c"InT".as_ptr(),
+            in_dtype,
+        );
+        mlx_sys::mlx_fast_metal_kernel_config_add_template_arg_int(
+            config,
+            c"Dk".as_ptr(),
+            head_k_dim,
+        );
+        mlx_sys::mlx_fast_metal_kernel_config_add_template_arg_int(
+            config,
+            c"Dv".as_ptr(),
+            head_v_dim,
+        );
+        mlx_sys::mlx_fast_metal_kernel_config_add_template_arg_int(
+            config,
+            c"Hk".as_ptr(),
+            num_k_heads,
+        );
+        mlx_sys::mlx_fast_metal_kernel_config_add_template_arg_int(
+            config,
+            c"Hv".as_ptr(),
+            num_v_heads,
+        );
+
+        let y_shape = [batch, seq_len, num_v_heads, head_v_dim];
+        let state_shape = [batch, num_v_heads, head_v_dim, head_k_dim];
+        let tape_shape = [batch, seq_len, num_v_heads, head_v_dim];
+        mlx_sys::mlx_fast_metal_kernel_config_add_output_arg(
+            config,
+            y_shape.as_ptr(),
+            y_shape.len(),
+            in_dtype,
+        );
+        mlx_sys::mlx_fast_metal_kernel_config_add_output_arg(
+            config,
+            state_shape.as_ptr(),
+            state_shape.len(),
+            in_dtype,
+        );
+        // Tape stores deltas in float32 for precision (matches dflash-mlx)
+        mlx_sys::mlx_fast_metal_kernel_config_add_output_arg(
+            config,
+            tape_shape.as_ptr(),
+            tape_shape.len(),
+            mlx_sys::mlx_dtype__MLX_FLOAT32,
+        );
+
+        mlx_sys::mlx_fast_metal_kernel_config_set_grid(config, 32, head_v_dim, batch * num_v_heads);
+        mlx_sys::mlx_fast_metal_kernel_config_set_thread_group(config, 32, 4, 1);
+
+        config
+    }
+}
+
+/// Tape-recording GDN kernel: returns `(y, state_out, innovation_tape)`.
+#[allow(unsafe_code, clippy::too_many_arguments)]
+pub(crate) fn gated_delta_kernel_ffi_with_tape(
+    q: &Array,
+    k: &Array,
+    v: &Array,
+    a_log: &Array,
+    a: &Array,
+    dt_bias: &Array,
+    b: &Array,
+    state_in: &Array,
+    batch: i32,
+    seq_len: i32,
+    num_k_heads: i32,
+    head_k_dim: i32,
+    num_v_heads: i32,
+    head_v_dim: i32,
+) -> Result<(Array, Array, Array), Exception> {
+    ensure_ffi_error_handler();
+
+    let stream = Stream::task_local_or_default();
+    let in_dtype = unsafe { mlx_sys::mlx_array_dtype(q.as_ptr()) };
+
+    let cached =
+        GATED_DELTA_TAPE_KERNEL.get_or_init(|| CachedMetalKernel(create_gated_delta_tape_kernel()));
+    let config = configure_gated_delta_tape_kernel(
+        in_dtype,
+        batch,
+        seq_len,
+        num_k_heads,
+        head_k_dim,
+        num_v_heads,
+        head_v_dim,
+    );
+
+    let t_scalar = unsafe { mlx_sys::mlx_array_new_int(seq_len) };
+    let input_ptrs = [
+        q.as_ptr(),
+        k.as_ptr(),
+        v.as_ptr(),
+        a_log.as_ptr(),
+        a.as_ptr(),
+        dt_bias.as_ptr(),
+        b.as_ptr(),
+        state_in.as_ptr(),
+        t_scalar,
+    ];
+    let inputs_vec =
+        unsafe { mlx_sys::mlx_vector_array_new_data(input_ptrs.as_ptr(), input_ptrs.len()) };
+
+    let mut outputs_vec = unsafe { mlx_sys::mlx_vector_array_new() };
+    let status = unsafe {
+        mlx_sys::mlx_fast_metal_kernel_apply(
+            &raw mut outputs_vec,
+            cached.0,
+            inputs_vec,
+            config,
+            stream.as_ptr(),
+        )
+    };
+
+    let result = if status != 0 {
+        let mlx_msg = FFI_LAST_ERROR
+            .with(|cell| cell.borrow_mut().take())
+            .unwrap_or_default();
+        Err(Exception::custom(format!(
+            "gated_delta_tape_kernel failed: {mlx_msg}"
+        )))
+    } else {
+        let mut y_ptr = unsafe { mlx_sys::mlx_array_new() };
+        let mut state_ptr = unsafe { mlx_sys::mlx_array_new() };
+        let mut tape_ptr = unsafe { mlx_sys::mlx_array_new() };
+        unsafe {
+            mlx_sys::mlx_vector_array_get(&raw mut y_ptr, outputs_vec, 0);
+            mlx_sys::mlx_vector_array_get(&raw mut state_ptr, outputs_vec, 1);
+            mlx_sys::mlx_vector_array_get(&raw mut tape_ptr, outputs_vec, 2);
+        }
+        Ok((
+            unsafe { Array::from_ptr(y_ptr) },
+            unsafe { Array::from_ptr(state_ptr) },
+            unsafe { Array::from_ptr(tape_ptr) },
+        ))
+    };
+
+    unsafe {
+        mlx_sys::mlx_fast_metal_kernel_config_free(config);
+        mlx_sys::mlx_vector_array_free(inputs_vec);
+        mlx_sys::mlx_vector_array_free(outputs_vec);
+        mlx_sys::mlx_array_free(t_scalar);
+    }
+
+    result
+}
+
+// ---------------------------------------------------------------------------
+// Tape replay kernel: replays accepted steps to advance GDN state
+// ---------------------------------------------------------------------------
+
+/// Replays the GDN recurrence from a recorded innovation tape.
+/// Inputs: `tape[B,T,Hv,Dv]`, `k[B,T,Hk,Dk]`, `a[B,T,Hv]`, `a_log[Hv]`,
+/// `dt_bias[Hv]`, `state_in[B,Hv,Dv,Dk]`. Output: `state_out[B,Hv,Dv,Dk]`.
+const TAPE_REPLAY_KERNEL_SOURCE: &str = r"
+auto n = thread_position_in_grid.z;
+auto b_idx = n / Hv;
+auto hv_idx = n % Hv;
+auto hk_idx = hv_idx / (Hv / Hk);
+constexpr int n_per_t = Dk / 32;
+
+auto tape_ = tape + b_idx * T * Hv * Dv + hv_idx * Dv;
+auto k_ = k + b_idx * T * Hk * Dk + hk_idx * Dk;
+
+auto dk_idx = thread_position_in_threadgroup.x;
+auto dv_idx = thread_position_in_grid.y;
+
+auto i_state = state_in + (n * Dv + dv_idx) * Dk;
+auto o_state = state_out + (n * Dv + dv_idx) * Dk;
+
+float state[n_per_t];
+for (int i = 0; i < n_per_t; ++i) {
+  auto s_idx = n_per_t * dk_idx + i;
+  state[i] = static_cast<float>(i_state[s_idx]);
+}
+
+// a_log and dt_bias are [B * Hv] when batched across layers
+float a_log_val = static_cast<float>(a_log[b_idx * Hv + hv_idx]);
+float dt_bias_val = static_cast<float>(dt_bias[b_idx * Hv + hv_idx]);
+auto a_ = a + b_idx * T * Hv;
+
+for (int t = 0; t < T; ++t) {
+  float x = static_cast<float>(a_[hv_idx]) + dt_bias_val;
+  float sp = fmax(x, 0.0f) + log1p(exp(-fabs(x)));
+  float g_val = exp(-exp(a_log_val) * sp);
+
+  auto delta = tape_[dv_idx];
+  for (int i = 0; i < n_per_t; ++i) {
+    auto s_idx = n_per_t * dk_idx + i;
+    state[i] = state[i] * g_val + k_[s_idx] * delta;
+  }
+  // Match mlx-lm precision: cast state to InT between timesteps
+  for (int i = 0; i < n_per_t; ++i) {
+    state[i] = static_cast<float>(static_cast<InT>(state[i]));
+  }
+  tape_ += Hv * Dv;
+  k_ += Hk * Dk;
+  a_ += Hv;
+}
+for (int i = 0; i < n_per_t; ++i) {
+  auto s_idx = n_per_t * dk_idx + i;
+  o_state[s_idx] = static_cast<InT>(state[i]);
+}
+";
+
+#[allow(unsafe_code)]
+fn create_tape_replay_kernel() -> mlx_sys::mlx_fast_metal_kernel {
+    let input_names: [&std::ffi::CStr; 7] =
+        [c"tape", c"k", c"a", c"a_log", c"dt_bias", c"state_in", c"T"];
+    let output_names: [&std::ffi::CStr; 1] = [c"state_out"];
+
+    let input_ptrs: Vec<*const c_char> = input_names.iter().map(|s| s.as_ptr()).collect();
+    let output_ptrs: Vec<*const c_char> = output_names.iter().map(|s| s.as_ptr()).collect();
+
+    let source = CString::new(TAPE_REPLAY_KERNEL_SOURCE).unwrap_or_else(|_| CString::default());
+
+    unsafe {
+        let in_vec =
+            mlx_sys::mlx_vector_string_new_data(input_ptrs.as_ptr().cast_mut(), input_ptrs.len());
+        let out_vec =
+            mlx_sys::mlx_vector_string_new_data(output_ptrs.as_ptr().cast_mut(), output_ptrs.len());
+        let kernel = mlx_sys::mlx_fast_metal_kernel_new(
+            c"tape_replay".as_ptr(),
+            in_vec,
+            out_vec,
+            source.as_ptr(),
+            c"".as_ptr(),
+            true,
+            false,
+        );
+        mlx_sys::mlx_vector_string_free(in_vec);
+        mlx_sys::mlx_vector_string_free(out_vec);
+        kernel
+    }
+}
+
+/// Replay accepted steps from a recorded innovation tape.
+/// Returns the new SSM state after replaying `seq_len` steps.
+#[allow(unsafe_code, clippy::too_many_arguments)]
+pub(crate) fn tape_replay_kernel_ffi(
+    tape: &Array,
+    k: &Array,
+    a: &Array,
+    a_log: &Array,
+    dt_bias: &Array,
+    state_in: &Array,
+    batch: i32,
+    seq_len: i32,
+    num_k_heads: i32,
+    head_k_dim: i32,
+    num_v_heads: i32,
+    head_v_dim: i32,
+) -> Result<Array, Exception> {
+    ensure_ffi_error_handler();
+
+    let stream = Stream::task_local_or_default();
+    let in_dtype = unsafe { mlx_sys::mlx_array_dtype(state_in.as_ptr()) };
+
+    let cached = TAPE_REPLAY_KERNEL.get_or_init(|| CachedMetalKernel(create_tape_replay_kernel()));
+
+    let config = unsafe {
+        let config = mlx_sys::mlx_fast_metal_kernel_config_new();
+        mlx_sys::mlx_fast_metal_kernel_config_add_template_arg_dtype(
+            config,
+            c"InT".as_ptr(),
+            in_dtype,
+        );
+        mlx_sys::mlx_fast_metal_kernel_config_add_template_arg_int(
+            config,
+            c"Dk".as_ptr(),
+            head_k_dim,
+        );
+        mlx_sys::mlx_fast_metal_kernel_config_add_template_arg_int(
+            config,
+            c"Dv".as_ptr(),
+            head_v_dim,
+        );
+        mlx_sys::mlx_fast_metal_kernel_config_add_template_arg_int(
+            config,
+            c"Hk".as_ptr(),
+            num_k_heads,
+        );
+        mlx_sys::mlx_fast_metal_kernel_config_add_template_arg_int(
+            config,
+            c"Hv".as_ptr(),
+            num_v_heads,
+        );
+
+        let state_shape = [batch, num_v_heads, head_v_dim, head_k_dim];
+        mlx_sys::mlx_fast_metal_kernel_config_add_output_arg(
+            config,
+            state_shape.as_ptr(),
+            state_shape.len(),
+            in_dtype,
+        );
+
+        mlx_sys::mlx_fast_metal_kernel_config_set_grid(config, 32, head_v_dim, batch * num_v_heads);
+        mlx_sys::mlx_fast_metal_kernel_config_set_thread_group(config, 32, 4, 1);
+
+        config
+    };
+
+    let t_scalar = unsafe { mlx_sys::mlx_array_new_int(seq_len) };
+    let input_ptrs = [
+        tape.as_ptr(),
+        k.as_ptr(),
+        a.as_ptr(),
+        a_log.as_ptr(),
+        dt_bias.as_ptr(),
+        state_in.as_ptr(),
+        t_scalar,
+    ];
+    let inputs_vec =
+        unsafe { mlx_sys::mlx_vector_array_new_data(input_ptrs.as_ptr(), input_ptrs.len()) };
+
+    let mut outputs_vec = unsafe { mlx_sys::mlx_vector_array_new() };
+    let status = unsafe {
+        mlx_sys::mlx_fast_metal_kernel_apply(
+            &raw mut outputs_vec,
+            cached.0,
+            inputs_vec,
+            config,
+            stream.as_ptr(),
+        )
+    };
+
+    let result = if status != 0 {
+        let mlx_msg = FFI_LAST_ERROR
+            .with(|cell| cell.borrow_mut().take())
+            .unwrap_or_default();
+        Err(Exception::custom(format!(
+            "tape_replay_kernel failed: {mlx_msg}"
+        )))
+    } else {
+        let mut state_ptr = unsafe { mlx_sys::mlx_array_new() };
+        unsafe {
+            mlx_sys::mlx_vector_array_get(&raw mut state_ptr, outputs_vec, 0);
+        }
+        Ok(unsafe { Array::from_ptr(state_ptr) })
+    };
+
+    unsafe {
+        mlx_sys::mlx_fast_metal_kernel_config_free(config);
+        mlx_sys::mlx_vector_array_free(inputs_vec);
+        mlx_sys::mlx_vector_array_free(outputs_vec);
+        mlx_sys::mlx_array_free(t_scalar);
+    }
+
+    result
+}
+
 /// Eliminates per-token dtype conversions for scales/biases (packed once at load time).
 /// Tiled GEMV with shared memory for x and K-chunking.
 ///
@@ -2536,6 +3071,24 @@ fn compiled_gdn_decode_step(
     Ok(vec![gated])
 }
 
+/// conv1d, norms, or attention. Just `state = state * g + k * delta`.
+pub struct GdnLayerTape {
+    /// Innovation delta at each timestep: `[B, T, Hv, Dv]`
+    pub delta_tape: Array,
+    /// Post-conv, post-norm key vectors: `[B, T, Hk, Dk]`
+    pub norm_k: Array,
+    /// Projected gate values: `[B, T, Hv]`
+    pub a_proj: Array,
+    /// Raw QKV input to conv1d (for `conv_state` rebuild): `[B, T, conv_dim]`
+    pub qkv_input: Array,
+    /// Pre-forward `conv_state` for rollback: `[B, K-1, conv_dim]`
+    pub conv_state_init: Option<Array>,
+    /// Pre-forward `ssm_state` for rollback: `[B, Hv, Dv, Dk]`
+    pub ssm_state_init: Option<Array>,
+    /// Pre-forward cache offset for rollback
+    pub offset_init: i32,
+}
+
 #[allow(non_snake_case)]
 #[derive(Debug, Clone, ModuleParameters)]
 struct GatedDeltaNet {
@@ -3020,6 +3573,501 @@ impl GatedDeltaNet {
         let a = a_raw.reshape(&[B, S, nv])?;
 
         Ok((q, k, v, z, b, a))
+    }
+
+    fn replay_from_tape(
+        &self,
+        tape: &GdnLayerTape,
+        n_accepted: i32,
+        cache: &mut ArraysCache,
+    ) -> Result<(), Exception> {
+        if n_accepted <= 0 {
+            return Ok(());
+        }
+
+        // Slice tape data to accepted steps only
+        let tape_slice = tape.delta_tape.index((.., ..n_accepted, ..));
+        let k_slice = tape.norm_k.index((.., ..n_accepted, ..));
+        let a_slice = tape.a_proj.index((.., ..n_accepted, ..));
+
+        let state = if let Some(s) = cache.ssm_state.take() {
+            s
+        } else {
+            let dt = tape.delta_tape.dtype();
+            ops::zeros_dtype(&[1, self.num_v_heads, self.head_v_dim, self.head_k_dim], dt)?
+        };
+
+        let new_state = tape_replay_kernel_ffi(
+            &tape_slice,
+            &k_slice,
+            &a_slice,
+            &self.A_log,
+            &self.dt_bias,
+            &state,
+            1,
+            n_accepted,
+            self.num_k_heads,
+            self.head_k_dim,
+            self.num_v_heads,
+            self.head_v_dim,
+        )?;
+        cache.ssm_state = Some(new_state);
+        cache.offset += n_accepted;
+
+        // Rebuild conv_state from recorded qkv input
+        let ks = self.conv_kernel_size;
+        let n_keep = ks - 1;
+        if n_keep > 0 {
+            let qkv_slice = tape.qkv_input.index((.., ..n_accepted, ..));
+            // Prepend existing conv_state (or zeros), take last n_keep entries
+            let prefix = match &cache.conv_state {
+                Some(cs) => cs.clone(),
+                None => ops::zeros_dtype(&[1, n_keep, self.conv_dim], tape.qkv_input.dtype())?,
+            };
+            let full = ops::concatenate_axis(&[&prefix, &qkv_slice], 1)?;
+            let total_len = *full
+                .shape()
+                .get(1)
+                .ok_or_else(|| Exception::custom("conv rebuild: missing seq dim"))?;
+            let start = total_len - n_keep;
+            let cs = full.index((.., start.., ..));
+            let cs_shape = cs.shape().to_vec();
+            cache.conv_state = Some(cs.flatten(None, None)?.reshape(&cs_shape)?);
+        }
+
+        Ok(())
+    }
+
+    /// Side-effect-free forward used by `DFlash` verify. Identical numerics to
+    /// `forward`, but reads `cache.conv_state` / `cache.ssm_state` without
+    /// mutating them so a rejected speculation can be retried cleanly.
+    // Numerical kernel: tensor shape indices known finite; explicit casts preferred over try_from for hot path.
+    #[allow(
+        non_snake_case,
+        clippy::too_many_lines,
+        clippy::indexing_slicing,
+        clippy::as_conversions,
+        clippy::cast_sign_loss,
+        clippy::if_not_else,
+        clippy::single_match_else,
+        clippy::shadow_unrelated,
+        clippy::shadow_reuse
+    )]
+    fn forward_stateless(
+        &mut self,
+        inputs: &Array,
+        _mask: Option<&AttentionMask>,
+        cache: &ArraysCache,
+    ) -> Result<Array, Exception> {
+        let shape = inputs.shape();
+        let B = *shape
+            .first()
+            .ok_or_else(|| Exception::custom("Input must have >= 2 dims"))?;
+        let S = *shape
+            .get(1)
+            .ok_or_else(|| Exception::custom("Input must have >= 2 dims"))?;
+
+        // Project inputs — same as stateful forward
+        let (q, k, v, z, b, a) = if self.use_separate_projections {
+            let qkv_proj = self
+                .in_proj_qkv
+                .as_ref()
+                .ok_or_else(|| Exception::custom("in_proj_qkv missing"))?;
+            let z_proj = self
+                .in_proj_z
+                .as_ref()
+                .ok_or_else(|| Exception::custom("in_proj_z missing"))?;
+            let b_proj = self
+                .in_proj_b
+                .as_ref()
+                .ok_or_else(|| Exception::custom("in_proj_b missing"))?;
+            let a_proj = self
+                .in_proj_a
+                .as_ref()
+                .ok_or_else(|| Exception::custom("in_proj_a missing"))?;
+
+            let qkv = qkv_proj.forward(inputs)?;
+            let z = z_proj
+                .forward(inputs)?
+                .reshape(&[B, S, self.num_v_heads, self.head_v_dim])?;
+            let b = b_proj.forward(inputs)?;
+            let a = a_proj.forward(inputs)?;
+
+            let split_indices = &[self.key_dim, self.key_dim * 2];
+            let qkv_parts = qkv.split_axis(split_indices, Some(-1))?;
+            let q = qkv_parts
+                .first()
+                .ok_or_else(|| Exception::custom("qkv split failed"))?
+                .reshape(&[B, S, self.num_k_heads, self.head_k_dim])?;
+            let k = qkv_parts
+                .get(1)
+                .ok_or_else(|| Exception::custom("qkv split failed"))?
+                .reshape(&[B, S, self.num_k_heads, self.head_k_dim])?;
+            let v = qkv_parts
+                .get(2)
+                .ok_or_else(|| Exception::custom("qkv split failed"))?
+                .reshape(&[B, S, self.num_v_heads, self.head_v_dim])?;
+
+            (q, k, v, z, b, a)
+        } else {
+            let mixed_qkvz = self.in_proj_qkvz.forward(inputs)?;
+            let mixed_ba = self.in_proj_ba.forward(inputs)?;
+            self.fix_query_key_value_ordering(&mixed_qkvz, &mixed_ba, B, S)?
+        };
+
+        // Conv1d — read conv_state without consuming it
+        let q_flat = q.reshape(&[B, S, -1])?;
+        let k_flat = k.reshape(&[B, S, -1])?;
+        let v_flat = v.reshape(&[B, S, -1])?;
+        let mixed_qkv = ops::concatenate_axis(&[&q_flat, &k_flat, &v_flat], -1)?;
+
+        // Borrow conv_state without taking it (stateless must not mutate cache)
+        let conv_state = match &cache.conv_state {
+            Some(state) => state.clone(),
+            None => ops::zeros_dtype(
+                &[B, self.conv_kernel_size - 1, self.conv_dim],
+                inputs.dtype(),
+            )?,
+        };
+        let conv_input = ops::concatenate_axis(&[&conv_state, &mixed_qkv], 1)?;
+
+        // DO NOT update cache.conv_state
+
+        let conv_out = if S > 1 && S <= 32 {
+            let wt = match &self.conv_weight_t {
+                Some(w) => w.clone(),
+                None => {
+                    let shape = self.conv1d.weight.shape();
+                    let w = if shape.len() == 3 && shape[2] == 1 {
+                        self.conv1d.weight.squeeze_axes(&[-1])?.transpose()?
+                    } else if shape.len() == 3 && shape[1] == 1 {
+                        self.conv1d.weight.squeeze_axes(&[1])?.transpose()?
+                    } else {
+                        return Err(Exception::custom(format!(
+                            "Unexpected conv1d weight shape: {shape:?}"
+                        )));
+                    };
+                    let w = w.as_dtype(inputs.dtype())?;
+                    w.eval()?;
+                    // Don't cache weight here — stateless should be side-effect-free
+                    w
+                }
+            };
+            let ks = self.conv_kernel_size;
+            let mut windows = Vec::with_capacity(S as usize);
+            for i in 0..S {
+                windows.push(
+                    conv_input
+                        .index((.., i..i + ks, ..))
+                        .multiply(&wt)?
+                        .sum_axes(&[1], true)?,
+                );
+            }
+            nn::silu(&ops::concatenate_axis(
+                &windows.iter().collect::<Vec<_>>(),
+                1,
+            )?)?
+        } else {
+            // Stateless path: clone-coerce rather than mutate self.conv1d.weight,
+            // matching the qk_norm_weight_* clone pattern below.
+            let in_dt = inputs.dtype();
+            if self.conv1d.weight.dtype() != in_dt {
+                let coerced = self.conv1d.weight.as_dtype(in_dt)?;
+                let out = ops::conv1d(&conv_input, &coerced, 1, 0, 1, self.conv_dim)?;
+                nn::silu(&out)?
+            } else {
+                nn::silu(&self.conv1d.forward(&conv_input)?)?
+            }
+        };
+
+        let split_indices = &[self.key_dim, self.key_dim * 2];
+        let conv_parts = conv_out.split_axis(split_indices, Some(-1))?;
+        let conv_q = conv_parts
+            .first()
+            .ok_or_else(|| Exception::custom("conv split failed"))?
+            .reshape(&[B, S, self.num_k_heads, self.head_k_dim])?;
+        let conv_k = conv_parts
+            .get(1)
+            .ok_or_else(|| Exception::custom("conv split failed"))?
+            .reshape(&[B, S, self.num_k_heads, self.head_k_dim])?;
+        let conv_v = conv_parts
+            .get(2)
+            .ok_or_else(|| Exception::custom("conv split failed"))?
+            .reshape(&[B, S, self.num_v_heads, self.head_v_dim])?;
+
+        let in_dt = inputs.dtype();
+        let qk_wq = if self.qk_norm_weight_q.dtype() != in_dt {
+            self.qk_norm_weight_q.as_dtype(in_dt)?
+        } else {
+            self.qk_norm_weight_q.clone()
+        };
+        let qk_wk = if self.qk_norm_weight_k.dtype() != in_dt {
+            self.qk_norm_weight_k.as_dtype(in_dt)?
+        } else {
+            self.qk_norm_weight_k.clone()
+        };
+
+        let norm_q = fast::rms_norm(&conv_q, &qk_wq, 1e-6)?;
+        let norm_k = fast::rms_norm(&conv_k, &qk_wk, 1e-6)?;
+
+        // Stateless SSM recurrence — state_out := state_in
+        let state = match &cache.ssm_state {
+            Some(s) => s.clone(),
+            None => ops::zeros_dtype(
+                &[B, self.num_v_heads, self.head_v_dim, self.head_k_dim],
+                inputs.dtype(),
+            )?,
+        };
+        let (y, _unchanged_state) = gated_delta_kernel_ffi_stateless(
+            &norm_q,
+            &norm_k,
+            &conv_v,
+            &self.A_log,
+            &a,
+            &self.dt_bias,
+            &b,
+            &state,
+            B,
+            S,
+            self.num_k_heads,
+            self.head_k_dim,
+            self.num_v_heads,
+            self.head_v_dim,
+        )?;
+        // DO NOT update cache.ssm_state or cache.offset
+
+        let normed = self.norm.forward(&y)?;
+        let gated_out = swiglu(&z, &normed)?;
+
+        let out_flat = gated_out.reshape(&[B, S, -1])?;
+        self.out_proj.forward(&out_flat)
+    }
+
+    /// Tape-recording forward: identical output, also returns a `GdnLayerTape`
+    /// containing everything needed to cheaply replay accepted steps.
+    /// State IS updated (normal forward) — on full acceptance, zero extra work.
+    // Numerical kernel: tensor shape indices known finite; explicit casts preferred over try_from for hot path.
+    #[allow(
+        non_snake_case,
+        clippy::too_many_lines,
+        clippy::indexing_slicing,
+        clippy::as_conversions,
+        clippy::cast_sign_loss,
+        clippy::single_match_else,
+        clippy::shadow_unrelated,
+        clippy::shadow_reuse
+    )]
+    fn forward_with_tape(
+        &mut self,
+        inputs: &Array,
+        _mask: Option<&AttentionMask>,
+        cache: &mut ArraysCache,
+    ) -> Result<(Array, GdnLayerTape), Exception> {
+        let shape = inputs.shape();
+        let B = *shape
+            .first()
+            .ok_or_else(|| Exception::custom("need >= 2 dims"))?;
+        let S = *shape
+            .get(1)
+            .ok_or_else(|| Exception::custom("need >= 2 dims"))?;
+
+        let (q, k, v, z, b, a) = if self.use_separate_projections {
+            let qkv_proj = self
+                .in_proj_qkv
+                .as_ref()
+                .ok_or_else(|| Exception::custom("in_proj_qkv missing"))?;
+            let z_proj = self
+                .in_proj_z
+                .as_ref()
+                .ok_or_else(|| Exception::custom("in_proj_z missing"))?;
+            let b_proj = self
+                .in_proj_b
+                .as_ref()
+                .ok_or_else(|| Exception::custom("in_proj_b missing"))?;
+            let a_proj = self
+                .in_proj_a
+                .as_ref()
+                .ok_or_else(|| Exception::custom("in_proj_a missing"))?;
+
+            let qkv = qkv_proj.forward(inputs)?;
+            let z = z_proj
+                .forward(inputs)?
+                .reshape(&[B, S, self.num_v_heads, self.head_v_dim])?;
+            let b = b_proj.forward(inputs)?;
+            let a = a_proj.forward(inputs)?;
+
+            let split_indices = &[self.key_dim, self.key_dim * 2];
+            let qkv_parts = qkv.split_axis(split_indices, Some(-1))?;
+            let q = qkv_parts
+                .first()
+                .ok_or_else(|| Exception::custom("qkv split failed"))?
+                .reshape(&[B, S, self.num_k_heads, self.head_k_dim])?;
+            let k = qkv_parts
+                .get(1)
+                .ok_or_else(|| Exception::custom("qkv split failed"))?
+                .reshape(&[B, S, self.num_k_heads, self.head_k_dim])?;
+            let v = qkv_parts
+                .get(2)
+                .ok_or_else(|| Exception::custom("qkv split failed"))?
+                .reshape(&[B, S, self.num_v_heads, self.head_v_dim])?;
+            (q, k, v, z, b, a)
+        } else {
+            let mixed_qkvz = self.in_proj_qkvz.forward(inputs)?;
+            let mixed_ba = self.in_proj_ba.forward(inputs)?;
+            self.fix_query_key_value_ordering(&mixed_qkvz, &mixed_ba, B, S)?
+        };
+
+        // Save a for replay (before any reshape that might happen)
+        let a_for_replay = a.clone();
+
+        // Conv1d — same as normal forward
+        let q_flat = q.reshape(&[B, S, -1])?;
+        let k_flat = k.reshape(&[B, S, -1])?;
+        let v_flat = v.reshape(&[B, S, -1])?;
+        let mixed_qkv = ops::concatenate_axis(&[&q_flat, &k_flat, &v_flat], -1)?;
+
+        // Save qkv for conv_state rebuild on replay
+        let qkv_for_replay = mixed_qkv.clone();
+
+        // Capture initial state for rollback (Python `_GDNStateCapture` equivalent)
+        let conv_state_init = cache.conv_state.clone();
+        let ssm_state_init = cache.ssm_state.clone();
+        let offset_init = cache.offset;
+
+        let conv_state = match cache.conv_state.take() {
+            Some(state) => state,
+            None => ops::zeros_dtype(
+                &[B, self.conv_kernel_size - 1, self.conv_dim],
+                inputs.dtype(),
+            )?,
+        };
+        let conv_input = ops::concatenate_axis(&[&conv_state, &mixed_qkv], 1)?;
+
+        let n_keep = self.conv_kernel_size - 1;
+        let conv_input_len = *conv_input
+            .shape()
+            .get(1)
+            .ok_or_else(|| Exception::custom("conv_input missing seq dim"))?;
+        let keep_start = conv_input_len - n_keep;
+        let cs = conv_input.index((.., keep_start.., ..));
+        let cs_shape = cs.shape().to_vec();
+        cache.conv_state = Some(cs.flatten(None, None)?.reshape(&cs_shape)?);
+
+        let conv_out = if S > 1 && S <= 32 {
+            let wt = match &self.conv_weight_t {
+                Some(w) => w.clone(),
+                None => {
+                    let shape = self.conv1d.weight.shape();
+                    let w = if shape.len() == 3 && shape[2] == 1 {
+                        self.conv1d.weight.squeeze_axes(&[-1])?.transpose()?
+                    } else if shape.len() == 3 && shape[1] == 1 {
+                        self.conv1d.weight.squeeze_axes(&[1])?.transpose()?
+                    } else {
+                        return Err(Exception::custom(format!(
+                            "Unexpected conv1d weight shape: {shape:?}"
+                        )));
+                    };
+                    let w = w.as_dtype(inputs.dtype())?;
+                    w.eval()?;
+                    self.conv_weight_t = Some(w.clone());
+                    w
+                }
+            };
+            let ks = self.conv_kernel_size;
+            let mut windows = Vec::with_capacity(S as usize);
+            for i in 0..S {
+                windows.push(
+                    conv_input
+                        .index((.., i..i + ks, ..))
+                        .multiply(&wt)?
+                        .sum_axes(&[1], true)?,
+                );
+            }
+            nn::silu(&ops::concatenate_axis(
+                &windows.iter().collect::<Vec<_>>(),
+                1,
+            )?)?
+        } else {
+            // Mirror the S>1 dtype coercion for the native Conv1d path.
+            let in_dt = inputs.dtype();
+            if self.conv1d.weight.dtype() != in_dt {
+                let coerced = self.conv1d.weight.as_dtype(in_dt)?;
+                coerced.eval()?;
+                self.conv1d.weight = Param::new(coerced);
+            }
+            nn::silu(&self.conv1d.forward(&conv_input)?)?
+        };
+
+        let split_indices = &[self.key_dim, self.key_dim * 2];
+        let conv_parts = conv_out.split_axis(split_indices, Some(-1))?;
+        let conv_q = conv_parts
+            .first()
+            .ok_or_else(|| Exception::custom("conv split failed"))?
+            .reshape(&[B, S, self.num_k_heads, self.head_k_dim])?;
+        let conv_k = conv_parts
+            .get(1)
+            .ok_or_else(|| Exception::custom("conv split failed"))?
+            .reshape(&[B, S, self.num_k_heads, self.head_k_dim])?;
+        let conv_v = conv_parts
+            .get(2)
+            .ok_or_else(|| Exception::custom("conv split failed"))?
+            .reshape(&[B, S, self.num_v_heads, self.head_v_dim])?;
+
+        let in_dt = inputs.dtype();
+        if self.qk_norm_weight_q.dtype() != in_dt {
+            self.qk_norm_weight_q = self.qk_norm_weight_q.as_dtype(in_dt)?;
+            self.qk_norm_weight_k = self.qk_norm_weight_k.as_dtype(in_dt)?;
+        }
+
+        let norm_q = fast::rms_norm(&conv_q, &self.qk_norm_weight_q, 1e-6)?;
+        let norm_k = fast::rms_norm(&conv_k, &self.qk_norm_weight_k, 1e-6)?;
+
+        // Save norm_k for replay
+        let norm_k_for_replay = norm_k.clone();
+
+        // Tape-recording kernel — state IS updated, tape IS recorded
+        let state = match cache.ssm_state.take() {
+            Some(s) => s,
+            None => ops::zeros_dtype(
+                &[B, self.num_v_heads, self.head_v_dim, self.head_k_dim],
+                inputs.dtype(),
+            )?,
+        };
+        let (y, new_state, delta_tape) = gated_delta_kernel_ffi_with_tape(
+            &norm_q,
+            &norm_k,
+            &conv_v,
+            &self.A_log,
+            &a,
+            &self.dt_bias,
+            &b,
+            &state,
+            B,
+            S,
+            self.num_k_heads,
+            self.head_k_dim,
+            self.num_v_heads,
+            self.head_v_dim,
+        )?;
+        cache.ssm_state = Some(new_state);
+        cache.offset += S;
+
+        let normed = self.norm.forward(&y)?;
+        let gated_out = swiglu(&z, &normed)?;
+        let out_flat = gated_out.reshape(&[B, S, -1])?;
+        let output = self.out_proj.forward(&out_flat)?;
+
+        let tape = GdnLayerTape {
+            delta_tape,
+            norm_k: norm_k_for_replay,
+            a_proj: a_for_replay,
+            qkv_input: qkv_for_replay,
+            conv_state_init,
+            ssm_state_init,
+            offset_init,
+        };
+
+        Ok((output, tape))
     }
 }
 
@@ -4253,6 +5301,589 @@ mod prefill_eval_tests {
     fn keeps_layer_eval_barriers_for_long_prefill_chunks() {
         assert!(should_eval_between_prefill_layers(128, 7));
         assert!(!should_eval_between_prefill_layers(128, 6));
+    }
+
+    pub fn forward_with_taps(
+        &mut self,
+        inputs: &Array,
+        _mask: Option<&Array>,
+        kv_cache: &mut Vec<Option<LayerCache>>,
+        tap_layers: &[usize],
+    ) -> Result<(Array, Vec<Array>), Exception> {
+        let mut h = self.model.embed_tokens.forward(inputs)?;
+
+        if kv_cache.is_empty() {
+            *kv_cache = self.make_cache();
+        }
+
+        if kv_cache.len() != self.model.layers.len() {
+            return Err(Exception::custom(format!(
+                "cache length ({}) must match num layers ({})",
+                kv_cache.len(),
+                self.model.layers.len()
+            )));
+        }
+
+        let shape = h.shape();
+        let T = *shape
+            .get(1)
+            .ok_or_else(|| Exception::custom("Hidden state must have >= 2 dims"))?;
+
+        let fa_mask: Option<AttentionMask> = if T > 1 {
+            let kv_offset = kv_cache
+                .iter()
+                .find_map(|lc| match lc.as_ref()? {
+                    LayerCache::KV(kv) => Some(kv.offset()),
+                    LayerCache::Arrays(_) => None,
+                })
+                .unwrap_or(0);
+
+            if kv_offset > 0 {
+                Some(AttentionMask::Array(create_causal_mask(
+                    T,
+                    Some(kv_offset),
+                )?))
+            } else {
+                Some(AttentionMask::Causal)
+            }
+        } else {
+            None
+        };
+
+        let mut taps = Vec::with_capacity(tap_layers.len());
+
+        for (layer_idx, (layer, layer_cache)) in self
+            .model
+            .layers
+            .iter_mut()
+            .zip(kv_cache.iter_mut())
+            .enumerate()
+        {
+            let cache = layer_cache
+                .as_mut()
+                .ok_or_else(|| Exception::custom("Layer cache is None"))?;
+            let mask_ref = if layer.is_linear {
+                None
+            } else {
+                fa_mask.as_ref()
+            };
+
+            let normed = layer.input_layernorm.forward(&h)?;
+
+            let r = if layer.is_linear {
+                let attn = layer
+                    .linear_attn
+                    .as_mut()
+                    .ok_or_else(|| Exception::custom("linear_attn missing"))?;
+                let LayerCache::Arrays(ssm_cache) = cache else {
+                    return Err(Exception::custom("Expected ArraysCache"));
+                };
+                attn.forward(&normed, mask_ref, ssm_cache)?
+            } else {
+                let attn = layer
+                    .self_attn
+                    .as_mut()
+                    .ok_or_else(|| Exception::custom("self_attn missing"))?;
+                let LayerCache::KV(layer_kv) = cache else {
+                    return Err(Exception::custom("Expected KVCache"));
+                };
+                attn.forward(&normed, mask_ref, layer_kv)?
+            };
+
+            let h2 = h.add(r)?;
+            let normed_post = layer.post_attention_layernorm.forward(&h2)?;
+            let mlp_out = layer.mlp.forward(&normed_post)?;
+            h = h2.add(mlp_out)?;
+
+            if tap_layers.contains(&layer_idx) {
+                taps.push(h.clone());
+            }
+        }
+
+        let normed = self.model.norm.forward(&h)?;
+        let logits = self.project_logits(&normed)?;
+
+        Ok((logits, taps))
+    }
+
+    /// Stateless verify pass: identical to `forward_with_taps` but GDN layers
+    /// use `forward_stateless` — they compute correct outputs without updating
+    /// `ssm_state` or `conv_state`. KV cache layers update normally (needed for
+    /// future decode). Eliminates GdnStateBackup/restore overhead in `DFlash` verify.
+    ///
+    /// After verify, the caller runs `forward_hidden` with only the accepted
+    /// tokens to commit the GDN state for those positions.
+    #[allow(non_snake_case)]
+    pub fn forward_with_taps_stateless(
+        &mut self,
+        inputs: &Array,
+        _mask: Option<&Array>,
+        kv_cache: &mut Vec<Option<LayerCache>>,
+        tap_layers: &[usize],
+    ) -> Result<(Array, Vec<Array>), Exception> {
+        let mut h = self.model.embed_tokens.forward(inputs)?;
+
+        if kv_cache.is_empty() {
+            *kv_cache = self.make_cache();
+        }
+
+        if kv_cache.len() != self.model.layers.len() {
+            return Err(Exception::custom(format!(
+                "cache length ({}) must match num layers ({})",
+                kv_cache.len(),
+                self.model.layers.len()
+            )));
+        }
+
+        let shape = h.shape();
+        let T = *shape
+            .get(1)
+            .ok_or_else(|| Exception::custom("Hidden state must have >= 2 dims"))?;
+
+        let fa_mask: Option<AttentionMask> = if T > 1 {
+            let kv_offset = kv_cache
+                .iter()
+                .find_map(|lc| match lc.as_ref()? {
+                    LayerCache::KV(kv) => Some(kv.offset()),
+                    LayerCache::Arrays(_) => None,
+                })
+                .unwrap_or(0);
+
+            if kv_offset > 0 {
+                Some(AttentionMask::Array(create_causal_mask(
+                    T,
+                    Some(kv_offset),
+                )?))
+            } else {
+                Some(AttentionMask::Causal)
+            }
+        } else {
+            None
+        };
+
+        let mut taps = Vec::with_capacity(tap_layers.len());
+
+        for (layer_idx, (layer, layer_cache)) in self
+            .model
+            .layers
+            .iter_mut()
+            .zip(kv_cache.iter_mut())
+            .enumerate()
+        {
+            let cache = layer_cache
+                .as_mut()
+                .ok_or_else(|| Exception::custom("Layer cache is None"))?;
+            let mask_ref = if layer.is_linear {
+                None
+            } else {
+                fa_mask.as_ref()
+            };
+
+            let normed = layer.input_layernorm.forward(&h)?;
+
+            let r = if layer.is_linear {
+                let attn = layer
+                    .linear_attn
+                    .as_mut()
+                    .ok_or_else(|| Exception::custom("linear_attn missing"))?;
+                let LayerCache::Arrays(ssm_cache) = cache else {
+                    return Err(Exception::custom("Expected ArraysCache"));
+                };
+                // STATELESS: GDN state not updated
+                attn.forward_stateless(&normed, mask_ref, ssm_cache)?
+            } else {
+                let attn = layer
+                    .self_attn
+                    .as_mut()
+                    .ok_or_else(|| Exception::custom("self_attn missing"))?;
+                let LayerCache::KV(layer_kv) = cache else {
+                    return Err(Exception::custom("Expected KVCache"));
+                };
+                // KV cache updates normally — needed for future decode
+                attn.forward(&normed, mask_ref, layer_kv)?
+            };
+
+            let h2 = h.add(r)?;
+            let normed_post = layer.post_attention_layernorm.forward(&h2)?;
+            let mlp_out = layer.mlp.forward(&normed_post)?;
+            h = h2.add(mlp_out)?;
+
+            if tap_layers.contains(&layer_idx) {
+                taps.push(h.clone());
+            }
+        }
+
+        let normed = self.model.norm.forward(&h)?;
+        let logits = self.project_logits(&normed)?;
+
+        Ok((logits, taps))
+    }
+
+    /// Tape-recording verify pass: runs normal forward (state IS updated) and
+    /// records innovation tape per GDN layer. Returns `(logits, taps, tape_data)`.
+    ///
+    /// On full acceptance (89% of rounds): zero extra work — state already correct.
+    /// On partial rejection: restore conv+ssm snapshots, replay `tape[:n_accepted]`.
+    // Numerical kernel dispatch: long fn but single straight-line decode loop, casts are timing arithmetic over small counters.
+    #[allow(
+        non_snake_case,
+        clippy::too_many_lines,
+        clippy::type_complexity,
+        clippy::cast_precision_loss,
+        clippy::as_conversions,
+        clippy::map_unwrap_or
+    )]
+    pub fn forward_with_taps_tape(
+        &mut self,
+        inputs: &Array,
+        _mask: Option<&Array>,
+        kv_cache: &mut Vec<Option<LayerCache>>,
+        tap_layers: &[usize],
+    ) -> Result<(Array, Vec<Array>, Vec<Option<GdnLayerTape>>), Exception> {
+        let mut h = self.model.embed_tokens.forward(inputs)?;
+
+        if kv_cache.is_empty() {
+            *kv_cache = self.make_cache();
+        }
+
+        if kv_cache.len() != self.model.layers.len() {
+            return Err(Exception::custom(format!(
+                "cache length ({}) must match num layers ({})",
+                kv_cache.len(),
+                self.model.layers.len()
+            )));
+        }
+
+        let shape = h.shape();
+        let T = *shape
+            .get(1)
+            .ok_or_else(|| Exception::custom("Hidden state must have >= 2 dims"))?;
+
+        let fa_mask: Option<AttentionMask> = if T > 1 {
+            let kv_offset = kv_cache
+                .iter()
+                .find_map(|lc| match lc.as_ref()? {
+                    LayerCache::KV(kv) => Some(kv.offset()),
+                    LayerCache::Arrays(_) => None,
+                })
+                .unwrap_or(0);
+
+            if kv_offset > 0 {
+                Some(AttentionMask::Array(create_causal_mask(
+                    T,
+                    Some(kv_offset),
+                )?))
+            } else {
+                Some(AttentionMask::Causal)
+            }
+        } else {
+            None
+        };
+
+        let mut taps = Vec::with_capacity(tap_layers.len());
+        let mut layer_tapes: Vec<Option<GdnLayerTape>> =
+            Vec::with_capacity(self.model.layers.len());
+
+        // Optional per-layer GDN/FA timing. Gated by env to avoid the eval()
+        // stalls (which serialize the GPU pipeline) in normal runs. Numbers
+        // produced under timing are upper bounds: they include synchronization
+        // cost that real execution overlaps. Useful for the GDN-vs-FA ratio.
+        let layer_timing = std::env::var("HIGGS_DFLASH_LAYER_TIMING")
+            .map(|v| v == "1")
+            .unwrap_or(false);
+        let mut gdn_total_ms = 0.0_f64;
+        let mut fa_total_ms = 0.0_f64;
+        let mut gdn_count = 0usize;
+        let mut fa_count = 0usize;
+        let mut layer_ckpt = if layer_timing {
+            mlx_rs::transforms::eval([&h])?;
+            Some(std::time::Instant::now())
+        } else {
+            None
+        };
+
+        for (layer_idx, (layer, layer_cache)) in self
+            .model
+            .layers
+            .iter_mut()
+            .zip(kv_cache.iter_mut())
+            .enumerate()
+        {
+            let cache = layer_cache
+                .as_mut()
+                .ok_or_else(|| Exception::custom("Layer cache is None"))?;
+            let is_linear = layer.is_linear;
+            let mask_ref = if is_linear { None } else { fa_mask.as_ref() };
+
+            let normed = layer.input_layernorm.forward(&h)?;
+
+            let (r, tape) = if is_linear {
+                let attn = layer
+                    .linear_attn
+                    .as_mut()
+                    .ok_or_else(|| Exception::custom("linear_attn missing"))?;
+                let LayerCache::Arrays(ssm_cache) = cache else {
+                    return Err(Exception::custom("Expected ArraysCache"));
+                };
+                let (out, tape) = attn.forward_with_tape(&normed, mask_ref, ssm_cache)?;
+                (out, Some(tape))
+            } else {
+                let attn = layer
+                    .self_attn
+                    .as_mut()
+                    .ok_or_else(|| Exception::custom("self_attn missing"))?;
+                let LayerCache::KV(layer_kv) = cache else {
+                    return Err(Exception::custom("Expected KVCache"));
+                };
+                (attn.forward(&normed, mask_ref, layer_kv)?, None)
+            };
+
+            layer_tapes.push(tape);
+
+            let h2 = h.add(r)?;
+            let normed_post = layer.post_attention_layernorm.forward(&h2)?;
+            let mlp_out = layer.mlp.forward(&normed_post)?;
+            h = h2.add(mlp_out)?;
+
+            if tap_layers.contains(&layer_idx) {
+                taps.push(h.clone());
+            }
+
+            if let Some(ckpt) = layer_ckpt.as_mut() {
+                mlx_rs::transforms::eval([&h])?;
+                let now = std::time::Instant::now();
+                let dt_ms = now.duration_since(*ckpt).as_secs_f64() * 1000.0;
+                if is_linear {
+                    gdn_total_ms += dt_ms;
+                    gdn_count += 1;
+                } else {
+                    fa_total_ms += dt_ms;
+                    fa_count += 1;
+                }
+                *ckpt = now;
+            }
+        }
+
+        let normed = self.model.norm.forward(&h)?;
+        let logits = self.project_logits(&normed)?;
+
+        if layer_timing {
+            mlx_rs::transforms::eval([&logits])?;
+            let tail_ms = layer_ckpt
+                .map(|c| c.elapsed().as_secs_f64() * 1000.0)
+                .unwrap_or(0.0);
+            tracing::info!(
+                "dflash_layer_timing seq={} gdn_layers={} gdn_total_ms={:.1} gdn_avg={:.2}ms \
+                 fa_layers={} fa_total_ms={:.1} fa_avg={:.2}ms tail_ms={:.1}",
+                T,
+                gdn_count,
+                gdn_total_ms,
+                gdn_total_ms / gdn_count.max(1) as f64,
+                fa_count,
+                fa_total_ms,
+                fa_total_ms / fa_count.max(1) as f64,
+                tail_ms,
+            );
+        }
+
+        Ok((logits, taps, layer_tapes))
+    }
+
+    /// Replay accepted steps from recorded tape data on partial rejection.
+    /// Restores GDN state from `snapshots`, replays `tape[:n_accepted]`,
+    /// and rolls back KV cache for rejected positions.
+    ///
+    /// All GDN layers are batched into a single Metal kernel dispatch
+    /// (concat along batch dim, one kernel call, split back) to avoid
+    /// per-layer dispatch overhead (~0.4ms × 24 layers = 10ms → <1ms).
+    // Numerical kernel: layer indices and counts known finite; explicit casts preferred over try_from.
+    #[allow(
+        clippy::too_many_lines,
+        clippy::indexing_slicing,
+        clippy::as_conversions,
+        clippy::cast_possible_truncation,
+        clippy::cast_possible_wrap
+    )]
+    pub fn replay_tape_rollback(
+        &self,
+        layer_tapes: &[Option<GdnLayerTape>],
+        kv_cache: &mut [Option<LayerCache>],
+        n_accepted: i32,
+        kv_rollback: i32,
+    ) -> Result<(), Exception> {
+        use mlx_rs::ops;
+
+        // Collect GDN layer data for batched replay
+        struct GdnReplayEntry<'a> {
+            cache_idx: usize,
+            tape: &'a GdnLayerTape,
+            layer: &'a GatedDeltaNet,
+            snap_state: Array,
+        }
+
+        let mut gdn_entries: Vec<GdnReplayEntry> = Vec::new();
+
+        // First pass: restore state from tape's initial snapshot, rollback KV, collect GDN entries
+        for (i, lc) in kv_cache.iter_mut().enumerate() {
+            match lc {
+                Some(LayerCache::Arrays(ac)) => {
+                    if let Some(Some(tape)) = layer_tapes.get(i) {
+                        // Restore from tape-captured initial state (Python _GDNStateCapture equivalent)
+                        ac.conv_state.clone_from(&tape.conv_state_init);
+                        ac.ssm_state.clone_from(&tape.ssm_state_init);
+                        ac.offset = tape.offset_init;
+
+                        let gdn_layer = self.model.layers[i]
+                            .linear_attn
+                            .as_ref()
+                            .ok_or_else(|| Exception::custom("linear_attn missing for replay"))?;
+
+                        let state = if let Some(s) = tape.ssm_state_init.clone() {
+                            s
+                        } else {
+                            let dt = tape.delta_tape.dtype();
+                            ops::zeros_dtype(
+                                &[
+                                    1,
+                                    gdn_layer.num_v_heads,
+                                    gdn_layer.head_v_dim,
+                                    gdn_layer.head_k_dim,
+                                ],
+                                dt,
+                            )?
+                        };
+
+                        gdn_entries.push(GdnReplayEntry {
+                            cache_idx: i,
+                            tape,
+                            layer: gdn_layer,
+                            snap_state: state,
+                        });
+                    }
+                }
+                Some(LayerCache::KV(kv)) if kv_rollback > 0 => {
+                    kv.trim_by(kv_rollback.unsigned_abs().try_into().unwrap_or(usize::MAX));
+                }
+                Some(LayerCache::KV(_)) | None => {}
+            }
+        }
+
+        if gdn_entries.is_empty() {
+            return Ok(());
+        }
+
+        // Batch all GDN layers: concat tape/k/a/state/A_log/dt_bias along batch dim
+        let tape_slices: Vec<Array> = gdn_entries
+            .iter()
+            .map(|e| e.tape.delta_tape.index((.., ..n_accepted, ..)))
+            .collect();
+        let k_slices: Vec<Array> = gdn_entries
+            .iter()
+            .map(|e| e.tape.norm_k.index((.., ..n_accepted, ..)))
+            .collect();
+        let a_slices: Vec<Array> = gdn_entries
+            .iter()
+            .map(|e| e.tape.a_proj.index((.., ..n_accepted, ..)))
+            .collect();
+        let states: Vec<&Array> = gdn_entries.iter().map(|e| &e.snap_state).collect();
+        let a_logs: Vec<&Array> = gdn_entries.iter().map(|e| e.layer.A_log.as_ref()).collect();
+        let dt_biases: Vec<&Array> = gdn_entries
+            .iter()
+            .map(|e| e.layer.dt_bias.as_ref())
+            .collect();
+
+        let tape_refs: Vec<&Array> = tape_slices.iter().collect();
+        let k_refs: Vec<&Array> = k_slices.iter().collect();
+        let a_refs: Vec<&Array> = a_slices.iter().collect();
+
+        let batched_tape = ops::concatenate_axis(&tape_refs, 0)?;
+        let batched_k = ops::concatenate_axis(&k_refs, 0)?;
+        let batched_a = ops::concatenate_axis(&a_refs, 0)?;
+        let batched_state = ops::concatenate_axis(&states, 0)?;
+        // Flatten A_log [Hv] per layer → [num_layers * Hv]
+        let batched_a_log = ops::concatenate_axis(&a_logs, 0)?;
+        let batched_dt_bias = ops::concatenate_axis(&dt_biases, 0)?;
+
+        let num_layers = gdn_entries.len() as i32;
+        let e0 = &gdn_entries[0];
+
+        // Single kernel dispatch for all GDN layers
+        let batched_new_state = tape_replay_kernel_ffi(
+            &batched_tape,
+            &batched_k,
+            &batched_a,
+            &batched_a_log,
+            &batched_dt_bias,
+            &batched_state,
+            num_layers,
+            n_accepted,
+            e0.layer.num_k_heads,
+            e0.layer.head_k_dim,
+            e0.layer.num_v_heads,
+            e0.layer.head_v_dim,
+        )?;
+
+        // Split results back to individual layers and rebuild conv_state
+        for (offset, entry) in gdn_entries.iter().enumerate() {
+            let Some(LayerCache::Arrays(ac)) = &mut kv_cache[entry.cache_idx] else {
+                continue;
+            };
+
+            // Extract this layer's state from the batched result
+            let start = offset as i32;
+            let new_state = batched_new_state.index((start..start + 1, .., .., ..));
+            ac.ssm_state = Some(new_state);
+            ac.offset += n_accepted;
+
+            // Rebuild conv_state from recorded qkv input
+            let ks = entry.layer.conv_kernel_size;
+            let n_keep = ks - 1;
+            if n_keep > 0 {
+                let qkv_slice = entry.tape.qkv_input.index((.., ..n_accepted, ..));
+                let prefix = match &ac.conv_state {
+                    Some(cs) => cs.clone(),
+                    None => ops::zeros_dtype(
+                        &[1, n_keep, entry.layer.conv_dim],
+                        entry.tape.qkv_input.dtype(),
+                    )?,
+                };
+                let full = ops::concatenate_axis(&[&prefix, &qkv_slice], 1)?;
+                let total_len = *full
+                    .shape()
+                    .get(1)
+                    .ok_or_else(|| Exception::custom("conv rebuild: missing seq dim"))?;
+                let cs_start = total_len - n_keep;
+                let cs = full.index((.., cs_start.., ..));
+                let cs_shape = cs.shape().to_vec();
+                ac.conv_state = Some(cs.flatten(None, None)?.reshape(&cs_shape)?);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Embed raw token IDs through the target model's embedding layer.
+    ///
+    /// Used by `DFlash` to convert `[anchor, mask, mask, ...]` block into
+    /// the embedding space expected by the drafter.
+    pub fn embed_token_ids(&self, token_ids: &Array) -> Result<Array, Exception> {
+        self.model.embed_tokens.forward(token_ids)
+    }
+
+    /// Apply only the `lm_head` to pre-computed hidden states.
+    ///
+    /// Used by `DFlash`: the drafter produces hidden states in the target model's
+    /// hidden space, and we project them through the target's `lm_head` to get logits.
+    /// Input: `[B, T, hidden_size]`. Returns: `[B, T, vocab_size]`.
+    pub fn forward_all_logits_from_hidden(&self, hidden: &Array) -> Result<Array, Exception> {
+        self.project_logits(hidden)
+    }
+
+    fn project_logits(&self, hidden: &Array) -> Result<Array, Exception> {
+        self.lm_head.as_ref().map_or_else(
+            || self.model.embed_tokens.as_linear(hidden),
+            |head| head.forward(hidden),
+        )
     }
 }
 
@@ -6477,6 +8108,148 @@ mod tests {
         assert!(
             max_diff < 1e-5,
             "compiled gdn_output_gate differs from raw by {max_diff}"
+        );
+    }
+
+    /// P2a gate (correctness): the DFlash tape replay must reconstruct the GDN
+    /// SSM state at a partial-accept boundary *exactly* like a fresh forward over
+    /// the accepted prefix. This bit-exactness is what makes greedy spec-decode
+    /// AR-identical regardless of draft quality (commit e23415da's whole point).
+    /// Tested at the kernel level (the projections need loaded quantized weights).
+    #[test]
+    #[allow(clippy::print_stderr, clippy::many_single_char_names)]
+    fn test_gdn_tape_replay_kernel_matches_forward() {
+        let (b_, kk, j, nk, dk, nv, dv) = (1, 8, 5, 2, 32, 4, 32);
+        let rnd = |s: &[i32]| mlx_rs::random::uniform::<f32, f32>(-1.0, 1.0, s, None).unwrap();
+        let q = rnd(&[b_, kk, nk, dk]);
+        let k = rnd(&[b_, kk, nk, dk]);
+        let v = rnd(&[b_, kk, nv, dv]);
+        let a = rnd(&[b_, kk, nv]);
+        let beta = rnd(&[b_, kk, nv]);
+        let a_log = Array::zeros::<f32>(&[nv]).unwrap();
+        let dt_bias = Array::zeros::<f32>(&[nv]).unwrap();
+        let s0 = Array::zeros::<f32>(&[b_, nv, dv, dk]).unwrap();
+
+        // Record the tape over the whole draft block.
+        let (_y, _sk, tape) = gated_delta_kernel_ffi_with_tape(
+            &q, &k, &v, &a_log, &a, &dt_bias, &beta, &s0, b_, kk, nk, dk, nv, dv,
+        )
+        .unwrap();
+
+        // Slice tape/inputs to the accepted prefix (mirrors replay_from_tape).
+        let sj = |arr: &Array| arr.index((.., ..j, ..));
+
+        // Ground truth: fresh forward kernel over the first j steps.
+        let (_yj, state_fwd) = gated_delta_kernel_ffi(
+            &sj(&q),
+            &sj(&k),
+            &sj(&v),
+            &a_log,
+            &sj(&a),
+            &dt_bias,
+            &sj(&beta),
+            &s0,
+            b_,
+            j,
+            nk,
+            dk,
+            nv,
+            dv,
+        )
+        .unwrap();
+
+        // Replay the first j steps from the recorded tape.
+        let state_replay = tape_replay_kernel_ffi(
+            &sj(&tape),
+            &sj(&k),
+            &sj(&a),
+            &a_log,
+            &dt_bias,
+            &s0,
+            b_,
+            j,
+            nk,
+            dk,
+            nv,
+            dv,
+        )
+        .unwrap();
+
+        mlx_rs::transforms::eval([&state_fwd, &state_replay]).unwrap();
+        let max_diff: f32 = state_fwd
+            .subtract(&state_replay)
+            .unwrap()
+            .abs()
+            .unwrap()
+            .max(None)
+            .unwrap()
+            .item();
+        eprintln!("tape-replay vs forward SSM max_diff = {max_diff:.2e}");
+        assert!(
+            max_diff < 1e-3,
+            "tape replay differs from forward by {max_diff}"
+        );
+    }
+
+    /// P2a gate (cost): rollback must be cheap vs recompute, or partial accepts
+    /// (every round) erode the spec-decode win. Times the tape-replay kernel vs
+    /// the forward kernel at the accepted length — and note the *real* rollback
+    /// win is bigger still, since replay skips all the QLinear projections.
+    #[test]
+    #[ignore = "bench: GDN tape-replay rollback kernel cost vs forward kernel"]
+    #[allow(
+        clippy::print_stderr,
+        clippy::cast_precision_loss,
+        clippy::many_single_char_names
+    )]
+    fn bench_gdn_tape_replay_rollback_cost() {
+        // Real Qwen3.6-35B-A3B GDN dims: 16 k-heads, 32 v-heads, 128 head dims.
+        let (b_, kk, j, nk, dk, nv, dv) = (1, 16, 10, 16, 128, 32, 128);
+        let rnd = |s: &[i32]| mlx_rs::random::uniform::<f32, f32>(-1.0, 1.0, s, None).unwrap();
+        let (q, k, v) = (
+            rnd(&[b_, kk, nk, dk]),
+            rnd(&[b_, kk, nk, dk]),
+            rnd(&[b_, kk, nv, dv]),
+        );
+        let (a, beta) = (rnd(&[b_, kk, nv]), rnd(&[b_, kk, nv]));
+        let a_log = Array::zeros::<f32>(&[nv]).unwrap();
+        let dt_bias = Array::zeros::<f32>(&[nv]).unwrap();
+        let s0 = Array::zeros::<f32>(&[b_, nv, dv, dk]).unwrap();
+        let (_y, _sk, tape) = gated_delta_kernel_ffi_with_tape(
+            &q, &k, &v, &a_log, &a, &dt_bias, &beta, &s0, b_, kk, nk, dk, nv, dv,
+        )
+        .unwrap();
+        let sj = |arr: &Array| arr.index((.., ..j, ..));
+        let (tj, kj, aj, qj, vj, bj) = (sj(&tape), sj(&k), sj(&a), sj(&q), sj(&v), sj(&beta));
+
+        let n = 100;
+        // warm
+        tape_replay_kernel_ffi(&tj, &kj, &aj, &a_log, &dt_bias, &s0, b_, j, nk, dk, nv, dv)
+            .unwrap();
+        let t0 = std::time::Instant::now();
+        for _ in 0..n {
+            let s =
+                tape_replay_kernel_ffi(&tj, &kj, &aj, &a_log, &dt_bias, &s0, b_, j, nk, dk, nv, dv)
+                    .unwrap();
+            mlx_rs::transforms::eval([&s]).unwrap();
+        }
+        let t_replay = t0.elapsed().as_secs_f64() / f64::from(n);
+
+        let t1 = std::time::Instant::now();
+        for _ in 0..n {
+            let (_y, s) = gated_delta_kernel_ffi(
+                &qj, &kj, &vj, &a_log, &aj, &dt_bias, &bj, &s0, b_, j, nk, dk, nv, dv,
+            )
+            .unwrap();
+            mlx_rs::transforms::eval([&s]).unwrap();
+        }
+        let t_forward = t1.elapsed().as_secs_f64() / f64::from(n);
+
+        eprintln!(
+            "GDN ROLLBACK KERNEL [accept={j}/{kk}]: replay={:.4}ms forward(SSM-only)={:.4}ms ratio={:.2}x  (real rollback also skips projections -> bigger win)",
+            t_replay * 1e3,
+            t_forward * 1e3,
+            t_replay / t_forward
         );
     }
 

--- a/crates/higgs-models/src/qwen3_next.rs
+++ b/crates/higgs-models/src/qwen3_next.rs
@@ -1049,8 +1049,10 @@ auto tape_ = innovation_tape + b_idx * T * Hv * Dv + hv_idx * Dv;
 auto dk_idx = thread_position_in_threadgroup.x;
 auto dv_idx = thread_position_in_grid.y;
 
-auto i_state = state_in + (n * Dv + dv_idx) * Dk;
-auto o_state = state_out + (n * Dv + dv_idx) * Dk;
+// state_in/state_out are float32 buffers (must match the f32 precision of the
+// AR-decode kernel so verify argmax is bit-exact); reinterpret from InT*.
+auto i_state = reinterpret_cast<const device float*>(state_in) + (n * Dv + dv_idx) * Dk;
+auto o_state = reinterpret_cast<device float*>(state_out) + (n * Dv + dv_idx) * Dk;
 
 float state[n_per_t];
 for (int i = 0; i < n_per_t; ++i) {
@@ -1094,10 +1096,8 @@ for (int t = 0; t < T; ++t) {
       tape_[dv_idx] = delta;
     }
   }
-  // Match mlx-lm precision: cast state to InT between timesteps
-  for (int i = 0; i < n_per_t; ++i) {
-    state[i] = static_cast<float>(static_cast<InT>(state[i]));
-  }
+  // Keep state in float32 across timesteps (no InT downcast) so the recurrence
+  // is bit-exact with the AR-decode kernel.
   q_ += Hk * Dk;
   k_ += Hk * Dk;
   v_ += Hv * Dv;
@@ -1108,7 +1108,7 @@ for (int t = 0; t < T; ++t) {
 }
 for (int i = 0; i < n_per_t; ++i) {
   auto s_idx = n_per_t * dk_idx + i;
-  o_state[s_idx] = static_cast<InT>(state[i]);
+  o_state[s_idx] = state[i];
 }
 ";
 
@@ -1201,11 +1201,12 @@ fn configure_gated_delta_tape_kernel(
             y_shape.len(),
             in_dtype,
         );
+        // State is float32 (matches the AR-decode kernel) for bit-exact verify.
         mlx_sys::mlx_fast_metal_kernel_config_add_output_arg(
             config,
             state_shape.as_ptr(),
             state_shape.len(),
-            in_dtype,
+            mlx_sys::mlx_dtype__MLX_FLOAT32,
         );
         // Tape stores deltas in float32 for precision (matches dflash-mlx)
         mlx_sys::mlx_fast_metal_kernel_config_add_output_arg(
@@ -1356,13 +1357,14 @@ for (int t = 0; t < T; ++t) {
   float g_val = exp(-exp(a_log_val) * sp);
 
   auto delta = tape_[dv_idx];
+  // Replay the forward kernel's EXACT op sequence (decay as a separate
+  // statement, then the k*delta update) so the replayed state is bit-exact
+  // with a fresh forward. Fusing into `state*g + k*delta` rounds differently
+  // (FMA) and the ~1e-8 drift accumulates across rollbacks → argmax flips.
   for (int i = 0; i < n_per_t; ++i) {
     auto s_idx = n_per_t * dk_idx + i;
-    state[i] = state[i] * g_val + k_[s_idx] * delta;
-  }
-  // Match mlx-lm precision: cast state to InT between timesteps
-  for (int i = 0; i < n_per_t; ++i) {
-    state[i] = static_cast<float>(static_cast<InT>(state[i]));
+    state[i] = state[i] * g_val;
+    state[i] = state[i] + k_[s_idx] * delta;
   }
   tape_ += Hv * Dv;
   k_ += Hk * Dk;
@@ -1370,7 +1372,7 @@ for (int t = 0; t < T; ++t) {
 }
 for (int i = 0; i < n_per_t; ++i) {
   auto s_idx = n_per_t * dk_idx + i;
-  o_state[s_idx] = static_cast<InT>(state[i]);
+  o_state[s_idx] = state[i];
 }
 ";
 
@@ -3575,69 +3577,6 @@ impl GatedDeltaNet {
         Ok((q, k, v, z, b, a))
     }
 
-    fn replay_from_tape(
-        &self,
-        tape: &GdnLayerTape,
-        n_accepted: i32,
-        cache: &mut ArraysCache,
-    ) -> Result<(), Exception> {
-        if n_accepted <= 0 {
-            return Ok(());
-        }
-
-        // Slice tape data to accepted steps only
-        let tape_slice = tape.delta_tape.index((.., ..n_accepted, ..));
-        let k_slice = tape.norm_k.index((.., ..n_accepted, ..));
-        let a_slice = tape.a_proj.index((.., ..n_accepted, ..));
-
-        let state = if let Some(s) = cache.ssm_state.take() {
-            s
-        } else {
-            let dt = tape.delta_tape.dtype();
-            ops::zeros_dtype(&[1, self.num_v_heads, self.head_v_dim, self.head_k_dim], dt)?
-        };
-
-        let new_state = tape_replay_kernel_ffi(
-            &tape_slice,
-            &k_slice,
-            &a_slice,
-            &self.A_log,
-            &self.dt_bias,
-            &state,
-            1,
-            n_accepted,
-            self.num_k_heads,
-            self.head_k_dim,
-            self.num_v_heads,
-            self.head_v_dim,
-        )?;
-        cache.ssm_state = Some(new_state);
-        cache.offset += n_accepted;
-
-        // Rebuild conv_state from recorded qkv input
-        let ks = self.conv_kernel_size;
-        let n_keep = ks - 1;
-        if n_keep > 0 {
-            let qkv_slice = tape.qkv_input.index((.., ..n_accepted, ..));
-            // Prepend existing conv_state (or zeros), take last n_keep entries
-            let prefix = match &cache.conv_state {
-                Some(cs) => cs.clone(),
-                None => ops::zeros_dtype(&[1, n_keep, self.conv_dim], tape.qkv_input.dtype())?,
-            };
-            let full = ops::concatenate_axis(&[&prefix, &qkv_slice], 1)?;
-            let total_len = *full
-                .shape()
-                .get(1)
-                .ok_or_else(|| Exception::custom("conv rebuild: missing seq dim"))?;
-            let start = total_len - n_keep;
-            let cs = full.index((.., start.., ..));
-            let cs_shape = cs.shape().to_vec();
-            cache.conv_state = Some(cs.flatten(None, None)?.reshape(&cs_shape)?);
-        }
-
-        Ok(())
-    }
-
     /// Side-effect-free forward used by `DFlash` verify. Identical numerics to
     /// `forward`, but reads `cache.conv_state` / `cache.ssm_state` without
     /// mutating them so a rejected speculation can be retried cleanly.
@@ -4025,12 +3964,13 @@ impl GatedDeltaNet {
         // Save norm_k for replay
         let norm_k_for_replay = norm_k.clone();
 
-        // Tape-recording kernel — state IS updated, tape IS recorded
+        // Tape-recording kernel — state IS updated, tape IS recorded.
+        // State is float32 to match the AR-decode kernel (bit-exact verify).
         let state = match cache.ssm_state.take() {
             Some(s) => s,
             None => ops::zeros_dtype(
                 &[B, self.num_v_heads, self.head_v_dim, self.head_k_dim],
-                inputs.dtype(),
+                Dtype::Float32,
             )?,
         };
         let (y, new_state, delta_tape) = gated_delta_kernel_ffi_with_tape(
@@ -5278,6 +5218,7 @@ impl Qwen3NextCausalLM {
         Ok((h_raw, logits))
     }
 
+    #[allow(non_snake_case)]
     pub fn forward_with_taps(
         &mut self,
         inputs: &Array,
@@ -8189,6 +8130,61 @@ mod tests {
             max_diff < 1e-3,
             "tape replay differs from forward by {max_diff}"
         );
+    }
+
+    /// DFlash verify must be bit-exact with AR decode. The verify path uses the
+    /// tape kernel (S>1 block); AR decode uses the plain kernel. With **bf16**
+    /// inputs (the production dtype) both must keep the SSM state in f32 and
+    /// produce identical `y`/`state` — otherwise the verify argmax flips on
+    /// close calls and DFlash diverges from greedy AR. Regression for the bug
+    /// where the tape kernel downcast state to bf16 between timesteps.
+    #[test]
+    #[allow(clippy::print_stderr, clippy::many_single_char_names)]
+    fn test_gdn_tape_forward_matches_plain_forward_bf16() {
+        let (b_, t, nk, dk, nv, dv) = (1, 12, 2, 32, 4, 32);
+        let rnd_bf16 = |s: &[i32]| {
+            mlx_rs::random::uniform::<f32, f32>(-1.0, 1.0, s, None)
+                .unwrap()
+                .as_dtype(Dtype::Bfloat16)
+                .unwrap()
+        };
+        // Production dtypes: q/k/v/a/beta bf16, a_log/dt_bias/state f32.
+        let q = rnd_bf16(&[b_, t, nk, dk]);
+        let k = rnd_bf16(&[b_, t, nk, dk]);
+        let v = rnd_bf16(&[b_, t, nv, dv]);
+        let a = rnd_bf16(&[b_, t, nv]);
+        let beta = rnd_bf16(&[b_, t, nv]);
+        let a_log = Array::zeros::<f32>(&[nv]).unwrap();
+        let dt_bias = Array::zeros::<f32>(&[nv]).unwrap();
+        let s0 = Array::zeros::<f32>(&[b_, nv, dv, dk]).unwrap();
+
+        let (y_plain, st_plain) = gated_delta_kernel_ffi(
+            &q, &k, &v, &a_log, &a, &dt_bias, &beta, &s0, b_, t, nk, dk, nv, dv,
+        )
+        .unwrap();
+        let (y_tape, st_tape, _tape) = gated_delta_kernel_ffi_with_tape(
+            &q, &k, &v, &a_log, &a, &dt_bias, &beta, &s0, b_, t, nk, dk, nv, dv,
+        )
+        .unwrap();
+
+        let dmax = |x: &Array, y: &Array| -> f32 {
+            x.as_dtype(Dtype::Float32)
+                .unwrap()
+                .subtract(&y.as_dtype(Dtype::Float32).unwrap())
+                .unwrap()
+                .abs()
+                .unwrap()
+                .max(None)
+                .unwrap()
+                .item()
+        };
+        let y_diff = dmax(&y_plain, &y_tape);
+        let st_diff = dmax(&st_plain, &st_tape);
+        eprintln!("tape-vs-plain bf16: y_max_diff={y_diff:.2e} state_max_diff={st_diff:.2e}");
+        // y is stored bf16 in both kernels → identical. State is f32 in both →
+        // identical. Anything above bf16 epsilon means a precision divergence.
+        assert!(y_diff < 1e-2, "tape y differs from plain by {y_diff}");
+        assert!(st_diff < 1e-4, "tape state differs from plain by {st_diff}");
     }
 
     /// P2a gate (cost): rollback must be cheap vs recompute, or partial accepts

--- a/crates/higgs/src/config.rs
+++ b/crates/higgs/src/config.rs
@@ -414,6 +414,9 @@ pub struct ModelConfig {
     /// Seed used by `TurboQuant` setup.
     #[serde(default)]
     pub kv_seed: u64,
+    /// Optional path to a DFlash drafter (simple engine); overrides HIGGS_DFLASH_PATH.
+    #[serde(default)]
+    pub draft_model: Option<String>,
 }
 
 const fn default_norm_correction() -> bool {
@@ -666,6 +669,7 @@ pub fn build_simple_config(args: &ServeArgs) -> Result<HiggsConfig, String> {
             kv_norm_correction: !args.kv_no_norm_correction,
             kv_adaptive_dense_layers: args.kv_adaptive_dense_layers.unwrap_or(0),
             kv_seed: args.kv_seed.unwrap_or_default(),
+            draft_model: None,
         })
         .collect();
 
@@ -753,6 +757,7 @@ pub fn load_config_file(path: &Path, args: Option<&ServeArgs>) -> Result<HiggsCo
                     kv_norm_correction: !serve_args.kv_no_norm_correction,
                     kv_adaptive_dense_layers: serve_args.kv_adaptive_dense_layers.unwrap_or(0),
                     kv_seed: serve_args.kv_seed.unwrap_or_default(),
+                    draft_model: None,
                 })
                 .collect();
             let mut existing = figment
@@ -924,6 +929,7 @@ fn ensure_auto_router_model(config: &mut HiggsConfig) {
         kv_norm_correction: true,
         kv_adaptive_dense_layers: 0,
         kv_seed: 0,
+        draft_model: None,
     });
     config.auto_router.model = name;
 }

--- a/crates/higgs/src/doctor.rs
+++ b/crates/higgs/src/doctor.rs
@@ -284,6 +284,24 @@ fn check_models(config: &HiggsConfig, result: &mut DoctorResult) {
             );
             continue;
         }
+        if let Some(ref drafter) = model.draft_model {
+            if !std::path::Path::new(drafter).exists() {
+                fail(
+                    &format!("model {label} draft_model path does not exist: {drafter}"),
+                    result,
+                );
+                continue;
+            }
+            if model.batch {
+                fail(
+                    &format!(
+                        "model {label} sets draft_model but DFlash is simple-engine only (batch=true)"
+                    ),
+                    result,
+                );
+                continue;
+            }
+        }
         match model_resolver::resolve(&model.path) {
             Ok(resolved) => {
                 if model.batch {
@@ -598,6 +616,7 @@ mod tests {
                     kv_cache: higgs_models::turboquant::KvCacheMode::Off,
                     kv_bits: 3,
                     kv_seed: 0,
+                    draft_model: None,
                     kv_key_bits: None,
                     kv_value_bits: None,
                     kv_norm_correction: true,
@@ -611,6 +630,7 @@ mod tests {
                     kv_cache: higgs_models::turboquant::KvCacheMode::Off,
                     kv_bits: 3,
                     kv_seed: 0,
+                    draft_model: None,
                     kv_key_bits: None,
                     kv_value_bits: None,
                     kv_norm_correction: true,
@@ -637,6 +657,7 @@ mod tests {
                     kv_cache: higgs_models::turboquant::KvCacheMode::Off,
                     kv_bits: 3,
                     kv_seed: 0,
+                    draft_model: None,
                     kv_key_bits: None,
                     kv_value_bits: None,
                     kv_norm_correction: true,
@@ -650,6 +671,7 @@ mod tests {
                     kv_cache: higgs_models::turboquant::KvCacheMode::Off,
                     kv_bits: 3,
                     kv_seed: 0,
+                    draft_model: None,
                     kv_key_bits: None,
                     kv_value_bits: None,
                     kv_norm_correction: true,
@@ -1125,6 +1147,7 @@ mod tests {
                 kv_cache: higgs_models::turboquant::KvCacheMode::Off,
                 kv_bits: 3,
                 kv_seed: 0,
+                draft_model: None,
                 kv_key_bits: None,
                 kv_value_bits: None,
                 kv_norm_correction: true,
@@ -1155,6 +1178,7 @@ mod tests {
                 kv_cache: higgs_models::turboquant::KvCacheMode::Off,
                 kv_bits: 3,
                 kv_seed: 0,
+                draft_model: None,
                 kv_key_bits: None,
                 kv_value_bits: None,
                 kv_norm_correction: true,
@@ -1187,6 +1211,7 @@ mod tests {
                 kv_cache: higgs_models::turboquant::KvCacheMode::Off,
                 kv_bits: 3,
                 kv_seed: 0,
+                draft_model: None,
                 kv_key_bits: None,
                 kv_value_bits: None,
                 kv_norm_correction: true,

--- a/crates/higgs/src/doctor.rs
+++ b/crates/higgs/src/doctor.rs
@@ -262,6 +262,57 @@ fn model_label(model: &crate::config::ModelConfig) -> String {
     )
 }
 
+fn validate_dflash_drafter_dir(path: &std::path::Path) -> Result<(), String> {
+    if !path.exists() {
+        return Err("path does not exist".to_owned());
+    }
+    if !path.is_dir() {
+        return Err("path is not a directory".to_owned());
+    }
+
+    let config_path = path.join("config.json");
+    if !config_path.is_file() {
+        return Err("missing config.json".to_owned());
+    }
+    let config = std::fs::read_to_string(&config_path)
+        .map_err(|err| format!("cannot read config.json: {err}"))?;
+    serde_json::from_str::<higgs_models::dflash::DFlashConfig>(&config)
+        .map_err(|err| format!("cannot parse DFlash config.json: {err}"))?;
+
+    if path.join("model.safetensors").is_file() {
+        return Ok(());
+    }
+
+    let index_path = path.join("model.safetensors.index.json");
+    if !index_path.is_file() {
+        return Err("missing model.safetensors or model.safetensors.index.json".to_owned());
+    }
+
+    let index_json = std::fs::read_to_string(&index_path)
+        .map_err(|err| format!("cannot read model.safetensors.index.json: {err}"))?;
+    let index_value: serde_json::Value = serde_json::from_str(&index_json)
+        .map_err(|err| format!("cannot parse model.safetensors.index.json: {err}"))?;
+    let weight_map = index_value
+        .get("weight_map")
+        .and_then(serde_json::Value::as_object)
+        .ok_or_else(|| "model.safetensors.index.json missing weight_map".to_owned())?;
+    if weight_map.is_empty() {
+        return Err("model.safetensors.index.json has empty weight_map".to_owned());
+    }
+    for file in weight_map.values() {
+        let file = file.as_str().ok_or_else(|| {
+            "model.safetensors.index.json weight_map contains a non-string file name".to_owned()
+        })?;
+        if !path.join(file).is_file() {
+            return Err(format!(
+                "missing safetensors shard referenced by index: {file}"
+            ));
+        }
+    }
+
+    Ok(())
+}
+
 fn check_models(config: &HiggsConfig, result: &mut DoctorResult) {
     for model in &config.models {
         let label = model_label(model);
@@ -285,9 +336,11 @@ fn check_models(config: &HiggsConfig, result: &mut DoctorResult) {
             continue;
         }
         if let Some(ref drafter) = model.draft_model {
-            if !std::path::Path::new(drafter).exists() {
+            if let Err(err) = validate_dflash_drafter_dir(std::path::Path::new(drafter)) {
                 fail(
-                    &format!("model {label} draft_model path does not exist: {drafter}"),
+                    &format!(
+                        "model {label} draft_model is not a valid DFlash drafter directory ({drafter}): {err}"
+                    ),
                     result,
                 );
                 continue;
@@ -573,6 +626,25 @@ mod tests {
         }
     }
 
+    fn write_valid_dflash_config(dir: &std::path::Path) {
+        std::fs::write(
+            dir.join("config.json"),
+            r#"{
+                "hidden_size": 2048,
+                "num_hidden_layers": 6,
+                "num_attention_heads": 16,
+                "num_key_value_heads": 4,
+                "intermediate_size": 11008,
+                "vocab_size": 248064,
+                "dflash_config": {
+                    "target_layer_ids": [1, 6, 11, 16, 22, 27, 32, 37],
+                    "mask_token_id": 248077
+                }
+            }"#,
+        )
+        .unwrap();
+    }
+
     // -- Helper function counter tests --
 
     #[test]
@@ -600,6 +672,39 @@ mod tests {
         assert_eq!(result.passes, 0);
         assert_eq!(result.warnings, 0);
         assert_eq!(result.failures, 1);
+    }
+
+    #[test]
+    fn dflash_drafter_validation_accepts_single_safetensors_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        write_valid_dflash_config(dir.path());
+        std::fs::write(dir.path().join("model.safetensors"), b"weights").unwrap();
+
+        assert!(validate_dflash_drafter_dir(dir.path()).is_ok());
+    }
+
+    #[test]
+    fn dflash_drafter_validation_rejects_file_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("drafter");
+        std::fs::write(&file, b"not a directory").unwrap();
+
+        let err = validate_dflash_drafter_dir(&file).unwrap_err();
+        assert!(err.contains("not a directory"));
+    }
+
+    #[test]
+    fn dflash_drafter_validation_rejects_missing_index_shard() {
+        let dir = tempfile::tempdir().unwrap();
+        write_valid_dflash_config(dir.path());
+        std::fs::write(
+            dir.path().join("model.safetensors.index.json"),
+            r#"{"weight_map":{"layer.weight":"missing.safetensors"}}"#,
+        )
+        .unwrap();
+
+        let err = validate_dflash_drafter_dir(dir.path()).unwrap_err();
+        assert!(err.contains("missing safetensors shard"));
     }
 
     // -- Duplicate model detection --

--- a/crates/higgs/src/main.rs
+++ b/crates/higgs/src/main.rs
@@ -293,6 +293,7 @@ fn load_engines(
                 kv_cache_config,
                 tuning,
                 config.local.raise_wired_limit,
+                model_cfg.draft_model.as_deref().map(Path::new),
             )?
         };
         let name = model_cfg

--- a/crates/higgs/src/state.rs
+++ b/crates/higgs/src/state.rs
@@ -31,8 +31,9 @@ impl Engine {
         kv_cache_config: KvCacheConfig,
         tuning: MlxRuntimeTuning,
         raise_wired_limit: bool,
+        draft_model: Option<&Path>,
     ) -> Result<Self, EngineError> {
-        SimpleEngine::load(dir, kv_cache_config, tuning, raise_wired_limit)
+        SimpleEngine::load_with_dflash(dir, kv_cache_config, tuning, raise_wired_limit, draft_model)
             .map(|e| Self::Simple(Box::new(e)))
     }
 

--- a/crates/higgs/src/tui/mod.rs
+++ b/crates/higgs/src/tui/mod.rs
@@ -653,6 +653,7 @@ mod tests {
                 kv_value_bits: None,
                 kv_norm_correction: true,
                 kv_adaptive_dense_layers: 0,
+                draft_model: None,
             }],
             ..HiggsConfig::default()
         }

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -93,6 +93,141 @@ OpenAI-compatible server with Qwen thinking disabled via
 `draft-mtp` depth 2. On this run, Higgs MTP draft depth 2 was `1.05x` faster
 than llama.cpp `draft-mtp` depth 2 at the request level.
 
+## DFlash Speculative Decoding
+
+DFlash pairs the target model with a small tap-fed drafter (hidden states tapped
+from a handful of target layers feed a lightweight head that proposes a block of
+tokens, which the target then verifies in one batched pass). Higgs is, as far as
+we know, the first Rust+MLX DFlash engine; on its strong workloads it matches the
+acceptance of the community Python-MLX ports.
+
+### Characterization is by output entropy, not task label
+
+The single best predictor of DFlash acceptance is the **target's output entropy**,
+not the task name. The `dflash_entropy_sweep` harness (`#[ignore]`,
+`crates/higgs-engine/src/simple.rs`) measures, per prompt and gate-OFF (raw
+drafter capability): mean top-50 Shannon entropy of the target's greedy
+distribution (`H_bits`), top-1 probability, and the per-round accepted-token
+count (`accept_mean` + p10/p50/p90 + `accept_frac = accept_mean / block_size`).
+`byte_exact` flags whether the DFlash stream is prefix-consistent with the plain
+greedy AR stream.
+
+Reproduce (set the target + drafter dirs; `block_size` defaults to 16,
+`MAX_TOKENS=160`, `temperature=0`, thinking OFF):
+
+```bash
+HIGGS_DFLASH_TARGET_DIR=<target-mlx-dir> \
+HIGGS_DFLASH_DRAFTER_DIR=<dflash-drafter-dir> \
+cargo test --release -p higgs-engine dflash_entropy_sweep -- --ignored --nocapture
+```
+
+`accept_len`, entropy, and `byte_exact` are **thermal-independent** and carry the
+characterization. Absolute tok/s on a laptop is thermally confounded (this
+harness reloads the model several times and runs 16K-token prefills, so its
+per-row tok/s swings widely and is not used for headline numbers); derive speedup
+analytically from `accept_len` and use only paired AR/DFlash back-to-back runs on
+a non-throttling machine for tok/s.
+
+### Measured: accept_len vs entropy (M4 Max 128GB, `temperature=0`, 160 tokens)
+
+**Qwen3.6-35B-A3B-4bit (MoE) + `modal-labs/Qwen3.6-35B-A3B-DFlash`** — block 16:
+
+| task | H_bits | top1_prob | accept_mean | p10 | p50 | p90 | accept_frac | byte_exact |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| count 1..200 | 0.006 | 0.997 | 14.82 | 16 | 16 | 16 | 0.926 | true |
+| multiplication tables | 0.014 | 0.997 | 14.33 | 9 | 16 | 16 | 0.896 | true |
+| fixed-schema JSON | 0.019 | 0.994 | 14.00 | 10 | 16 | 16 | 0.875 | true |
+| capitals list | 0.032 | 0.992 | 7.17 | 3 | 8 | 9 | 0.448 | false |
+| struct getters | 0.041 | 0.989 | 7.90 | 2 | 6 | 16 | 0.494 | true |
+| iterative sort | 0.106 | 0.973 | 8.47 | 2 | 6 | 16 | 0.530 | true |
+| CSV table | 0.142 | 0.964 | 6.31 | 1 | 5 | 12 | 0.394 | true |
+| EN-FR translation | 0.154 | 0.971 | 2.79 | 1 | 3 | 4 | 0.174 | true |
+| unit conversion | 0.205 | 0.945 | 5.23 | 2 | 4 | 10 | 0.327 | false |
+| GSM8K word problem | 0.209 | 0.945 | 6.68 | 1 | 5 | 15 | 0.417 | false |
+| photosynthesis | 0.695 | 0.842 | 2.37 | 1 | 2 | 4 | 0.148 | false |
+| short story | 1.082 | 0.762 | 1.90 | 1 | 2 | 3 | 0.119 | false |
+
+**Qwen3.5-9B-MLX-4bit (dense) + `modal-labs/Qwen3.5-9B-DFlash`** — block 16:
+
+| task | H_bits | top1_prob | accept_mean | p10 | p50 | p90 | accept_frac | byte_exact |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| count 1..200 | 0.006 | 0.998 | 14.73 | 16 | 16 | 16 | 0.920 | true |
+| multiplication tables | 0.019 | 0.997 | 14.91 | 14 | 16 | 16 | 0.932 | true |
+| fixed-schema JSON | 0.035 | 0.992 | 15.36 | 13 | 16 | 16 | 0.960 | true |
+| capitals list | 0.064 | 0.984 | 8.58 | 2 | 8 | 16 | 0.536 | true |
+| unit conversion | 0.143 | 0.963 | 6.33 | 2 | 5 | 11 | 0.396 | true |
+| EN-FR translation | 0.242 | 0.953 | 3.00 | 2 | 3 | 4 | 0.188 | true |
+| struct getters | 0.258 | 0.940 | 6.54 | 1 | 5 | 16 | 0.409 | false |
+| CSV table | 0.288 | 0.922 | 5.73 | 1 | 4 | 12 | 0.358 | true |
+| iterative sort | 0.366 | 0.906 | 6.07 | 2 | 5 | 16 | 0.380 | false |
+| GSM8K word problem | 0.440 | 0.889 | 4.77 | 1 | 3 | 10 | 0.298 | false |
+| photosynthesis | 0.811 | 0.829 | 3.12 | 1 | 2 | 5 | 0.195 | false |
+| short story | 1.494 | 0.687 | 2.19 | 1 | 2 | 3 | 0.137 | false |
+
+Three regimes, consistent across both models:
+
+- **Deterministic** (`H < 0.04` bits, top1 ≈ 0.99): `accept_mean` saturates the
+  block at 14–15.4, `accept_frac` 0.88–0.96, byte-exact. Counting, tables,
+  fixed-schema JSON.
+- **Structured / constrained** (`H` ≈ 0.04–0.4 bits): `accept_mean` 5–9. Code
+  skeletons, CSV/unit tables, capitals, worked arithmetic.
+- **Prose / open generation** (`H > 0.7` bits): `accept_mean` ≈ 1.9–3.1,
+  `accept_frac` ≈ 0.12–0.20. Exposition, translation, story.
+
+The two models share the curve shape; **their `accept_len`-vs-entropy curves
+nearly coincide** rather than the MoE sitting above the dense model. At the
+deterministic end the dense 9B is marginally higher (JSON 15.36 vs 14.00). MoE's
+practical edge is therefore **economic, not higher acceptance**: with ~3B active
+parameters per token its verify pass is far cheaper to amortize, so the same
+`accept_len` converts into more wall-clock speedup than on a dense target.
+
+### Analytic speedup
+
+Each speculative round commits `accept_len` tokens for ~one batched target verify
+pass; plain AR commits one token per target pass. Decode speedup is therefore
+bounded above by `accept_len` and realized as roughly
+
+```
+speedup ≈ accept_len / (1 + c_draft·block + c_verify)
+```
+
+where `c_draft` is drafter cost and `c_verify` the batched-verify overhead,
+both relative to one target decode step. On the MoE the denominator is near 1
+(cheap active-param verify + small DFlash head), so deterministic workloads
+approach the acceptance ceiling, while prose floors near parity — which is why
+the production gate disables speculation once measured acceptance collapses.
+Prior paired AR/DFlash spot-checks on a non-throttling run landed near **2×**
+plain-AR (≈1.3× over MTP) for the 35B on low-entropy code, and **~2.5×** for the
+9B on low-entropy math; this harness's per-row tok/s is thermally confounded and
+is not quoted as a headline.
+
+### Context depth does not erode acceptance — entropy does
+
+Low-entropy acceptance holds flat as prompt depth grows to 16K tokens, validating
+the drafter sliding-window port (eviction active above 4096, absolute RoPE
+offset). High-entropy prose stays floored at every depth. Depth is not the
+variable; entropy is.
+
+| task | model | 512 | 4096 | 16384 |
+| --- | --- | ---: | ---: | ---: |
+| multiplication (low H) | MoE 35B | 14.08 | 12.92 | 14.91 |
+| multiplication (low H) | dense 9B | 13.67 | 13.67 | 14.00 |
+| story (high H) | MoE 35B | 2.01 | 2.18 | 2.09 |
+| story (high H) | dense 9B | 2.24 | 2.11 | 2.25 |
+
+### Block size trades fraction for raw accepted tokens
+
+On a fixed mid-entropy task (iterative sort), a larger block commits more raw
+tokens per round (`accept_mean` rises) but at a falling `accept_frac` — the
+drafter runs past its predictable runway. Block 16 maximizes `accept_mean` here;
+smaller blocks raise `accept_frac` (less wasted draft) at lower absolute throughput.
+
+| block | MoE accept_mean / frac | dense accept_mean / frac |
+| ---: | ---: | ---: |
+| 4 | 3.81 / 0.952 | 3.53 / 0.883 |
+| 8 | 7.23 / 0.903 | 5.12 / 0.641 |
+| 16 | 8.47 / 0.530 | 6.07 / 0.380 |
+
 ## Iterations
 
 The harness compares five iterations:


### PR DESCRIPTION
## What

First Rust + MLX implementation of **DFlash speculative decoding** (tap-fed drafter → batched target verify) for Qwen3.6-35B-A3B (MoE) and Qwen3.5-9B (dense). On its strong workloads it matches the acceptance of the community Python-MLX DFlash ports.

Pipeline: hidden states tapped from a handful of target layers feed a small DFlash drafter that proposes a block of tokens; the target verifies the block in one batched pass; the accepted prefix is committed and rejected positions are rolled back. Qwen3Next GDN (linear-attention) state is made **bit-exact** across the multi-token verify via a tape-record/replay kernel.

Key pieces:
- `crates/higgs-models/src/dflash.rs` — drafter module (loads `modal-labs` DFlash weights), `accept_prefix`, drafter-cache crop.
- `crates/higgs-models/src/qwen3_next.rs` — `forward_with_taps` / `forward_with_taps_tape` / `replay_tape_rollback` + GDN tape kernels.
- `crates/higgs-engine/src/simple.rs` — draft-verify loop, entropy-adaptive block size, and an **auto-calibrated realized-speedup gate** that floors DFlash→plain-AR when speculation is actually slower than AR for the current text/thermal state (keeping AR regions byte-exact), plus a drafter sliding-window port for long context.
- `crates/higgs/src/config.rs` + `doctor.rs` — `draft_model` config field (simple engine only; doctor validates).

## Results

See `docs/benchmarking.md` → "DFlash Speculative Decoding". Acceptance is governed by the target's **output entropy**, not the task label. Three regimes, consistent across both models:
- Deterministic (H < 0.04 bits): `accept_len` 14–15.4, byte-exact.
- Structured / code (H 0.04–0.4): 5–9.
- Prose (H > 0.7): ~2–3 (the gate floors to ~parity).

`accept_len` / entropy / `byte_exact` are **thermal-independent** and carry the characterization; absolute tok/s is thermally confounded on a laptop and is not quoted as a headline.

## Reproduce (Apple Silicon + MLX required)

Models (public on HF): target `mlx-community/Qwen3.6-35B-A3B-4bit` (or `mlx-community/Qwen3.5-9B-MLX-4bit`) + drafter `modal-labs/Qwen3.6-35B-A3B-DFlash` (or `modal-labs/Qwen3.5-9B-DFlash`).

```bash
HIGGS_DFLASH_TARGET_DIR=<target-mlx-dir> HIGGS_DFLASH_DRAFTER_DIR=<dflash-drafter-dir> \
cargo test --release -p higgs-engine dflash_entropy_sweep -- --ignored --nocapture
```
Byte-exactness vs plain AR greedy: `dflash_matches_ar_greedy_and_reports_accept_len` (same env vars).

## Notes for review
- Large branch with progressive commits (P1→P5: drafter port → GDN tape bit-exactness → draft-verify loop → realized-speedup gate → sliding window → entropy-sweep harness) — reviewing commit-by-commit is easiest.
- DFlash is **simple-engine only** (incompatible with the batch engine).
- A follow-up PR adds per-request MTP/DFlash selection + DFlash streaming on top of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added DFlash speculative decoding to speed up token generation when a draft model is available and generation settings are compatible.
  * Exposed DFlash acceptance metrics (via a new getter) after generation runs.

* **Configuration**
  * Added optional per-model `draft_model` to enable DFlash; also supports discovery via `HIGGS_DFLASH_PATH` and block sizing via `HIGGS_DFLASH_BLOCK_SIZE`.

* **Validation**
  * Enhanced model “doctor” checks to verify draft-model directories and weight files.

* **Documentation**
  * Added a DFlash benchmarking guide with acceptance and speedup metrics.

* **Tests**
  * Updated DFlash-related benchmark/sweep coverage (ignored manual runs where applicable).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->