### PR TITLE
DFlash split 2: drafter module + tap APIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   test:
     name: Test
-    runs-on: macos-latest
+    runs-on: macos-15
     permissions:
       contents: read
 
@@ -39,7 +39,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: macos-latest
+    runs-on: macos-15
     permissions:
       contents: read
 
@@ -60,7 +60,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: macos-latest
+    runs-on: macos-15
     permissions:
       contents: read
 
@@ -85,7 +85,7 @@ jobs:
 
   msrv:
     name: MSRV
-    runs-on: macos-latest
+    runs-on: macos-15
     permissions:
       contents: read
 
@@ -106,7 +106,7 @@ jobs:
 
   coverage:
     name: Coverage
-    runs-on: macos-latest
+    runs-on: macos-15
     permissions:
       contents: read
 

--- a/crates/higgs-models/src/dflash.rs
+++ b/crates/higgs-models/src/dflash.rs
@@ -1,0 +1,747 @@
+//! `DFlash` block-diffusion drafter for speculative decoding.
+//!
+//! A 0.5B drafter that produces 16 draft tokens per round via a single
+//! non-causal forward pass. The Modal drafter checkpoints verified by the
+//! loader tests use 8 target-layer taps: `[1, 6, 11, 16, 22, 27, 32, 37]`.
+//!
+//! Architecture: 6 decoder layers with dual-stream attention —
+//! Q from noise embedding, K/V from `concat(target_hidden, noise)`.
+//! No `embed_tokens` or `lm_head` — uses the target model's `lm_head`.
+//!
+//! Reference checkpoints: `modal-labs/Qwen3.6-35B-A3B-DFlash` and
+//! `modal-labs/Qwen3.5-9B-DFlash`.
+use std::path::Path;
+
+use mlx_rs::{
+    Array, builder::Builder, error::Exception, macros::ModuleParameters, module::Module, nn, ops,
+};
+use serde::Deserialize;
+
+use crate::{error::ModelError, utils::apply_rope};
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Deserialize)]
+struct DFlashSubConfig {
+    target_layer_ids: Vec<usize>,
+    #[serde(default)]
+    mask_token_id: Option<i32>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DFlashConfig {
+    pub hidden_size: i32,
+    pub num_hidden_layers: i32,
+    pub num_attention_heads: i32,
+    pub num_key_value_heads: i32,
+    #[serde(default = "default_head_dim")]
+    pub head_dim: i32,
+    pub intermediate_size: i32,
+    #[serde(default = "default_rms_norm_eps")]
+    pub rms_norm_eps: f32,
+    #[serde(default = "default_rope_theta")]
+    pub rope_theta: f32,
+    #[serde(default = "default_block_size")]
+    pub block_size: i32,
+    pub vocab_size: i32,
+    #[serde(default)]
+    pub layer_types: Option<Vec<String>>,
+    #[serde(default)]
+    pub sliding_window: Option<i32>,
+    dflash_config: DFlashSubConfig,
+}
+
+impl DFlashConfig {
+    pub fn target_layer_ids(&self) -> &[usize] {
+        &self.dflash_config.target_layer_ids
+    }
+
+    pub const fn num_taps(&self) -> usize {
+        self.dflash_config.target_layer_ids.len()
+    }
+
+    pub fn mask_token_id(&self) -> i32 {
+        self.dflash_config.mask_token_id.unwrap_or(248_070)
+    }
+}
+
+const fn default_head_dim() -> i32 {
+    128
+}
+
+const fn default_rms_norm_eps() -> f32 {
+    1e-6
+}
+
+const fn default_rope_theta() -> f32 {
+    1e7
+}
+
+const fn default_block_size() -> i32 {
+    16
+}
+
+/// Runtime decode `block_size` used at inference.
+///
+/// Overridable via `HIGGS_DFLASH_BLOCK_SIZE`. Diverges from the drafter's
+/// trained `block_size` (16) because acceptance rate plateaus at ~3 tokens
+/// and smaller blocks amortize verify cost better.
+pub const DEFAULT_DECODE_BLOCK_SIZE: i32 = 4;
+
+// ---------------------------------------------------------------------------
+// SwiGLU MLP (non-quantized)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, ModuleParameters)]
+struct DFlashMLP {
+    #[param]
+    gate_proj: nn::Linear,
+    #[param]
+    up_proj: nn::Linear,
+    #[param]
+    down_proj: nn::Linear,
+}
+
+impl DFlashMLP {
+    fn new(hidden_size: i32, intermediate_size: i32) -> Result<Self, Exception> {
+        Ok(Self {
+            gate_proj: nn::LinearBuilder::new(hidden_size, intermediate_size)
+                .bias(false)
+                .build()?,
+            up_proj: nn::LinearBuilder::new(hidden_size, intermediate_size)
+                .bias(false)
+                .build()?,
+            down_proj: nn::LinearBuilder::new(intermediate_size, hidden_size)
+                .bias(false)
+                .build()?,
+        })
+    }
+
+    fn forward(&mut self, x: &Array) -> Result<Array, Exception> {
+        let gate = self.gate_proj.forward(x)?;
+        let up = self.up_proj.forward(x)?;
+        let activated = nn::sigmoid(&gate)?.multiply(&gate)?.multiply(&up)?;
+        self.down_proj.forward(&activated)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DFlash dual-stream attention
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, ModuleParameters)]
+struct DFlashAttention {
+    #[param]
+    q_proj: nn::Linear,
+    #[param]
+    k_proj: nn::Linear,
+    #[param]
+    v_proj: nn::Linear,
+    #[param]
+    o_proj: nn::Linear,
+    #[param]
+    q_norm: nn::RmsNorm,
+    #[param]
+    k_norm: nn::RmsNorm,
+    #[param]
+    rope: nn::Rope,
+    num_attention_heads: i32,
+    num_key_value_heads: i32,
+    head_dim: i32,
+    scale: f32,
+    is_sliding: bool,
+    sliding_window: i32,
+}
+
+impl DFlashAttention {
+    fn new(config: &DFlashConfig, layer_idx: usize) -> Result<Self, Exception> {
+        let head_dim = config.head_dim;
+        let n_heads = config.num_attention_heads;
+        let n_kv_heads = config.num_key_value_heads;
+        let hidden = config.hidden_size;
+        let is_sliding = config
+            .layer_types
+            .as_ref()
+            .and_then(|lt| lt.get(layer_idx))
+            .is_some_and(|t| t == "sliding_attention");
+        let sliding_window = config.sliding_window.unwrap_or(0);
+
+        Ok(Self {
+            q_proj: nn::LinearBuilder::new(hidden, n_heads * head_dim)
+                .bias(false)
+                .build()?,
+            k_proj: nn::LinearBuilder::new(hidden, n_kv_heads * head_dim)
+                .bias(false)
+                .build()?,
+            v_proj: nn::LinearBuilder::new(hidden, n_kv_heads * head_dim)
+                .bias(false)
+                .build()?,
+            o_proj: nn::LinearBuilder::new(n_heads * head_dim, hidden)
+                .bias(false)
+                .build()?,
+            q_norm: nn::RmsNormBuilder::new(head_dim)
+                .eps(config.rms_norm_eps)
+                .build()?,
+            k_norm: nn::RmsNormBuilder::new(head_dim)
+                .eps(config.rms_norm_eps)
+                .build()?,
+            rope: nn::RopeBuilder::new(head_dim)
+                .traditional(false)
+                .base(config.rope_theta)
+                .scale(1.0)
+                .build()
+                .map_err(|e| Exception::custom(format!("Failed to build RoPE: {e}")))?,
+            num_attention_heads: n_heads,
+            num_key_value_heads: n_kv_heads,
+            head_dim,
+            scale: f32::from(
+                i16::try_from(head_dim)
+                    .map_err(|_| Exception::custom("head_dim out of i16 range"))?,
+            )
+            .sqrt()
+            .recip(),
+            is_sliding,
+            sliding_window,
+        })
+    }
+
+    /// Dual-stream attention: Q from noise, K/V from `concat(target, noise)`.
+    ///
+    /// `noise`: `[B, block_size, hidden]` — the 16 draft positions.
+    /// `target_hidden`: `[B, ctx_len, hidden]` — projected+normed tap states.
+    /// `cache`: optional (K, V) from prior rounds, shape `[B, n_kv, cached_len, head_dim]`.
+    ///   Post-RoPE K and raw V. Updated in-place with the new K/V appended.
+    /// `cache_offset`: absolute position offset for `RoPE` (= cached seq length).
+    #[allow(non_snake_case, clippy::shadow_reuse)]
+    fn forward(
+        &mut self,
+        noise: &Array,
+        target_hidden: &Array,
+        cache: &mut Option<(Array, Array)>,
+        cache_offset: i32,
+    ) -> Result<Array, Exception> {
+        use mlx_rs::ops::indexing::IndexOp;
+
+        let B = *noise
+            .shape()
+            .first()
+            .ok_or_else(|| Exception::custom("need 3D"))?;
+        let q_len = *noise
+            .shape()
+            .get(1)
+            .ok_or_else(|| Exception::custom("need 3D"))?;
+        let ctx_len = *target_hidden
+            .shape()
+            .get(1)
+            .ok_or_else(|| Exception::custom("need 3D"))?;
+        // Q from noise only
+        let q = self.q_proj.forward(noise)?;
+        let q = q.reshape(&[B, q_len, self.num_attention_heads, self.head_dim])?;
+        let q = self.q_norm.forward(&q)?.transpose_axes(&[0, 2, 1, 3])?;
+
+        // K/V from context (target_hidden) — SEPARATE from noise
+        let ctx_k = self.k_proj.forward(target_hidden)?;
+        let ctx_v = self.v_proj.forward(target_hidden)?;
+        let ctx_k = ctx_k.reshape(&[B, ctx_len, self.num_key_value_heads, self.head_dim])?;
+        let ctx_k = self.k_norm.forward(&ctx_k)?.transpose_axes(&[0, 2, 1, 3])?;
+        let ctx_v = ctx_v
+            .reshape(&[B, ctx_len, self.num_key_value_heads, self.head_dim])?
+            .transpose_axes(&[0, 2, 1, 3])?;
+
+        // K/V from noise — freshly computed every round, never cached
+        let noise_k = self.k_proj.forward(noise)?;
+        let noise_v = self.v_proj.forward(noise)?;
+        let noise_k = noise_k.reshape(&[B, q_len, self.num_key_value_heads, self.head_dim])?;
+        let noise_k = self
+            .k_norm
+            .forward(&noise_k)?
+            .transpose_axes(&[0, 2, 1, 3])?;
+        let noise_v = noise_v
+            .reshape(&[B, q_len, self.num_key_value_heads, self.head_dim])?
+            .transpose_axes(&[0, 2, 1, 3])?;
+
+        // RoPE with absolute positions:
+        // Context K: [cache_offset .. cache_offset + ctx_len]
+        // Noise K + Q: [cache_offset + ctx_len .. cache_offset + ctx_len + q_len]
+        let q = apply_rope(&q, &self.rope, cache_offset + ctx_len)?;
+        let ctx_k = apply_rope(&ctx_k, &self.rope, cache_offset)?;
+        let noise_k = apply_rope(&noise_k, &self.rope, cache_offset + ctx_len)?;
+
+        // Cache stores ONLY context K/V (append to prior rounds)
+        let (ctx_k, ctx_v) = if let Some((k_cached, v_cached)) = cache.as_ref() {
+            (
+                ops::concatenate_axis(&[k_cached, &ctx_k], 2)?,
+                ops::concatenate_axis(&[v_cached, &ctx_v], 2)?,
+            )
+        } else {
+            (ctx_k, ctx_v)
+        };
+        let (ctx_k, ctx_v) = if self.is_sliding && self.sliding_window > 1 {
+            let keep = self.sliding_window - 1;
+            let len = ctx_k.shape().get(2).copied().unwrap_or(0);
+            if len > keep {
+                let skip = len - keep;
+                (
+                    ctx_k.index((.., .., skip.., ..)),
+                    ctx_v.index((.., .., skip.., ..)),
+                )
+            } else {
+                (ctx_k, ctx_v)
+            }
+        } else {
+            (ctx_k, ctx_v)
+        };
+        *cache = Some((ctx_k.clone(), ctx_v.clone()));
+
+        // Attention over cached_context + fresh_noise
+        let k = ops::concatenate_axis(&[&ctx_k, &noise_k], 2)?;
+        let v = ops::concatenate_axis(&[&ctx_v, &noise_v], 2)?;
+
+        // Non-causal SDPA (no mask)
+        let output = mlx_rs::fast::scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            self.scale,
+            None::<mlx_rs::fast::ScaledDotProductAttentionMask>,
+            None::<&Array>,
+        )?;
+
+        // [B, n_heads, q_len, head_dim] -> [B, q_len, n_heads * head_dim]
+        let output = output.transpose_axes(&[0, 2, 1, 3])?;
+        let output = output.reshape(&[B, q_len, -1])?;
+        self.o_proj.forward(&output)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DFlash decoder layer
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, ModuleParameters)]
+struct DFlashDecoderLayer {
+    #[param]
+    self_attn: DFlashAttention,
+    #[param]
+    mlp: DFlashMLP,
+    #[param]
+    input_layernorm: nn::RmsNorm,
+    #[param]
+    post_attention_layernorm: nn::RmsNorm,
+}
+
+impl DFlashDecoderLayer {
+    fn new(config: &DFlashConfig, layer_idx: usize) -> Result<Self, Exception> {
+        Ok(Self {
+            self_attn: DFlashAttention::new(config, layer_idx)?,
+            mlp: DFlashMLP::new(config.hidden_size, config.intermediate_size)?,
+            input_layernorm: nn::RmsNormBuilder::new(config.hidden_size)
+                .eps(config.rms_norm_eps)
+                .build()?,
+            post_attention_layernorm: nn::RmsNormBuilder::new(config.hidden_size)
+                .eps(config.rms_norm_eps)
+                .build()?,
+        })
+    }
+
+    fn forward(
+        &mut self,
+        noise: &Array,
+        target_hidden: &Array,
+        cache: &mut Option<(Array, Array)>,
+        cache_offset: i32,
+    ) -> Result<Array, Exception> {
+        let normed = self.input_layernorm.forward(noise)?;
+        let attn_out = self
+            .self_attn
+            .forward(&normed, target_hidden, cache, cache_offset)?;
+        let h = noise.add(attn_out)?;
+        let normed_post = self.post_attention_layernorm.forward(&h)?;
+        let mlp_out = self.mlp.forward(&normed_post)?;
+        h.add(mlp_out)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DFlash drafter (top-level)
+// ---------------------------------------------------------------------------
+
+/// `DFlash` block-diffusion drafter.
+///
+/// Produces `block_size` (16) draft tokens per round. Does NOT have its own
+/// `embed_tokens` or `lm_head` — uses the target model's `lm_head` on the output.
+#[derive(Debug, ModuleParameters)]
+pub struct DFlashDrafter {
+    #[param]
+    fc: nn::Linear,
+    #[param]
+    hidden_norm: nn::RmsNorm,
+    #[param]
+    layers: Vec<DFlashDecoderLayer>,
+    #[param]
+    norm: nn::RmsNorm,
+    pub config: DFlashConfig,
+}
+
+impl DFlashDrafter {
+    pub fn new(config: DFlashConfig) -> Result<Self, Exception> {
+        let fc_in = i32::try_from(config.num_taps())
+            .map_err(|e| Exception::custom(format!("num_taps too large for i32: {e}")))?
+            * config.hidden_size;
+        let layers = (0..config.num_hidden_layers)
+            .map(|i| DFlashDecoderLayer::new(&config, usize::try_from(i).unwrap_or(0)))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Self {
+            fc: nn::LinearBuilder::new(fc_in, config.hidden_size)
+                .bias(false)
+                .build()?,
+            hidden_norm: nn::RmsNormBuilder::new(config.hidden_size)
+                .eps(config.rms_norm_eps)
+                .build()?,
+            layers,
+            norm: nn::RmsNormBuilder::new(config.hidden_size)
+                .eps(config.rms_norm_eps)
+                .build()?,
+            config,
+        })
+    }
+
+    /// Create an empty per-layer KV cache for the drafter.
+    pub fn make_cache(&self) -> Vec<Option<(Array, Array)>> {
+        vec![None; self.layers.len()]
+    }
+
+    /// Run the drafter forward pass.
+    ///
+    /// - `noise`: `[B, block_size, hidden_size]` — embedded block tokens.
+    /// - `taps`: slice of hidden states from the target model at tap layers,
+    ///   each `[B, T, target_hidden_size]`. Concatenated along the last dim,
+    ///   projected via `fc`, then normalized.
+    /// - `cache`: per-layer KV cache. Grows each round; crop after verify.
+    ///
+    /// Returns `[B, block_size, hidden_size]` — pass to target's `lm_head` for logits.
+    #[allow(non_snake_case)]
+    pub fn forward(
+        &mut self,
+        noise: &Array,
+        taps: &[Array],
+        cache: &mut [Option<(Array, Array)>],
+    ) -> Result<Array, Exception> {
+        if taps.len() != self.config.num_taps() {
+            return Err(Exception::custom(format!(
+                "expected {} taps, got {}",
+                self.config.num_taps(),
+                taps.len()
+            )));
+        }
+
+        // Cache offset = max cached seq length (0 on first round)
+        let cache_offset = cache
+            .iter()
+            .filter_map(|c| c.as_ref())
+            .filter_map(|(k, _)| k.shape().get(2).copied())
+            .max()
+            .unwrap_or(0);
+
+        // Concatenate tap hidden states: [B, T, num_taps * hidden_size]
+        let tap_refs: Vec<&Array> = taps.iter().collect();
+        let target_cat = ops::concatenate_axis(&tap_refs, -1)?;
+
+        // Project + norm: [B, T, hidden_size]
+        let target_projected = self.fc.forward(&target_cat)?;
+        let target_hidden = self.hidden_norm.forward(&target_projected)?;
+
+        let mut h = noise.clone();
+        for (layer, lc) in self.layers.iter_mut().zip(cache.iter_mut()) {
+            h = layer.forward(&h, &target_hidden, lc, cache_offset)?;
+        }
+
+        self.norm.forward(&h)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GDN state save/restore for hybrid models (Qwen3.5)
+// ---------------------------------------------------------------------------
+
+/// Saved state for all GDN/linear-attention layers in the target model.
+///
+/// Much smaller than cloning the full KV cache — only stores `conv_state`,
+/// `ssm_state`, and offset for each `ArraysCache` layer.
+pub struct GdnStateBackup {
+    states: Vec<(Option<Array>, Option<Array>, i32)>,
+}
+
+impl GdnStateBackup {
+    /// Save GDN (`ArraysCache`) state from all layers. Call BEFORE verify forward.
+    /// KV layers are not saved — they use cheap offset-based rollback instead.
+    pub fn save(kv_cache: &[Option<crate::qwen3_next::LayerCache>]) -> Result<Self, Exception> {
+        let mut states = Vec::with_capacity(kv_cache.len());
+        for lc in kv_cache {
+            match lc {
+                Some(crate::qwen3_next::LayerCache::Arrays(ac)) => {
+                    ac.eval_arrays()?;
+                    states.push((ac.conv_state.clone(), ac.ssm_state.clone(), ac.offset));
+                }
+                _ => states.push((None, None, 0)),
+            }
+        }
+        Ok(Self { states })
+    }
+
+    /// Restore GDN state and rollback KV offsets. On rejection, call this
+    /// BEFORE re-running the accepted tokens.
+    pub fn restore_and_rollback(
+        &self,
+        kv_cache: &mut [Option<crate::qwen3_next::LayerCache>],
+        rollback: i32,
+    ) {
+        for (lc, (conv, ssm, offset)) in kv_cache.iter_mut().zip(self.states.iter()) {
+            match lc {
+                Some(crate::qwen3_next::LayerCache::Arrays(ac)) => {
+                    ac.conv_state.clone_from(conv);
+                    ac.ssm_state.clone_from(ssm);
+                    ac.offset = *offset;
+                }
+                Some(crate::qwen3_next::LayerCache::KV(kv)) if rollback > 0 => {
+                    kv.trim_by(rollback.unsigned_abs().try_into().unwrap_or(usize::MAX));
+                }
+                Some(crate::qwen3_next::LayerCache::KV(_)) | None => {}
+            }
+        }
+    }
+}
+
+/// Crop the drafter KV cache to `keep_len` along the sequence dim.
+///
+/// Called after verify to discard rejected positions.
+/// Cache tensors have shape `[B, n_kv_heads, seq_len, head_dim]`.
+pub fn crop_drafter_cache(cache: &mut [Option<(Array, Array)>], keep_len: i32) {
+    use mlx_rs::ops::indexing::IndexOp;
+    for (k, v) in cache.iter_mut().filter_map(Option::as_mut) {
+        *k = k.index((.., .., ..keep_len, ..));
+        *v = v.index((.., .., ..keep_len, ..));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Loading
+// ---------------------------------------------------------------------------
+
+/// Load a `DFlash` drafter from a directory containing `config.json` + `model.safetensors`.
+pub fn load_dflash_drafter(model_path: &Path) -> Result<DFlashDrafter, ModelError> {
+    let config_path = model_path.join("config.json");
+    let config_str = std::fs::read_to_string(&config_path)
+        .map_err(|e| ModelError::Io(std::io::Error::other(format!("reading config.json: {e}"))))?;
+    let config: DFlashConfig = serde_json::from_str(&config_str)
+        .map_err(|e| ModelError::Io(std::io::Error::other(format!("parsing config.json: {e}"))))?;
+
+    let mut drafter = DFlashDrafter::new(config)
+        .map_err(|e| ModelError::Io(std::io::Error::other(e.to_string())))?;
+
+    crate::load_safetensors_weights(&mut drafter, model_path)?;
+
+    Ok(drafter)
+}
+
+// ---------------------------------------------------------------------------
+// Speculative-decode acceptance helper
+// ---------------------------------------------------------------------------
+
+/// Greedy speculative-decode acceptance.
+///
+/// Compares each drafted token to the target's verified argmax. Accepts the
+/// longest matching prefix and appends one bonus token (the target's argmax at
+/// the position immediately after the rejected draft, or after the last accept
+/// if all tokens accepted).
+///
+/// Returns at least 1 token, at most `draft.len() + 1`.
+///
+/// # Panics in debug
+/// Panics if `verify_argmax.len() != draft.len() + 1`.
+pub fn accept_prefix(draft: &[u32], verify_argmax: &[u32]) -> Vec<u32> {
+    debug_assert_eq!(verify_argmax.len(), draft.len() + 1);
+
+    let accepted = draft
+        .iter()
+        .zip(verify_argmax.iter())
+        .take_while(|(d, v)| **d == **v)
+        .count();
+    let mut out: Vec<u32> = draft.get(..accepted).unwrap_or_default().to_vec();
+    if let Some(&bonus) = verify_argmax.get(accepted) {
+        out.push(bonus);
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+//
+// The full DFlash test suite (~3.8K lines, 30+ end-to-end tests covering the
+// draft-verify loop against a real target model) lives on `feat/magic-canvas`
+// and will be ported in a follow-up PR alongside the engine glue
+// (`SimpleEngine::generate_dflash_inner`).
+//
+// What's tested here: only the pure helpers (`accept_prefix`) — the
+// rest depends on MLX-loaded model weights which aren't part of unit-test
+// surface.
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::accept_prefix;
+
+    #[test]
+    fn accept_prefix_full_match_returns_draft_plus_bonus() {
+        let draft = vec![1, 2, 3];
+        let verify = vec![1, 2, 3, 4];
+        assert_eq!(accept_prefix(&draft, &verify), vec![1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn accept_prefix_first_token_rejects_returns_correction() {
+        let draft = vec![1, 2, 3];
+        let verify = vec![9, 5, 5, 5];
+        assert_eq!(accept_prefix(&draft, &verify), vec![9]);
+    }
+
+    #[test]
+    fn accept_prefix_partial_match_returns_prefix_plus_correction() {
+        let draft = vec![1, 2, 3];
+        let verify = vec![1, 2, 9, 0];
+        assert_eq!(accept_prefix(&draft, &verify), vec![1, 2, 9]);
+    }
+
+    #[test]
+    fn accept_prefix_empty_draft_returns_single_verify_token() {
+        let draft: Vec<u32> = vec![];
+        let verify = vec![42];
+        assert_eq!(accept_prefix(&draft, &verify), vec![42]);
+    }
+
+    #[test]
+    #[should_panic(expected = "left == right")]
+    fn accept_prefix_mismatched_lengths_panic_in_debug() {
+        let draft = vec![1, 2, 3];
+        let verify = vec![1, 2]; // wrong length
+        let _ = accept_prefix(&draft, &verify);
+    }
+
+    /// Sliding-window eviction: a tiny random drafter with layer 0 = sliding
+    /// (window 4) and layer 1 = full. Driving several rounds must cap the
+    /// sliding layer's context KV at `sliding_window - 1` while the full layer
+    /// accumulates all context — and the rope offset (max cache length across
+    /// layers) must keep advancing absolutely. No weights needed.
+    #[test]
+    fn sliding_layer_cache_caps_while_full_layer_grows() {
+        use super::{DFlashConfig, DFlashDrafter, DFlashSubConfig};
+        use mlx_rs::Array;
+
+        let hidden = 8i32;
+        let config = DFlashConfig {
+            hidden_size: hidden,
+            num_hidden_layers: 2,
+            num_attention_heads: 2,
+            num_key_value_heads: 1,
+            head_dim: 4,
+            intermediate_size: 16,
+            rms_norm_eps: 1e-6,
+            rope_theta: 1e7,
+            block_size: 4,
+            vocab_size: 32,
+            layer_types: Some(vec![
+                "sliding_attention".to_owned(),
+                "full_attention".to_owned(),
+            ]),
+            sliding_window: Some(4),
+            dflash_config: DFlashSubConfig {
+                target_layer_ids: vec![0],
+                mask_token_id: Some(1),
+            },
+        };
+        let mut drafter = DFlashDrafter::new(config).unwrap();
+        let mut cache = drafter.make_cache();
+
+        let ctx_len = 2i32; // context positions added per round
+        let rounds = 6;
+        let zeros = |t: i32| {
+            let n = usize::try_from(t * hidden).unwrap();
+            Array::from_slice(&vec![0f32; n], &[1, t, hidden])
+        };
+        for _ in 0..rounds {
+            let taps = vec![zeros(ctx_len)]; // num_taps = 1
+            let noise = zeros(4); // block_size noise positions
+            drafter.forward(&noise, &taps, &mut cache).unwrap();
+        }
+
+        let sliding_len = cache
+            .first()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .0
+            .shape()
+            .get(2)
+            .copied()
+            .unwrap();
+        let full_len = cache
+            .get(1)
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .0
+            .shape()
+            .get(2)
+            .copied()
+            .unwrap();
+        assert!(
+            sliding_len <= 3,
+            "sliding cache must cap at window-1=3, got {sliding_len}"
+        );
+        assert_eq!(
+            full_len,
+            ctx_len * rounds,
+            "full-attn cache must accumulate all {} context positions, got {full_len}",
+            ctx_len * rounds
+        );
+        assert!(
+            full_len > sliding_len,
+            "eviction must make the sliding cache shorter than the full one"
+        );
+    }
+
+    /// The "drop-in drafter, no MLX port" claim: the config-driven loader must
+    /// parse Modal's config.json and populate every module from Modal's bf16
+    /// safetensors by key name. Gated on the real weights dir.
+    #[test]
+    #[ignore = "load: set HIGGS_DFLASH_DRAFTER_DIR to the Modal drafter snapshot dir"]
+    #[allow(clippy::print_stderr)]
+    fn loads_modal_drafter_against_real_weights() {
+        let Ok(dir) = std::env::var("HIGGS_DFLASH_DRAFTER_DIR") else {
+            eprintln!("skip: set HIGGS_DFLASH_DRAFTER_DIR");
+            return;
+        };
+        let d = super::load_dflash_drafter(std::path::Path::new(&dir)).unwrap();
+        let c = &d.config;
+        assert_eq!(c.num_hidden_layers, 6, "layers");
+        assert_eq!(c.hidden_size, 2048, "hidden");
+        assert_eq!(c.num_taps(), 8, "taps");
+        assert_eq!(
+            c.target_layer_ids(),
+            &[1, 6, 11, 16, 22, 27, 32, 37],
+            "tap ids"
+        );
+        assert_eq!(c.mask_token_id(), 248_077, "mask token");
+        eprintln!(
+            "Modal drafter loaded OK: {} layers, hidden {}, {} taps, fc_in {}",
+            c.num_hidden_layers,
+            c.hidden_size,
+            c.num_taps(),
+            i32::try_from(c.num_taps()).unwrap() * c.hidden_size
+        );
+    }
+}

--- a/crates/higgs-models/src/lib.rs
+++ b/crates/higgs-models/src/lib.rs
@@ -866,6 +866,12 @@ impl AnyModel {
         cache: &mut AnyCache,
         tap_layers: &[usize],
     ) -> Result<(Array, Vec<Array>), Exception> {
+        if mask.is_some() {
+            return Err(Exception::custom(
+                "forward_with_taps does not support external masks",
+            ));
+        }
+
         match (self, cache) {
             (Self::Qwen3Next(m), AnyCache::Hybrid(c)) => {
                 m.forward_with_taps(inputs, mask, c, tap_layers)
@@ -884,6 +890,12 @@ impl AnyModel {
         cache: &mut AnyCache,
         tap_layers: &[usize],
     ) -> Result<TapsTapeOutput, Exception> {
+        if mask.is_some() {
+            return Err(Exception::custom(
+                "forward_with_taps_tape does not support external masks",
+            ));
+        }
+
         match (self, cache) {
             (Self::Qwen3Next(m), AnyCache::Hybrid(c)) => {
                 m.forward_with_taps_tape(inputs, mask, c, tap_layers)
@@ -907,8 +919,69 @@ impl AnyModel {
         n_accepted: i32,
         kv_rollback: i32,
     ) -> Result<(), Exception> {
+        if n_accepted < 0 {
+            return Err(Exception::custom(format!(
+                "replay_tape_rollback requires n_accepted >= 0, got {n_accepted}"
+            )));
+        }
+
+        if kv_rollback < 0 {
+            return Err(Exception::custom(format!(
+                "replay_tape_rollback requires kv_rollback >= 0, got {kv_rollback}"
+            )));
+        }
+
         match (self, cache) {
             (Self::Qwen3Next(m), AnyCache::Hybrid(c)) => {
+                if layer_tapes.len() != c.len() {
+                    return Err(Exception::custom(format!(
+                        "replay_tape_rollback layer_tapes length ({}) must match cache length ({})",
+                        layer_tapes.len(),
+                        c.len()
+                    )));
+                }
+
+                for (idx, (layer_cache, layer_tape)) in c.iter().zip(layer_tapes.iter()).enumerate()
+                {
+                    match (layer_cache, layer_tape) {
+                        (Some(LayerCache::Arrays(_)), Some(gdn_tape)) => {
+                            for (name, tensor) in [
+                                ("delta_tape", &gdn_tape.delta_tape),
+                                ("norm_k", &gdn_tape.norm_k),
+                                ("a_proj", &gdn_tape.a_proj),
+                            ] {
+                                let tape_len = *tensor.shape().get(1).ok_or_else(|| {
+                                    Exception::custom(format!(
+                                        "replay_tape_rollback layer {idx} {name} must have a sequence dimension"
+                                    ))
+                                })?;
+
+                                if n_accepted > tape_len {
+                                    return Err(Exception::custom(format!(
+                                        "replay_tape_rollback n_accepted ({n_accepted}) exceeds layer {idx} {name} sequence length ({tape_len})"
+                                    )));
+                                }
+                            }
+                        }
+                        (Some(LayerCache::Arrays(_)), None) => {
+                            return Err(Exception::custom(format!(
+                                "replay_tape_rollback missing GDN tape for Arrays cache layer {idx}"
+                            )));
+                        }
+                        (Some(LayerCache::KV(_)), Some(_)) => {
+                            return Err(Exception::custom(format!(
+                                "replay_tape_rollback got GDN tape for KV cache layer {idx}"
+                            )));
+                        }
+                        (None, Some(_)) => {
+                            return Err(Exception::custom(format!(
+                                "replay_tape_rollback got GDN tape for empty cache layer {idx}"
+                            )));
+                        }
+                        (Some(LayerCache::KV(_)) | None, None) => {}
+                    }
+                }
+
                 m.replay_tape_rollback(layer_tapes, c, n_accepted, kv_rollback)
             }
             _ => Err(Exception::custom(

--- a/crates/higgs-models/src/lib.rs
+++ b/crates/higgs-models/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod bonsai_q1;
 pub mod cache;
 pub mod deepseek_v2;
+pub mod dflash;
 pub mod error;
 pub mod gemma2;
 pub mod gemma3;

--- a/crates/higgs-models/src/lib.rs
+++ b/crates/higgs-models/src/lib.rs
@@ -150,6 +150,22 @@ impl AnyCache {
             ),
         }
     }
+
+    /// Borrow the inner hybrid (KV+SSM) cache slice; errors on a KV-only cache.
+    pub fn as_hybrid(&self) -> Result<&[Option<LayerCache>], Exception> {
+        match self {
+            Self::Hybrid(c) => Ok(c),
+            Self::KV(_) => Err(Exception::custom("expected Hybrid cache, got KV")),
+        }
+    }
+
+    /// Mutably borrow the inner hybrid cache vec; errors on a KV-only cache.
+    pub fn as_hybrid_mut(&mut self) -> Result<&mut Vec<Option<LayerCache>>, Exception> {
+        match self {
+            Self::Hybrid(c) => Ok(c),
+            Self::KV(_) => Err(Exception::custom("expected Hybrid cache, got KV")),
+        }
+    }
 }
 
 /// Independent deep copy of an MTP head cache (`Vec<SteppingKeyValueCache>`).
@@ -257,6 +273,9 @@ fn make_turboquant_kv_cache(
     }
     Ok(AnyCache::KV(caches))
 }
+
+/// Output of [`AnyModel::forward_with_taps_tape`]: logits, tap hiddens, per-layer GDN tape.
+pub type TapsTapeOutput = (Array, Vec<Array>, Vec<Option<qwen3_next::GdnLayerTape>>);
 
 impl AnyModel {
     pub fn forward(
@@ -835,6 +854,103 @@ impl AnyModel {
             }
             _ => Err(Exception::custom(
                 "Model does not support multimodal forward",
+            )),
+        }
+    }
+
+    /// `DFlash`: forward returning logits + hidden states at `tap_layers` (drafter input).
+    pub fn forward_with_taps(
+        &mut self,
+        inputs: &Array,
+        mask: Option<&Array>,
+        cache: &mut AnyCache,
+        tap_layers: &[usize],
+    ) -> Result<(Array, Vec<Array>), Exception> {
+        match (self, cache) {
+            (Self::Qwen3Next(m), AnyCache::Hybrid(c)) => {
+                m.forward_with_taps(inputs, mask, c, tap_layers)
+            }
+            _ => Err(Exception::custom(
+                "forward_with_taps requires Qwen3Next + Hybrid cache",
+            )),
+        }
+    }
+
+    /// `DFlash` verify: forward returning logits + tap hiddens + per-layer GDN tape (for cheap rollback).
+    pub fn forward_with_taps_tape(
+        &mut self,
+        inputs: &Array,
+        mask: Option<&Array>,
+        cache: &mut AnyCache,
+        tap_layers: &[usize],
+    ) -> Result<TapsTapeOutput, Exception> {
+        match (self, cache) {
+            (Self::Qwen3Next(m), AnyCache::Hybrid(c)) => {
+                m.forward_with_taps_tape(inputs, mask, c, tap_layers)
+            }
+            _ => Err(Exception::custom(
+                "forward_with_taps_tape requires Qwen3Next + Hybrid cache",
+            )),
+        }
+    }
+
+    /// Replay GDN innovation tape for accepted prefix on partial accept.
+    ///
+    /// Used by `DFlash` verify path: after partial acceptance, restore each
+    /// GDN layer's state from the tape's initial snapshot, replay only the
+    /// SSM recurrence kernel for `n_accepted` accepted positions, and roll
+    /// KV layers back by `kv_rollback`. Avoids the cost of a full rerun.
+    pub fn replay_tape_rollback(
+        &self,
+        layer_tapes: &[Option<qwen3_next::GdnLayerTape>],
+        cache: &mut AnyCache,
+        n_accepted: i32,
+        kv_rollback: i32,
+    ) -> Result<(), Exception> {
+        match (self, cache) {
+            (Self::Qwen3Next(m), AnyCache::Hybrid(c)) => {
+                m.replay_tape_rollback(layer_tapes, c, n_accepted, kv_rollback)
+            }
+            _ => Err(Exception::custom(
+                "replay_tape_rollback requires Qwen3Next + Hybrid cache",
+            )),
+        }
+    }
+
+    /// Embed raw token IDs through the target model's embedding layer.
+    pub fn embed_token_ids(&self, token_ids: &Array) -> Result<Array, Exception> {
+        match self {
+            Self::Qwen3Next(m) => m.embed_token_ids(token_ids),
+            Self::Transformer(_)
+            | Self::Qwen3Moe(_)
+            | Self::Gemma2(_)
+            | Self::Gemma3(_)
+            | Self::Gemma4(_)
+            | Self::Phi3(_)
+            | Self::Starcoder2(_)
+            | Self::LlavaQwen2(_)
+            | Self::DeepSeekV2(_)
+            | Self::BonsaiQ1(_) => Err(Exception::custom(
+                "embed_token_ids only implemented for Qwen3Next",
+            )),
+        }
+    }
+
+    /// Apply only the `lm_head` to pre-computed hidden states.
+    pub fn forward_all_logits_from_hidden(&self, hidden: &Array) -> Result<Array, Exception> {
+        match self {
+            Self::Qwen3Next(m) => m.forward_all_logits_from_hidden(hidden),
+            Self::Transformer(_)
+            | Self::Qwen3Moe(_)
+            | Self::Gemma2(_)
+            | Self::Gemma3(_)
+            | Self::Gemma4(_)
+            | Self::Phi3(_)
+            | Self::Starcoder2(_)
+            | Self::LlavaQwen2(_)
+            | Self::DeepSeekV2(_)
+            | Self::BonsaiQ1(_) => Err(Exception::custom(
+                "forward_all_logits_from_hidden only implemented for Qwen3Next",
             )),
         }
     }

--- a/crates/higgs-models/src/qwen3_next.rs
+++ b/crates/higgs-models/src/qwen3_next.rs
@@ -84,6 +84,8 @@ impl Drop for CachedMetalKernel {
 
 /// Cached `GatedDeltaNet` Metal kernel -- created once, reused for all layers.
 static GATED_DELTA_KERNEL: OnceLock<CachedMetalKernel> = OnceLock::new();
+static GATED_DELTA_TAPE_KERNEL: OnceLock<CachedMetalKernel> = OnceLock::new();
+static TAPE_REPLAY_KERNEL: OnceLock<CachedMetalKernel> = OnceLock::new();
 
 use crate::{
     cache::{KeyValueCache, SteppingKeyValueCache},
@@ -985,6 +987,541 @@ fn gated_delta_kernel_ffi(
 /// vectorized weight loads for peak bandwidth, vs MLX's `uint16` (2-byte) loads.
 ///
 /// Single packed buffer `wb` = [`weight_u32` | `scales_f32_as_u32` | `biases_f32_as_u32`].
+/// receive `state_in.clone()` so they can verify without mutating the cache.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn gated_delta_kernel_ffi_stateless(
+    q: &Array,
+    k: &Array,
+    v: &Array,
+    a_log: &Array,
+    a: &Array,
+    dt_bias: &Array,
+    b: &Array,
+    state_in: &Array,
+    batch: i32,
+    seq_len: i32,
+    num_k_heads: i32,
+    head_k_dim: i32,
+    num_v_heads: i32,
+    head_v_dim: i32,
+) -> Result<(Array, Array), Exception> {
+    let (y, _new_state) = gated_delta_kernel_ffi(
+        q,
+        k,
+        v,
+        a_log,
+        a,
+        dt_bias,
+        b,
+        state_in,
+        batch,
+        seq_len,
+        num_k_heads,
+        head_k_dim,
+        num_v_heads,
+        head_v_dim,
+    )?;
+    Ok((y, state_in.clone()))
+}
+
+// ---------------------------------------------------------------------------
+// Tape-recording GDN kernel: same recurrence, also outputs innovation delta
+// ---------------------------------------------------------------------------
+
+/// Tape-recording variant of the GDN kernel. Identical computation but also
+/// outputs `innovation_tape[B, T, Hv, Dv]` -- the delta residual at each step.
+/// Used for `DFlash` verify: on partial rejection, we replay only accepted steps
+/// from the tape instead of re-running the full forward.
+const GATED_DELTA_TAPE_KERNEL_SOURCE: &str = r"
+auto n = thread_position_in_grid.z;
+auto b_idx = n / Hv;
+auto hv_idx = n % Hv;
+auto hk_idx = hv_idx / (Hv / Hk);
+constexpr int n_per_t = Dk / 32;
+
+auto q_ = q + b_idx * T * Hk * Dk + hk_idx * Dk;
+auto k_ = k + b_idx * T * Hk * Dk + hk_idx * Dk;
+
+auto v_ = v + b_idx * T * Hv * Dv + hv_idx * Dv;
+y += b_idx * T * Hv * Dv + hv_idx * Dv;
+auto tape_ = innovation_tape + b_idx * T * Hv * Dv + hv_idx * Dv;
+
+auto dk_idx = thread_position_in_threadgroup.x;
+auto dv_idx = thread_position_in_grid.y;
+
+// state_in/state_out are float32 buffers (must match the f32 precision of the
+// AR-decode kernel so verify argmax is bit-exact); reinterpret from InT*.
+auto i_state = reinterpret_cast<const device float*>(state_in) + (n * Dv + dv_idx) * Dk;
+auto o_state = reinterpret_cast<device float*>(state_out) + (n * Dv + dv_idx) * Dk;
+
+float state[n_per_t];
+for (int i = 0; i < n_per_t; ++i) {
+  auto s_idx = n_per_t * dk_idx + i;
+  state[i] = static_cast<float>(i_state[s_idx]);
+}
+
+float a_log_val = static_cast<float>(a_log[hv_idx]);
+float dt_bias_val = static_cast<float>(dt_bias[hv_idx]);
+
+auto a_ = a + b_idx * T * Hv;
+auto b_ = b + b_idx * T * Hv;
+
+for (int t = 0; t < T; ++t) {
+  float x = static_cast<float>(a_[hv_idx]) + dt_bias_val;
+  float sp = fmax(x, 0.0f) + log1p(exp(-fabs(x)));
+  float g_val = exp(-exp(a_log_val) * sp);
+
+  float beta_val = 1.0f / (1.0f + exp(-static_cast<float>(b_[hv_idx])));
+
+  {
+    float kv_mem = 0.0f;
+    for (int i = 0; i < n_per_t; ++i) {
+      auto s_idx = n_per_t * dk_idx + i;
+      state[i] = state[i] * g_val;
+      kv_mem += state[i] * k_[s_idx];
+    }
+    kv_mem = simd_sum(kv_mem);
+
+    auto delta = (v_[dv_idx] - kv_mem) * beta_val;
+
+    float out = 0.0f;
+    for (int i = 0; i < n_per_t; ++i) {
+      auto s_idx = n_per_t * dk_idx + i;
+      state[i] = state[i] + k_[s_idx] * delta;
+      out += state[i] * q_[s_idx];
+    }
+    out = simd_sum(out);
+    if (thread_index_in_simdgroup == 0) {
+      y[dv_idx] = static_cast<InT>(out);
+      tape_[dv_idx] = delta;
+    }
+  }
+  // Keep state in float32 across timesteps (no InT downcast) so the recurrence
+  // is bit-exact with the AR-decode kernel.
+  q_ += Hk * Dk;
+  k_ += Hk * Dk;
+  v_ += Hv * Dv;
+  y += Hv * Dv;
+  tape_ += Hv * Dv;
+  a_ += Hv;
+  b_ += Hv;
+}
+for (int i = 0; i < n_per_t; ++i) {
+  auto s_idx = n_per_t * dk_idx + i;
+  o_state[s_idx] = state[i];
+}
+";
+
+#[allow(unsafe_code)]
+fn create_gated_delta_tape_kernel() -> mlx_sys::mlx_fast_metal_kernel {
+    let input_names: [&std::ffi::CStr; 9] = [
+        c"q",
+        c"k",
+        c"v",
+        c"a_log",
+        c"a",
+        c"dt_bias",
+        c"b",
+        c"state_in",
+        c"T",
+    ];
+    let output_names: [&std::ffi::CStr; 3] = [c"y", c"state_out", c"innovation_tape"];
+
+    let input_ptrs: Vec<*const c_char> = input_names.iter().map(|s| s.as_ptr()).collect();
+    let output_ptrs: Vec<*const c_char> = output_names.iter().map(|s| s.as_ptr()).collect();
+
+    let source =
+        CString::new(GATED_DELTA_TAPE_KERNEL_SOURCE).unwrap_or_else(|_| CString::default());
+
+    unsafe {
+        let in_vec =
+            mlx_sys::mlx_vector_string_new_data(input_ptrs.as_ptr().cast_mut(), input_ptrs.len());
+        let out_vec =
+            mlx_sys::mlx_vector_string_new_data(output_ptrs.as_ptr().cast_mut(), output_ptrs.len());
+        let kernel = mlx_sys::mlx_fast_metal_kernel_new(
+            c"gated_delta_tape".as_ptr(),
+            in_vec,
+            out_vec,
+            source.as_ptr(),
+            c"".as_ptr(),
+            true,
+            false,
+        );
+        mlx_sys::mlx_vector_string_free(in_vec);
+        mlx_sys::mlx_vector_string_free(out_vec);
+        kernel
+    }
+}
+
+#[allow(unsafe_code)]
+fn configure_gated_delta_tape_kernel(
+    in_dtype: mlx_sys::mlx_dtype,
+    batch: i32,
+    seq_len: i32,
+    num_k_heads: i32,
+    head_k_dim: i32,
+    num_v_heads: i32,
+    head_v_dim: i32,
+) -> mlx_sys::mlx_fast_metal_kernel_config {
+    unsafe {
+        let config = mlx_sys::mlx_fast_metal_kernel_config_new();
+
+        mlx_sys::mlx_fast_metal_kernel_config_add_template_arg_dtype(
+            config,
+            c"InT".as_ptr(),
+            in_dtype,
+        );
+        mlx_sys::mlx_fast_metal_kernel_config_add_template_arg_int(
+            config,
+            c"Dk".as_ptr(),
+            head_k_dim,
+        );
+        mlx_sys::mlx_fast_metal_kernel_config_add_template_arg_int(
+            config,
+            c"Dv".as_ptr(),
+            head_v_dim,
+        );
+        mlx_sys::mlx_fast_metal_kernel_config_add_template_arg_int(
+            config,
+            c"Hk".as_ptr(),
+            num_k_heads,
+        );
+        mlx_sys::mlx_fast_metal_kernel_config_add_template_arg_int(
+            config,
+            c"Hv".as_ptr(),
+            num_v_heads,
+        );
+
+        let y_shape = [batch, seq_len, num_v_heads, head_v_dim];
+        let state_shape = [batch, num_v_heads, head_v_dim, head_k_dim];
+        let tape_shape = [batch, seq_len, num_v_heads, head_v_dim];
+        mlx_sys::mlx_fast_metal_kernel_config_add_output_arg(
+            config,
+            y_shape.as_ptr(),
+            y_shape.len(),
+            in_dtype,
+        );
+        // State is float32 (matches the AR-decode kernel) for bit-exact verify.
+        mlx_sys::mlx_fast_metal_kernel_config_add_output_arg(
+            config,
+            state_shape.as_ptr(),
+            state_shape.len(),
+            mlx_sys::mlx_dtype__MLX_FLOAT32,
+        );
+        // Tape stores deltas in float32 for precision (matches dflash-mlx)
+        mlx_sys::mlx_fast_metal_kernel_config_add_output_arg(
+            config,
+            tape_shape.as_ptr(),
+            tape_shape.len(),
+            mlx_sys::mlx_dtype__MLX_FLOAT32,
+        );
+
+        mlx_sys::mlx_fast_metal_kernel_config_set_grid(config, 32, head_v_dim, batch * num_v_heads);
+        mlx_sys::mlx_fast_metal_kernel_config_set_thread_group(config, 32, 4, 1);
+
+        config
+    }
+}
+
+/// Tape-recording GDN kernel: returns `(y, state_out, innovation_tape)`.
+#[allow(unsafe_code, clippy::too_many_arguments)]
+pub(crate) fn gated_delta_kernel_ffi_with_tape(
+    q: &Array,
+    k: &Array,
+    v: &Array,
+    a_log: &Array,
+    a: &Array,
+    dt_bias: &Array,
+    b: &Array,
+    state_in: &Array,
+    batch: i32,
+    seq_len: i32,
+    num_k_heads: i32,
+    head_k_dim: i32,
+    num_v_heads: i32,
+    head_v_dim: i32,
+) -> Result<(Array, Array, Array), Exception> {
+    ensure_ffi_error_handler();
+
+    let stream = Stream::task_local_or_default();
+    let in_dtype = unsafe { mlx_sys::mlx_array_dtype(q.as_ptr()) };
+
+    let cached =
+        GATED_DELTA_TAPE_KERNEL.get_or_init(|| CachedMetalKernel(create_gated_delta_tape_kernel()));
+    let config = configure_gated_delta_tape_kernel(
+        in_dtype,
+        batch,
+        seq_len,
+        num_k_heads,
+        head_k_dim,
+        num_v_heads,
+        head_v_dim,
+    );
+
+    let t_scalar = unsafe { mlx_sys::mlx_array_new_int(seq_len) };
+    let input_ptrs = [
+        q.as_ptr(),
+        k.as_ptr(),
+        v.as_ptr(),
+        a_log.as_ptr(),
+        a.as_ptr(),
+        dt_bias.as_ptr(),
+        b.as_ptr(),
+        state_in.as_ptr(),
+        t_scalar,
+    ];
+    let inputs_vec =
+        unsafe { mlx_sys::mlx_vector_array_new_data(input_ptrs.as_ptr(), input_ptrs.len()) };
+
+    let mut outputs_vec = unsafe { mlx_sys::mlx_vector_array_new() };
+    let status = unsafe {
+        mlx_sys::mlx_fast_metal_kernel_apply(
+            &raw mut outputs_vec,
+            cached.0,
+            inputs_vec,
+            config,
+            stream.as_ptr(),
+        )
+    };
+
+    let result = if status != 0 {
+        let mlx_msg = FFI_LAST_ERROR
+            .with(|cell| cell.borrow_mut().take())
+            .unwrap_or_default();
+        Err(Exception::custom(format!(
+            "gated_delta_tape_kernel failed: {mlx_msg}"
+        )))
+    } else {
+        let mut y_ptr = unsafe { mlx_sys::mlx_array_new() };
+        let mut state_ptr = unsafe { mlx_sys::mlx_array_new() };
+        let mut tape_ptr = unsafe { mlx_sys::mlx_array_new() };
+        unsafe {
+            mlx_sys::mlx_vector_array_get(&raw mut y_ptr, outputs_vec, 0);
+            mlx_sys::mlx_vector_array_get(&raw mut state_ptr, outputs_vec, 1);
+            mlx_sys::mlx_vector_array_get(&raw mut tape_ptr, outputs_vec, 2);
+        }
+        Ok((
+            unsafe { Array::from_ptr(y_ptr) },
+            unsafe { Array::from_ptr(state_ptr) },
+            unsafe { Array::from_ptr(tape_ptr) },
+        ))
+    };
+
+    unsafe {
+        mlx_sys::mlx_fast_metal_kernel_config_free(config);
+        mlx_sys::mlx_vector_array_free(inputs_vec);
+        mlx_sys::mlx_vector_array_free(outputs_vec);
+        mlx_sys::mlx_array_free(t_scalar);
+    }
+
+    result
+}
+
+// ---------------------------------------------------------------------------
+// Tape replay kernel: replays accepted steps to advance GDN state
+// ---------------------------------------------------------------------------
+
+/// Replays the GDN recurrence from a recorded innovation tape.
+/// Inputs: `tape[B,T,Hv,Dv]`, `k[B,T,Hk,Dk]`, `a[B,T,Hv]`, `a_log[Hv]`,
+/// `dt_bias[Hv]`, `state_in[B,Hv,Dv,Dk]`. Output: `state_out[B,Hv,Dv,Dk]`.
+const TAPE_REPLAY_KERNEL_SOURCE: &str = r"
+auto n = thread_position_in_grid.z;
+auto b_idx = n / Hv;
+auto hv_idx = n % Hv;
+auto hk_idx = hv_idx / (Hv / Hk);
+constexpr int n_per_t = Dk / 32;
+
+auto tape_ = tape + b_idx * T * Hv * Dv + hv_idx * Dv;
+auto k_ = k + b_idx * T * Hk * Dk + hk_idx * Dk;
+
+auto dk_idx = thread_position_in_threadgroup.x;
+auto dv_idx = thread_position_in_grid.y;
+
+auto i_state = state_in + (n * Dv + dv_idx) * Dk;
+auto o_state = state_out + (n * Dv + dv_idx) * Dk;
+
+float state[n_per_t];
+for (int i = 0; i < n_per_t; ++i) {
+  auto s_idx = n_per_t * dk_idx + i;
+  state[i] = static_cast<float>(i_state[s_idx]);
+}
+
+// a_log and dt_bias are [B * Hv] when batched across layers
+float a_log_val = static_cast<float>(a_log[b_idx * Hv + hv_idx]);
+float dt_bias_val = static_cast<float>(dt_bias[b_idx * Hv + hv_idx]);
+auto a_ = a + b_idx * T * Hv;
+
+for (int t = 0; t < T; ++t) {
+  float x = static_cast<float>(a_[hv_idx]) + dt_bias_val;
+  float sp = fmax(x, 0.0f) + log1p(exp(-fabs(x)));
+  float g_val = exp(-exp(a_log_val) * sp);
+
+  auto delta = tape_[dv_idx];
+  // Replay the forward kernel's EXACT op sequence (decay as a separate
+  // statement, then the k*delta update) so the replayed state is bit-exact
+  // with a fresh forward. Fusing into `state*g + k*delta` rounds differently
+  // (FMA) and the ~1e-8 drift accumulates across rollbacks → argmax flips.
+  for (int i = 0; i < n_per_t; ++i) {
+    auto s_idx = n_per_t * dk_idx + i;
+    state[i] = state[i] * g_val;
+    state[i] = state[i] + k_[s_idx] * delta;
+  }
+  tape_ += Hv * Dv;
+  k_ += Hk * Dk;
+  a_ += Hv;
+}
+for (int i = 0; i < n_per_t; ++i) {
+  auto s_idx = n_per_t * dk_idx + i;
+  o_state[s_idx] = state[i];
+}
+";
+
+#[allow(unsafe_code)]
+fn create_tape_replay_kernel() -> mlx_sys::mlx_fast_metal_kernel {
+    let input_names: [&std::ffi::CStr; 7] =
+        [c"tape", c"k", c"a", c"a_log", c"dt_bias", c"state_in", c"T"];
+    let output_names: [&std::ffi::CStr; 1] = [c"state_out"];
+
+    let input_ptrs: Vec<*const c_char> = input_names.iter().map(|s| s.as_ptr()).collect();
+    let output_ptrs: Vec<*const c_char> = output_names.iter().map(|s| s.as_ptr()).collect();
+
+    let source = CString::new(TAPE_REPLAY_KERNEL_SOURCE).unwrap_or_else(|_| CString::default());
+
+    unsafe {
+        let in_vec =
+            mlx_sys::mlx_vector_string_new_data(input_ptrs.as_ptr().cast_mut(), input_ptrs.len());
+        let out_vec =
+            mlx_sys::mlx_vector_string_new_data(output_ptrs.as_ptr().cast_mut(), output_ptrs.len());
+        let kernel = mlx_sys::mlx_fast_metal_kernel_new(
+            c"tape_replay".as_ptr(),
+            in_vec,
+            out_vec,
+            source.as_ptr(),
+            c"".as_ptr(),
+            true,
+            false,
+        );
+        mlx_sys::mlx_vector_string_free(in_vec);
+        mlx_sys::mlx_vector_string_free(out_vec);
+        kernel
+    }
+}
+
+/// Replay accepted steps from a recorded innovation tape.
+/// Returns the new SSM state after replaying `seq_len` steps.
+#[allow(unsafe_code, clippy::too_many_arguments)]
+pub(crate) fn tape_replay_kernel_ffi(
+    tape: &Array,
+    k: &Array,
+    a: &Array,
+    a_log: &Array,
+    dt_bias: &Array,
+    state_in: &Array,
+    batch: i32,
+    seq_len: i32,
+    num_k_heads: i32,
+    head_k_dim: i32,
+    num_v_heads: i32,
+    head_v_dim: i32,
+) -> Result<Array, Exception> {
+    ensure_ffi_error_handler();
+
+    let stream = Stream::task_local_or_default();
+    let in_dtype = unsafe { mlx_sys::mlx_array_dtype(state_in.as_ptr()) };
+
+    let cached = TAPE_REPLAY_KERNEL.get_or_init(|| CachedMetalKernel(create_tape_replay_kernel()));
+
+    let config = unsafe {
+        let config = mlx_sys::mlx_fast_metal_kernel_config_new();
+        mlx_sys::mlx_fast_metal_kernel_config_add_template_arg_dtype(
+            config,
+            c"InT".as_ptr(),
+            in_dtype,
+        );
+        mlx_sys::mlx_fast_metal_kernel_config_add_template_arg_int(
+            config,
+            c"Dk".as_ptr(),
+            head_k_dim,
+        );
+        mlx_sys::mlx_fast_metal_kernel_config_add_template_arg_int(
+            config,
+            c"Dv".as_ptr(),
+            head_v_dim,
+        );
+        mlx_sys::mlx_fast_metal_kernel_config_add_template_arg_int(
+            config,
+            c"Hk".as_ptr(),
+            num_k_heads,
+        );
+        mlx_sys::mlx_fast_metal_kernel_config_add_template_arg_int(
+            config,
+            c"Hv".as_ptr(),
+            num_v_heads,
+        );
+
+        let state_shape = [batch, num_v_heads, head_v_dim, head_k_dim];
+        mlx_sys::mlx_fast_metal_kernel_config_add_output_arg(
+            config,
+            state_shape.as_ptr(),
+            state_shape.len(),
+            in_dtype,
+        );
+
+        mlx_sys::mlx_fast_metal_kernel_config_set_grid(config, 32, head_v_dim, batch * num_v_heads);
+        mlx_sys::mlx_fast_metal_kernel_config_set_thread_group(config, 32, 4, 1);
+
+        config
+    };
+
+    let t_scalar = unsafe { mlx_sys::mlx_array_new_int(seq_len) };
+    let input_ptrs = [
+        tape.as_ptr(),
+        k.as_ptr(),
+        a.as_ptr(),
+        a_log.as_ptr(),
+        dt_bias.as_ptr(),
+        state_in.as_ptr(),
+        t_scalar,
+    ];
+    let inputs_vec =
+        unsafe { mlx_sys::mlx_vector_array_new_data(input_ptrs.as_ptr(), input_ptrs.len()) };
+
+    let mut outputs_vec = unsafe { mlx_sys::mlx_vector_array_new() };
+    let status = unsafe {
+        mlx_sys::mlx_fast_metal_kernel_apply(
+            &raw mut outputs_vec,
+            cached.0,
+            inputs_vec,
+            config,
+            stream.as_ptr(),
+        )
+    };
+
+    let result = if status != 0 {
+        let mlx_msg = FFI_LAST_ERROR
+            .with(|cell| cell.borrow_mut().take())
+            .unwrap_or_default();
+        Err(Exception::custom(format!(
+            "tape_replay_kernel failed: {mlx_msg}"
+        )))
+    } else {
+        let mut state_ptr = unsafe { mlx_sys::mlx_array_new() };
+        unsafe {
+            mlx_sys::mlx_vector_array_get(&raw mut state_ptr, outputs_vec, 0);
+        }
+        Ok(unsafe { Array::from_ptr(state_ptr) })
+    };
+
+    unsafe {
+        mlx_sys::mlx_fast_metal_kernel_config_free(config);
+        mlx_sys::mlx_vector_array_free(inputs_vec);
+        mlx_sys::mlx_vector_array_free(outputs_vec);
+        mlx_sys::mlx_array_free(t_scalar);
+    }
+
+    result
+}
+
 /// Eliminates per-token dtype conversions for scales/biases (packed once at load time).
 /// Tiled GEMV with shared memory for x and K-chunking.
 ///
@@ -2536,6 +3073,24 @@ fn compiled_gdn_decode_step(
     Ok(vec![gated])
 }
 
+/// conv1d, norms, or attention. Just `state = state * g + k * delta`.
+pub struct GdnLayerTape {
+    /// Innovation delta at each timestep: `[B, T, Hv, Dv]`
+    pub delta_tape: Array,
+    /// Post-conv, post-norm key vectors: `[B, T, Hk, Dk]`
+    pub norm_k: Array,
+    /// Projected gate values: `[B, T, Hv]`
+    pub a_proj: Array,
+    /// Raw QKV input to conv1d (for `conv_state` rebuild): `[B, T, conv_dim]`
+    pub qkv_input: Array,
+    /// Pre-forward `conv_state` for rollback: `[B, K-1, conv_dim]`
+    pub conv_state_init: Option<Array>,
+    /// Pre-forward `ssm_state` for rollback: `[B, Hv, Dv, Dk]`
+    pub ssm_state_init: Option<Array>,
+    /// Pre-forward cache offset for rollback
+    pub offset_init: i32,
+}
+
 #[allow(non_snake_case)]
 #[derive(Debug, Clone, ModuleParameters)]
 struct GatedDeltaNet {
@@ -3020,6 +3575,439 @@ impl GatedDeltaNet {
         let a = a_raw.reshape(&[B, S, nv])?;
 
         Ok((q, k, v, z, b, a))
+    }
+
+    /// Side-effect-free forward used by `DFlash` verify. Identical numerics to
+    /// `forward`, but reads `cache.conv_state` / `cache.ssm_state` without
+    /// mutating them so a rejected speculation can be retried cleanly.
+    // Numerical kernel: tensor shape indices known finite; explicit casts preferred over try_from for hot path.
+    #[allow(
+        non_snake_case,
+        clippy::too_many_lines,
+        clippy::indexing_slicing,
+        clippy::as_conversions,
+        clippy::cast_sign_loss,
+        clippy::if_not_else,
+        clippy::single_match_else,
+        clippy::shadow_unrelated,
+        clippy::shadow_reuse
+    )]
+    fn forward_stateless(
+        &mut self,
+        inputs: &Array,
+        _mask: Option<&AttentionMask>,
+        cache: &ArraysCache,
+    ) -> Result<Array, Exception> {
+        let shape = inputs.shape();
+        let B = *shape
+            .first()
+            .ok_or_else(|| Exception::custom("Input must have >= 2 dims"))?;
+        let S = *shape
+            .get(1)
+            .ok_or_else(|| Exception::custom("Input must have >= 2 dims"))?;
+
+        // Project inputs — same as stateful forward
+        let (q, k, v, z, b, a) = if self.use_separate_projections {
+            let qkv_proj = self
+                .in_proj_qkv
+                .as_ref()
+                .ok_or_else(|| Exception::custom("in_proj_qkv missing"))?;
+            let z_proj = self
+                .in_proj_z
+                .as_ref()
+                .ok_or_else(|| Exception::custom("in_proj_z missing"))?;
+            let b_proj = self
+                .in_proj_b
+                .as_ref()
+                .ok_or_else(|| Exception::custom("in_proj_b missing"))?;
+            let a_proj = self
+                .in_proj_a
+                .as_ref()
+                .ok_or_else(|| Exception::custom("in_proj_a missing"))?;
+
+            let qkv = qkv_proj.forward(inputs)?;
+            let z = z_proj
+                .forward(inputs)?
+                .reshape(&[B, S, self.num_v_heads, self.head_v_dim])?;
+            let b = b_proj.forward(inputs)?;
+            let a = a_proj.forward(inputs)?;
+
+            let split_indices = &[self.key_dim, self.key_dim * 2];
+            let qkv_parts = qkv.split_axis(split_indices, Some(-1))?;
+            let q = qkv_parts
+                .first()
+                .ok_or_else(|| Exception::custom("qkv split failed"))?
+                .reshape(&[B, S, self.num_k_heads, self.head_k_dim])?;
+            let k = qkv_parts
+                .get(1)
+                .ok_or_else(|| Exception::custom("qkv split failed"))?
+                .reshape(&[B, S, self.num_k_heads, self.head_k_dim])?;
+            let v = qkv_parts
+                .get(2)
+                .ok_or_else(|| Exception::custom("qkv split failed"))?
+                .reshape(&[B, S, self.num_v_heads, self.head_v_dim])?;
+
+            (q, k, v, z, b, a)
+        } else {
+            let mixed_qkvz = self.in_proj_qkvz.forward(inputs)?;
+            let mixed_ba = self.in_proj_ba.forward(inputs)?;
+            self.fix_query_key_value_ordering(&mixed_qkvz, &mixed_ba, B, S)?
+        };
+
+        // Conv1d — read conv_state without consuming it
+        let q_flat = q.reshape(&[B, S, -1])?;
+        let k_flat = k.reshape(&[B, S, -1])?;
+        let v_flat = v.reshape(&[B, S, -1])?;
+        let mixed_qkv = ops::concatenate_axis(&[&q_flat, &k_flat, &v_flat], -1)?;
+
+        // Borrow conv_state without taking it (stateless must not mutate cache)
+        let conv_state = match &cache.conv_state {
+            Some(state) => state.clone(),
+            None => ops::zeros_dtype(
+                &[B, self.conv_kernel_size - 1, self.conv_dim],
+                inputs.dtype(),
+            )?,
+        };
+        let conv_input = ops::concatenate_axis(&[&conv_state, &mixed_qkv], 1)?;
+
+        // DO NOT update cache.conv_state
+
+        let conv_out = if S > 1 && S <= 32 {
+            let wt = match &self.conv_weight_t {
+                Some(w) => w.clone(),
+                None => {
+                    let shape = self.conv1d.weight.shape();
+                    let w = if shape.len() == 3 && shape[2] == 1 {
+                        self.conv1d.weight.squeeze_axes(&[-1])?.transpose()?
+                    } else if shape.len() == 3 && shape[1] == 1 {
+                        self.conv1d.weight.squeeze_axes(&[1])?.transpose()?
+                    } else {
+                        return Err(Exception::custom(format!(
+                            "Unexpected conv1d weight shape: {shape:?}"
+                        )));
+                    };
+                    let w = w.as_dtype(inputs.dtype())?;
+                    w.eval()?;
+                    // Don't cache weight here — stateless should be side-effect-free
+                    w
+                }
+            };
+            let ks = self.conv_kernel_size;
+            let mut windows = Vec::with_capacity(S as usize);
+            for i in 0..S {
+                windows.push(
+                    conv_input
+                        .index((.., i..i + ks, ..))
+                        .multiply(&wt)?
+                        .sum_axes(&[1], true)?,
+                );
+            }
+            nn::silu(&ops::concatenate_axis(
+                &windows.iter().collect::<Vec<_>>(),
+                1,
+            )?)?
+        } else {
+            // Stateless path: clone-coerce rather than mutate self.conv1d.weight,
+            // matching the qk_norm_weight_* clone pattern below.
+            let in_dt = inputs.dtype();
+            if self.conv1d.weight.dtype() != in_dt {
+                let coerced = self.conv1d.weight.as_dtype(in_dt)?;
+                let out = ops::conv1d(&conv_input, &coerced, 1, 0, 1, self.conv_dim)?;
+                nn::silu(&out)?
+            } else {
+                nn::silu(&self.conv1d.forward(&conv_input)?)?
+            }
+        };
+
+        let split_indices = &[self.key_dim, self.key_dim * 2];
+        let conv_parts = conv_out.split_axis(split_indices, Some(-1))?;
+        let conv_q = conv_parts
+            .first()
+            .ok_or_else(|| Exception::custom("conv split failed"))?
+            .reshape(&[B, S, self.num_k_heads, self.head_k_dim])?;
+        let conv_k = conv_parts
+            .get(1)
+            .ok_or_else(|| Exception::custom("conv split failed"))?
+            .reshape(&[B, S, self.num_k_heads, self.head_k_dim])?;
+        let conv_v = conv_parts
+            .get(2)
+            .ok_or_else(|| Exception::custom("conv split failed"))?
+            .reshape(&[B, S, self.num_v_heads, self.head_v_dim])?;
+
+        let in_dt = inputs.dtype();
+        let qk_wq = if self.qk_norm_weight_q.dtype() != in_dt {
+            self.qk_norm_weight_q.as_dtype(in_dt)?
+        } else {
+            self.qk_norm_weight_q.clone()
+        };
+        let qk_wk = if self.qk_norm_weight_k.dtype() != in_dt {
+            self.qk_norm_weight_k.as_dtype(in_dt)?
+        } else {
+            self.qk_norm_weight_k.clone()
+        };
+
+        let norm_q = fast::rms_norm(&conv_q, &qk_wq, 1e-6)?;
+        let norm_k = fast::rms_norm(&conv_k, &qk_wk, 1e-6)?;
+
+        // Stateless SSM recurrence — state_out := state_in
+        let state = match &cache.ssm_state {
+            Some(s) => s.clone(),
+            None => ops::zeros_dtype(
+                &[B, self.num_v_heads, self.head_v_dim, self.head_k_dim],
+                inputs.dtype(),
+            )?,
+        };
+        let (y, _unchanged_state) = gated_delta_kernel_ffi_stateless(
+            &norm_q,
+            &norm_k,
+            &conv_v,
+            &self.A_log,
+            &a,
+            &self.dt_bias,
+            &b,
+            &state,
+            B,
+            S,
+            self.num_k_heads,
+            self.head_k_dim,
+            self.num_v_heads,
+            self.head_v_dim,
+        )?;
+        // DO NOT update cache.ssm_state or cache.offset
+
+        let normed = self.norm.forward(&y)?;
+        let gated_out = swiglu(&z, &normed)?;
+
+        let out_flat = gated_out.reshape(&[B, S, -1])?;
+        self.out_proj.forward(&out_flat)
+    }
+
+    /// Tape-recording forward: identical output, also returns a `GdnLayerTape`
+    /// containing everything needed to cheaply replay accepted steps.
+    /// State IS updated (normal forward) — on full acceptance, zero extra work.
+    // Numerical kernel: tensor shape indices known finite; explicit casts preferred over try_from for hot path.
+    #[allow(
+        non_snake_case,
+        clippy::too_many_lines,
+        clippy::indexing_slicing,
+        clippy::as_conversions,
+        clippy::cast_sign_loss,
+        clippy::single_match_else,
+        clippy::shadow_unrelated,
+        clippy::shadow_reuse
+    )]
+    fn forward_with_tape(
+        &mut self,
+        inputs: &Array,
+        _mask: Option<&AttentionMask>,
+        cache: &mut ArraysCache,
+    ) -> Result<(Array, GdnLayerTape), Exception> {
+        let shape = inputs.shape();
+        let B = *shape
+            .first()
+            .ok_or_else(|| Exception::custom("need >= 2 dims"))?;
+        let S = *shape
+            .get(1)
+            .ok_or_else(|| Exception::custom("need >= 2 dims"))?;
+
+        let (q, k, v, z, b, a) = if self.use_separate_projections {
+            let qkv_proj = self
+                .in_proj_qkv
+                .as_ref()
+                .ok_or_else(|| Exception::custom("in_proj_qkv missing"))?;
+            let z_proj = self
+                .in_proj_z
+                .as_ref()
+                .ok_or_else(|| Exception::custom("in_proj_z missing"))?;
+            let b_proj = self
+                .in_proj_b
+                .as_ref()
+                .ok_or_else(|| Exception::custom("in_proj_b missing"))?;
+            let a_proj = self
+                .in_proj_a
+                .as_ref()
+                .ok_or_else(|| Exception::custom("in_proj_a missing"))?;
+
+            let qkv = qkv_proj.forward(inputs)?;
+            let z = z_proj
+                .forward(inputs)?
+                .reshape(&[B, S, self.num_v_heads, self.head_v_dim])?;
+            let b = b_proj.forward(inputs)?;
+            let a = a_proj.forward(inputs)?;
+
+            let split_indices = &[self.key_dim, self.key_dim * 2];
+            let qkv_parts = qkv.split_axis(split_indices, Some(-1))?;
+            let q = qkv_parts
+                .first()
+                .ok_or_else(|| Exception::custom("qkv split failed"))?
+                .reshape(&[B, S, self.num_k_heads, self.head_k_dim])?;
+            let k = qkv_parts
+                .get(1)
+                .ok_or_else(|| Exception::custom("qkv split failed"))?
+                .reshape(&[B, S, self.num_k_heads, self.head_k_dim])?;
+            let v = qkv_parts
+                .get(2)
+                .ok_or_else(|| Exception::custom("qkv split failed"))?
+                .reshape(&[B, S, self.num_v_heads, self.head_v_dim])?;
+            (q, k, v, z, b, a)
+        } else {
+            let mixed_qkvz = self.in_proj_qkvz.forward(inputs)?;
+            let mixed_ba = self.in_proj_ba.forward(inputs)?;
+            self.fix_query_key_value_ordering(&mixed_qkvz, &mixed_ba, B, S)?
+        };
+
+        // Save a for replay (before any reshape that might happen)
+        let a_for_replay = a.clone();
+
+        // Conv1d — same as normal forward
+        let q_flat = q.reshape(&[B, S, -1])?;
+        let k_flat = k.reshape(&[B, S, -1])?;
+        let v_flat = v.reshape(&[B, S, -1])?;
+        let mixed_qkv = ops::concatenate_axis(&[&q_flat, &k_flat, &v_flat], -1)?;
+
+        // Save qkv for conv_state rebuild on replay
+        let qkv_for_replay = mixed_qkv.clone();
+
+        // Capture initial state for rollback (Python `_GDNStateCapture` equivalent)
+        let conv_state_init = cache.conv_state.clone();
+        let ssm_state_init = cache.ssm_state.clone();
+        let offset_init = cache.offset;
+
+        let conv_state = match cache.conv_state.take() {
+            Some(state) => state,
+            None => ops::zeros_dtype(
+                &[B, self.conv_kernel_size - 1, self.conv_dim],
+                inputs.dtype(),
+            )?,
+        };
+        let conv_input = ops::concatenate_axis(&[&conv_state, &mixed_qkv], 1)?;
+
+        let n_keep = self.conv_kernel_size - 1;
+        let conv_input_len = *conv_input
+            .shape()
+            .get(1)
+            .ok_or_else(|| Exception::custom("conv_input missing seq dim"))?;
+        let keep_start = conv_input_len - n_keep;
+        let cs = conv_input.index((.., keep_start.., ..));
+        let cs_shape = cs.shape().to_vec();
+        cache.conv_state = Some(cs.flatten(None, None)?.reshape(&cs_shape)?);
+
+        let conv_out = if S > 1 && S <= 32 {
+            let wt = match &self.conv_weight_t {
+                Some(w) => w.clone(),
+                None => {
+                    let shape = self.conv1d.weight.shape();
+                    let w = if shape.len() == 3 && shape[2] == 1 {
+                        self.conv1d.weight.squeeze_axes(&[-1])?.transpose()?
+                    } else if shape.len() == 3 && shape[1] == 1 {
+                        self.conv1d.weight.squeeze_axes(&[1])?.transpose()?
+                    } else {
+                        return Err(Exception::custom(format!(
+                            "Unexpected conv1d weight shape: {shape:?}"
+                        )));
+                    };
+                    let w = w.as_dtype(inputs.dtype())?;
+                    w.eval()?;
+                    self.conv_weight_t = Some(w.clone());
+                    w
+                }
+            };
+            let ks = self.conv_kernel_size;
+            let mut windows = Vec::with_capacity(S as usize);
+            for i in 0..S {
+                windows.push(
+                    conv_input
+                        .index((.., i..i + ks, ..))
+                        .multiply(&wt)?
+                        .sum_axes(&[1], true)?,
+                );
+            }
+            nn::silu(&ops::concatenate_axis(
+                &windows.iter().collect::<Vec<_>>(),
+                1,
+            )?)?
+        } else {
+            // Mirror the S>1 dtype coercion for the native Conv1d path.
+            let in_dt = inputs.dtype();
+            if self.conv1d.weight.dtype() != in_dt {
+                let coerced = self.conv1d.weight.as_dtype(in_dt)?;
+                coerced.eval()?;
+                self.conv1d.weight = Param::new(coerced);
+            }
+            nn::silu(&self.conv1d.forward(&conv_input)?)?
+        };
+
+        let split_indices = &[self.key_dim, self.key_dim * 2];
+        let conv_parts = conv_out.split_axis(split_indices, Some(-1))?;
+        let conv_q = conv_parts
+            .first()
+            .ok_or_else(|| Exception::custom("conv split failed"))?
+            .reshape(&[B, S, self.num_k_heads, self.head_k_dim])?;
+        let conv_k = conv_parts
+            .get(1)
+            .ok_or_else(|| Exception::custom("conv split failed"))?
+            .reshape(&[B, S, self.num_k_heads, self.head_k_dim])?;
+        let conv_v = conv_parts
+            .get(2)
+            .ok_or_else(|| Exception::custom("conv split failed"))?
+            .reshape(&[B, S, self.num_v_heads, self.head_v_dim])?;
+
+        let in_dt = inputs.dtype();
+        if self.qk_norm_weight_q.dtype() != in_dt {
+            self.qk_norm_weight_q = self.qk_norm_weight_q.as_dtype(in_dt)?;
+            self.qk_norm_weight_k = self.qk_norm_weight_k.as_dtype(in_dt)?;
+        }
+
+        let norm_q = fast::rms_norm(&conv_q, &self.qk_norm_weight_q, 1e-6)?;
+        let norm_k = fast::rms_norm(&conv_k, &self.qk_norm_weight_k, 1e-6)?;
+
+        // Save norm_k for replay
+        let norm_k_for_replay = norm_k.clone();
+
+        // Tape-recording kernel — state IS updated, tape IS recorded.
+        // State is float32 to match the AR-decode kernel (bit-exact verify).
+        let state = match cache.ssm_state.take() {
+            Some(s) => s,
+            None => ops::zeros_dtype(
+                &[B, self.num_v_heads, self.head_v_dim, self.head_k_dim],
+                Dtype::Float32,
+            )?,
+        };
+        let (y, new_state, delta_tape) = gated_delta_kernel_ffi_with_tape(
+            &norm_q,
+            &norm_k,
+            &conv_v,
+            &self.A_log,
+            &a,
+            &self.dt_bias,
+            &b,
+            &state,
+            B,
+            S,
+            self.num_k_heads,
+            self.head_k_dim,
+            self.num_v_heads,
+            self.head_v_dim,
+        )?;
+        cache.ssm_state = Some(new_state);
+        cache.offset += S;
+
+        let normed = self.norm.forward(&y)?;
+        let gated_out = swiglu(&z, &normed)?;
+        let out_flat = gated_out.reshape(&[B, S, -1])?;
+        let output = self.out_proj.forward(&out_flat)?;
+
+        let tape = GdnLayerTape {
+            delta_tape,
+            norm_k: norm_k_for_replay,
+            a_proj: a_for_replay,
+            qkv_input: qkv_for_replay,
+            conv_state_init,
+            ssm_state_init,
+            offset_init,
+        };
+
+        Ok((output, tape))
     }
 }
 
@@ -4228,6 +5216,590 @@ impl Qwen3NextCausalLM {
             None => self.model.embed_tokens.as_linear(&h_normed)?,
         };
         Ok((h_raw, logits))
+    }
+
+    #[allow(non_snake_case)]
+    pub fn forward_with_taps(
+        &mut self,
+        inputs: &Array,
+        _mask: Option<&Array>,
+        kv_cache: &mut Vec<Option<LayerCache>>,
+        tap_layers: &[usize],
+    ) -> Result<(Array, Vec<Array>), Exception> {
+        let mut h = self.model.embed_tokens.forward(inputs)?;
+
+        if kv_cache.is_empty() {
+            *kv_cache = self.make_cache();
+        }
+
+        if kv_cache.len() != self.model.layers.len() {
+            return Err(Exception::custom(format!(
+                "cache length ({}) must match num layers ({})",
+                kv_cache.len(),
+                self.model.layers.len()
+            )));
+        }
+
+        let shape = h.shape();
+        let T = *shape
+            .get(1)
+            .ok_or_else(|| Exception::custom("Hidden state must have >= 2 dims"))?;
+
+        let fa_mask: Option<AttentionMask> = if T > 1 {
+            let kv_offset = kv_cache
+                .iter()
+                .find_map(|lc| match lc.as_ref()? {
+                    LayerCache::KV(kv) => Some(kv.offset()),
+                    LayerCache::Arrays(_) => None,
+                })
+                .unwrap_or(0);
+
+            if kv_offset > 0 {
+                Some(AttentionMask::Array(create_causal_mask(
+                    T,
+                    Some(kv_offset),
+                )?))
+            } else {
+                Some(AttentionMask::Causal)
+            }
+        } else {
+            None
+        };
+
+        let mut taps = Vec::with_capacity(tap_layers.len());
+
+        for (layer_idx, (layer, layer_cache)) in self
+            .model
+            .layers
+            .iter_mut()
+            .zip(kv_cache.iter_mut())
+            .enumerate()
+        {
+            let cache = layer_cache
+                .as_mut()
+                .ok_or_else(|| Exception::custom("Layer cache is None"))?;
+            let mask_ref = if layer.is_linear {
+                None
+            } else {
+                fa_mask.as_ref()
+            };
+
+            let normed = layer.input_layernorm.forward(&h)?;
+
+            let r = if layer.is_linear {
+                let attn = layer
+                    .linear_attn
+                    .as_mut()
+                    .ok_or_else(|| Exception::custom("linear_attn missing"))?;
+                let LayerCache::Arrays(ssm_cache) = cache else {
+                    return Err(Exception::custom("Expected ArraysCache"));
+                };
+                attn.forward(&normed, mask_ref, ssm_cache)?
+            } else {
+                let attn = layer
+                    .self_attn
+                    .as_mut()
+                    .ok_or_else(|| Exception::custom("self_attn missing"))?;
+                let LayerCache::KV(layer_kv) = cache else {
+                    return Err(Exception::custom("Expected KVCache"));
+                };
+                attn.forward(&normed, mask_ref, layer_kv)?
+            };
+
+            let h2 = h.add(r)?;
+            let normed_post = layer.post_attention_layernorm.forward(&h2)?;
+            let mlp_out = layer.mlp.forward(&normed_post)?;
+            h = h2.add(mlp_out)?;
+
+            if tap_layers.contains(&layer_idx) {
+                taps.push(h.clone());
+            }
+        }
+
+        let normed = self.model.norm.forward(&h)?;
+        let logits = self.project_logits(&normed)?;
+
+        Ok((logits, taps))
+    }
+
+    /// Stateless verify pass: identical to `forward_with_taps` but GDN layers
+    /// use `forward_stateless` — they compute correct outputs without updating
+    /// `ssm_state` or `conv_state`. KV cache layers update normally (needed for
+    /// future decode). Eliminates GdnStateBackup/restore overhead in `DFlash` verify.
+    ///
+    /// After verify, the caller runs `forward_hidden` with only the accepted
+    /// tokens to commit the GDN state for those positions.
+    #[allow(non_snake_case)]
+    pub fn forward_with_taps_stateless(
+        &mut self,
+        inputs: &Array,
+        _mask: Option<&Array>,
+        kv_cache: &mut Vec<Option<LayerCache>>,
+        tap_layers: &[usize],
+    ) -> Result<(Array, Vec<Array>), Exception> {
+        let mut h = self.model.embed_tokens.forward(inputs)?;
+
+        if kv_cache.is_empty() {
+            *kv_cache = self.make_cache();
+        }
+
+        if kv_cache.len() != self.model.layers.len() {
+            return Err(Exception::custom(format!(
+                "cache length ({}) must match num layers ({})",
+                kv_cache.len(),
+                self.model.layers.len()
+            )));
+        }
+
+        let shape = h.shape();
+        let T = *shape
+            .get(1)
+            .ok_or_else(|| Exception::custom("Hidden state must have >= 2 dims"))?;
+
+        let fa_mask: Option<AttentionMask> = if T > 1 {
+            let kv_offset = kv_cache
+                .iter()
+                .find_map(|lc| match lc.as_ref()? {
+                    LayerCache::KV(kv) => Some(kv.offset()),
+                    LayerCache::Arrays(_) => None,
+                })
+                .unwrap_or(0);
+
+            if kv_offset > 0 {
+                Some(AttentionMask::Array(create_causal_mask(
+                    T,
+                    Some(kv_offset),
+                )?))
+            } else {
+                Some(AttentionMask::Causal)
+            }
+        } else {
+            None
+        };
+
+        let mut taps = Vec::with_capacity(tap_layers.len());
+
+        for (layer_idx, (layer, layer_cache)) in self
+            .model
+            .layers
+            .iter_mut()
+            .zip(kv_cache.iter_mut())
+            .enumerate()
+        {
+            let cache = layer_cache
+                .as_mut()
+                .ok_or_else(|| Exception::custom("Layer cache is None"))?;
+            let mask_ref = if layer.is_linear {
+                None
+            } else {
+                fa_mask.as_ref()
+            };
+
+            let normed = layer.input_layernorm.forward(&h)?;
+
+            let r = if layer.is_linear {
+                let attn = layer
+                    .linear_attn
+                    .as_mut()
+                    .ok_or_else(|| Exception::custom("linear_attn missing"))?;
+                let LayerCache::Arrays(ssm_cache) = cache else {
+                    return Err(Exception::custom("Expected ArraysCache"));
+                };
+                // STATELESS: GDN state not updated
+                attn.forward_stateless(&normed, mask_ref, ssm_cache)?
+            } else {
+                let attn = layer
+                    .self_attn
+                    .as_mut()
+                    .ok_or_else(|| Exception::custom("self_attn missing"))?;
+                let LayerCache::KV(layer_kv) = cache else {
+                    return Err(Exception::custom("Expected KVCache"));
+                };
+                // KV cache updates normally — needed for future decode
+                attn.forward(&normed, mask_ref, layer_kv)?
+            };
+
+            let h2 = h.add(r)?;
+            let normed_post = layer.post_attention_layernorm.forward(&h2)?;
+            let mlp_out = layer.mlp.forward(&normed_post)?;
+            h = h2.add(mlp_out)?;
+
+            if tap_layers.contains(&layer_idx) {
+                taps.push(h.clone());
+            }
+        }
+
+        let normed = self.model.norm.forward(&h)?;
+        let logits = self.project_logits(&normed)?;
+
+        Ok((logits, taps))
+    }
+
+    /// Tape-recording verify pass: runs normal forward (state IS updated) and
+    /// records innovation tape per GDN layer. Returns `(logits, taps, tape_data)`.
+    ///
+    /// On full acceptance (89% of rounds): zero extra work — state already correct.
+    /// On partial rejection: restore conv+ssm snapshots, replay `tape[:n_accepted]`.
+    // Numerical kernel dispatch: long fn but single straight-line decode loop, casts are timing arithmetic over small counters.
+    #[allow(
+        non_snake_case,
+        clippy::too_many_lines,
+        clippy::type_complexity,
+        clippy::cast_precision_loss,
+        clippy::as_conversions,
+        clippy::map_unwrap_or
+    )]
+    pub fn forward_with_taps_tape(
+        &mut self,
+        inputs: &Array,
+        _mask: Option<&Array>,
+        kv_cache: &mut Vec<Option<LayerCache>>,
+        tap_layers: &[usize],
+    ) -> Result<(Array, Vec<Array>, Vec<Option<GdnLayerTape>>), Exception> {
+        let mut h = self.model.embed_tokens.forward(inputs)?;
+
+        if kv_cache.is_empty() {
+            *kv_cache = self.make_cache();
+        }
+
+        if kv_cache.len() != self.model.layers.len() {
+            return Err(Exception::custom(format!(
+                "cache length ({}) must match num layers ({})",
+                kv_cache.len(),
+                self.model.layers.len()
+            )));
+        }
+
+        let shape = h.shape();
+        let T = *shape
+            .get(1)
+            .ok_or_else(|| Exception::custom("Hidden state must have >= 2 dims"))?;
+
+        let fa_mask: Option<AttentionMask> = if T > 1 {
+            let kv_offset = kv_cache
+                .iter()
+                .find_map(|lc| match lc.as_ref()? {
+                    LayerCache::KV(kv) => Some(kv.offset()),
+                    LayerCache::Arrays(_) => None,
+                })
+                .unwrap_or(0);
+
+            if kv_offset > 0 {
+                Some(AttentionMask::Array(create_causal_mask(
+                    T,
+                    Some(kv_offset),
+                )?))
+            } else {
+                Some(AttentionMask::Causal)
+            }
+        } else {
+            None
+        };
+
+        let mut taps = Vec::with_capacity(tap_layers.len());
+        let mut layer_tapes: Vec<Option<GdnLayerTape>> =
+            Vec::with_capacity(self.model.layers.len());
+
+        // Optional per-layer GDN/FA timing. Gated by env to avoid the eval()
+        // stalls (which serialize the GPU pipeline) in normal runs. Numbers
+        // produced under timing are upper bounds: they include synchronization
+        // cost that real execution overlaps. Useful for the GDN-vs-FA ratio.
+        let layer_timing = std::env::var("HIGGS_DFLASH_LAYER_TIMING")
+            .map(|v| v == "1")
+            .unwrap_or(false);
+        let mut gdn_total_ms = 0.0_f64;
+        let mut fa_total_ms = 0.0_f64;
+        let mut gdn_count = 0usize;
+        let mut fa_count = 0usize;
+        let mut layer_ckpt = if layer_timing {
+            mlx_rs::transforms::eval([&h])?;
+            Some(std::time::Instant::now())
+        } else {
+            None
+        };
+
+        for (layer_idx, (layer, layer_cache)) in self
+            .model
+            .layers
+            .iter_mut()
+            .zip(kv_cache.iter_mut())
+            .enumerate()
+        {
+            let cache = layer_cache
+                .as_mut()
+                .ok_or_else(|| Exception::custom("Layer cache is None"))?;
+            let is_linear = layer.is_linear;
+            let mask_ref = if is_linear { None } else { fa_mask.as_ref() };
+
+            let normed = layer.input_layernorm.forward(&h)?;
+
+            let (r, tape) = if is_linear {
+                let attn = layer
+                    .linear_attn
+                    .as_mut()
+                    .ok_or_else(|| Exception::custom("linear_attn missing"))?;
+                let LayerCache::Arrays(ssm_cache) = cache else {
+                    return Err(Exception::custom("Expected ArraysCache"));
+                };
+                let (out, tape) = attn.forward_with_tape(&normed, mask_ref, ssm_cache)?;
+                (out, Some(tape))
+            } else {
+                let attn = layer
+                    .self_attn
+                    .as_mut()
+                    .ok_or_else(|| Exception::custom("self_attn missing"))?;
+                let LayerCache::KV(layer_kv) = cache else {
+                    return Err(Exception::custom("Expected KVCache"));
+                };
+                (attn.forward(&normed, mask_ref, layer_kv)?, None)
+            };
+
+            layer_tapes.push(tape);
+
+            let h2 = h.add(r)?;
+            let normed_post = layer.post_attention_layernorm.forward(&h2)?;
+            let mlp_out = layer.mlp.forward(&normed_post)?;
+            h = h2.add(mlp_out)?;
+
+            if tap_layers.contains(&layer_idx) {
+                taps.push(h.clone());
+            }
+
+            if let Some(ckpt) = layer_ckpt.as_mut() {
+                mlx_rs::transforms::eval([&h])?;
+                let now = std::time::Instant::now();
+                let dt_ms = now.duration_since(*ckpt).as_secs_f64() * 1000.0;
+                if is_linear {
+                    gdn_total_ms += dt_ms;
+                    gdn_count += 1;
+                } else {
+                    fa_total_ms += dt_ms;
+                    fa_count += 1;
+                }
+                *ckpt = now;
+            }
+        }
+
+        let normed = self.model.norm.forward(&h)?;
+        let logits = self.project_logits(&normed)?;
+
+        if layer_timing {
+            mlx_rs::transforms::eval([&logits])?;
+            let tail_ms = layer_ckpt
+                .map(|c| c.elapsed().as_secs_f64() * 1000.0)
+                .unwrap_or(0.0);
+            tracing::info!(
+                "dflash_layer_timing seq={} gdn_layers={} gdn_total_ms={:.1} gdn_avg={:.2}ms \
+                 fa_layers={} fa_total_ms={:.1} fa_avg={:.2}ms tail_ms={:.1}",
+                T,
+                gdn_count,
+                gdn_total_ms,
+                gdn_total_ms / gdn_count.max(1) as f64,
+                fa_count,
+                fa_total_ms,
+                fa_total_ms / fa_count.max(1) as f64,
+                tail_ms,
+            );
+        }
+
+        Ok((logits, taps, layer_tapes))
+    }
+
+    /// Replay accepted steps from recorded tape data on partial rejection.
+    /// Restores GDN state from `snapshots`, replays `tape[:n_accepted]`,
+    /// and rolls back KV cache for rejected positions.
+    ///
+    /// All GDN layers are batched into a single Metal kernel dispatch
+    /// (concat along batch dim, one kernel call, split back) to avoid
+    /// per-layer dispatch overhead (~0.4ms × 24 layers = 10ms → <1ms).
+    // Numerical kernel: layer indices and counts known finite; explicit casts preferred over try_from.
+    #[allow(
+        clippy::too_many_lines,
+        clippy::indexing_slicing,
+        clippy::as_conversions,
+        clippy::cast_possible_truncation,
+        clippy::cast_possible_wrap
+    )]
+    pub fn replay_tape_rollback(
+        &self,
+        layer_tapes: &[Option<GdnLayerTape>],
+        kv_cache: &mut [Option<LayerCache>],
+        n_accepted: i32,
+        kv_rollback: i32,
+    ) -> Result<(), Exception> {
+        use mlx_rs::ops;
+
+        // Collect GDN layer data for batched replay
+        struct GdnReplayEntry<'a> {
+            cache_idx: usize,
+            tape: &'a GdnLayerTape,
+            layer: &'a GatedDeltaNet,
+            snap_state: Array,
+        }
+
+        let mut gdn_entries: Vec<GdnReplayEntry> = Vec::new();
+
+        // First pass: restore state from tape's initial snapshot, rollback KV, collect GDN entries
+        for (i, lc) in kv_cache.iter_mut().enumerate() {
+            match lc {
+                Some(LayerCache::Arrays(ac)) => {
+                    if let Some(Some(tape)) = layer_tapes.get(i) {
+                        // Restore from tape-captured initial state (Python _GDNStateCapture equivalent)
+                        ac.conv_state.clone_from(&tape.conv_state_init);
+                        ac.ssm_state.clone_from(&tape.ssm_state_init);
+                        ac.offset = tape.offset_init;
+
+                        let gdn_layer = self.model.layers[i]
+                            .linear_attn
+                            .as_ref()
+                            .ok_or_else(|| Exception::custom("linear_attn missing for replay"))?;
+
+                        let state = if let Some(s) = tape.ssm_state_init.clone() {
+                            s
+                        } else {
+                            let dt = tape.delta_tape.dtype();
+                            ops::zeros_dtype(
+                                &[
+                                    1,
+                                    gdn_layer.num_v_heads,
+                                    gdn_layer.head_v_dim,
+                                    gdn_layer.head_k_dim,
+                                ],
+                                dt,
+                            )?
+                        };
+
+                        gdn_entries.push(GdnReplayEntry {
+                            cache_idx: i,
+                            tape,
+                            layer: gdn_layer,
+                            snap_state: state,
+                        });
+                    }
+                }
+                Some(LayerCache::KV(kv)) if kv_rollback > 0 => {
+                    kv.trim_by(kv_rollback.unsigned_abs().try_into().unwrap_or(usize::MAX));
+                }
+                Some(LayerCache::KV(_)) | None => {}
+            }
+        }
+
+        if gdn_entries.is_empty() {
+            return Ok(());
+        }
+
+        // Batch all GDN layers: concat tape/k/a/state/A_log/dt_bias along batch dim
+        let tape_slices: Vec<Array> = gdn_entries
+            .iter()
+            .map(|e| e.tape.delta_tape.index((.., ..n_accepted, ..)))
+            .collect();
+        let k_slices: Vec<Array> = gdn_entries
+            .iter()
+            .map(|e| e.tape.norm_k.index((.., ..n_accepted, ..)))
+            .collect();
+        let a_slices: Vec<Array> = gdn_entries
+            .iter()
+            .map(|e| e.tape.a_proj.index((.., ..n_accepted, ..)))
+            .collect();
+        let states: Vec<&Array> = gdn_entries.iter().map(|e| &e.snap_state).collect();
+        let a_logs: Vec<&Array> = gdn_entries.iter().map(|e| e.layer.A_log.as_ref()).collect();
+        let dt_biases: Vec<&Array> = gdn_entries
+            .iter()
+            .map(|e| e.layer.dt_bias.as_ref())
+            .collect();
+
+        let tape_refs: Vec<&Array> = tape_slices.iter().collect();
+        let k_refs: Vec<&Array> = k_slices.iter().collect();
+        let a_refs: Vec<&Array> = a_slices.iter().collect();
+
+        let batched_tape = ops::concatenate_axis(&tape_refs, 0)?;
+        let batched_k = ops::concatenate_axis(&k_refs, 0)?;
+        let batched_a = ops::concatenate_axis(&a_refs, 0)?;
+        let batched_state = ops::concatenate_axis(&states, 0)?;
+        // Flatten A_log [Hv] per layer → [num_layers * Hv]
+        let batched_a_log = ops::concatenate_axis(&a_logs, 0)?;
+        let batched_dt_bias = ops::concatenate_axis(&dt_biases, 0)?;
+
+        let num_layers = gdn_entries.len() as i32;
+        let e0 = &gdn_entries[0];
+
+        // Single kernel dispatch for all GDN layers
+        let batched_new_state = tape_replay_kernel_ffi(
+            &batched_tape,
+            &batched_k,
+            &batched_a,
+            &batched_a_log,
+            &batched_dt_bias,
+            &batched_state,
+            num_layers,
+            n_accepted,
+            e0.layer.num_k_heads,
+            e0.layer.head_k_dim,
+            e0.layer.num_v_heads,
+            e0.layer.head_v_dim,
+        )?;
+
+        // Split results back to individual layers and rebuild conv_state
+        for (offset, entry) in gdn_entries.iter().enumerate() {
+            let Some(LayerCache::Arrays(ac)) = &mut kv_cache[entry.cache_idx] else {
+                continue;
+            };
+
+            // Extract this layer's state from the batched result
+            let start = offset as i32;
+            let new_state = batched_new_state.index((start..start + 1, .., .., ..));
+            ac.ssm_state = Some(new_state);
+            ac.offset += n_accepted;
+
+            // Rebuild conv_state from recorded qkv input
+            let ks = entry.layer.conv_kernel_size;
+            let n_keep = ks - 1;
+            if n_keep > 0 {
+                let qkv_slice = entry.tape.qkv_input.index((.., ..n_accepted, ..));
+                let prefix = match &ac.conv_state {
+                    Some(cs) => cs.clone(),
+                    None => ops::zeros_dtype(
+                        &[1, n_keep, entry.layer.conv_dim],
+                        entry.tape.qkv_input.dtype(),
+                    )?,
+                };
+                let full = ops::concatenate_axis(&[&prefix, &qkv_slice], 1)?;
+                let total_len = *full
+                    .shape()
+                    .get(1)
+                    .ok_or_else(|| Exception::custom("conv rebuild: missing seq dim"))?;
+                let cs_start = total_len - n_keep;
+                let cs = full.index((.., cs_start.., ..));
+                let cs_shape = cs.shape().to_vec();
+                ac.conv_state = Some(cs.flatten(None, None)?.reshape(&cs_shape)?);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Embed raw token IDs through the target model's embedding layer.
+    ///
+    /// Used by `DFlash` to convert `[anchor, mask, mask, ...]` block into
+    /// the embedding space expected by the drafter.
+    pub fn embed_token_ids(&self, token_ids: &Array) -> Result<Array, Exception> {
+        self.model.embed_tokens.forward(token_ids)
+    }
+
+    /// Apply only the `lm_head` to pre-computed hidden states.
+    ///
+    /// Used by `DFlash`: the drafter produces hidden states in the target model's
+    /// hidden space, and we project them through the target's `lm_head` to get logits.
+    /// Input: `[B, T, hidden_size]`. Returns: `[B, T, vocab_size]`.
+    pub fn forward_all_logits_from_hidden(&self, hidden: &Array) -> Result<Array, Exception> {
+        self.project_logits(hidden)
+    }
+
+    fn project_logits(&self, hidden: &Array) -> Result<Array, Exception> {
+        self.lm_head.as_ref().map_or_else(
+            || self.model.embed_tokens.as_linear(hidden),
+            |head| head.forward(hidden),
+        )
     }
 }
 
@@ -6477,6 +8049,203 @@ mod tests {
         assert!(
             max_diff < 1e-5,
             "compiled gdn_output_gate differs from raw by {max_diff}"
+        );
+    }
+
+    /// P2a gate (correctness): the DFlash tape replay must reconstruct the GDN
+    /// SSM state at a partial-accept boundary *exactly* like a fresh forward over
+    /// the accepted prefix. This bit-exactness is what makes greedy spec-decode
+    /// AR-identical regardless of draft quality (commit e23415da's whole point).
+    /// Tested at the kernel level (the projections need loaded quantized weights).
+    #[test]
+    #[allow(clippy::print_stderr, clippy::many_single_char_names)]
+    fn test_gdn_tape_replay_kernel_matches_forward() {
+        let (b_, kk, j, nk, dk, nv, dv) = (1, 8, 5, 2, 32, 4, 32);
+        let rnd = |s: &[i32]| mlx_rs::random::uniform::<f32, f32>(-1.0, 1.0, s, None).unwrap();
+        let q = rnd(&[b_, kk, nk, dk]);
+        let k = rnd(&[b_, kk, nk, dk]);
+        let v = rnd(&[b_, kk, nv, dv]);
+        let a = rnd(&[b_, kk, nv]);
+        let beta = rnd(&[b_, kk, nv]);
+        let a_log = Array::zeros::<f32>(&[nv]).unwrap();
+        let dt_bias = Array::zeros::<f32>(&[nv]).unwrap();
+        let s0 = Array::zeros::<f32>(&[b_, nv, dv, dk]).unwrap();
+
+        // Record the tape over the whole draft block.
+        let (_y, _sk, tape) = gated_delta_kernel_ffi_with_tape(
+            &q, &k, &v, &a_log, &a, &dt_bias, &beta, &s0, b_, kk, nk, dk, nv, dv,
+        )
+        .unwrap();
+
+        // Slice tape/inputs to the accepted prefix (mirrors replay_from_tape).
+        let sj = |arr: &Array| arr.index((.., ..j, ..));
+
+        // Ground truth: fresh forward kernel over the first j steps.
+        let (_yj, state_fwd) = gated_delta_kernel_ffi(
+            &sj(&q),
+            &sj(&k),
+            &sj(&v),
+            &a_log,
+            &sj(&a),
+            &dt_bias,
+            &sj(&beta),
+            &s0,
+            b_,
+            j,
+            nk,
+            dk,
+            nv,
+            dv,
+        )
+        .unwrap();
+
+        // Replay the first j steps from the recorded tape.
+        let state_replay = tape_replay_kernel_ffi(
+            &sj(&tape),
+            &sj(&k),
+            &sj(&a),
+            &a_log,
+            &dt_bias,
+            &s0,
+            b_,
+            j,
+            nk,
+            dk,
+            nv,
+            dv,
+        )
+        .unwrap();
+
+        mlx_rs::transforms::eval([&state_fwd, &state_replay]).unwrap();
+        let max_diff: f32 = state_fwd
+            .subtract(&state_replay)
+            .unwrap()
+            .abs()
+            .unwrap()
+            .max(None)
+            .unwrap()
+            .item();
+        eprintln!("tape-replay vs forward SSM max_diff = {max_diff:.2e}");
+        assert!(
+            max_diff < 1e-3,
+            "tape replay differs from forward by {max_diff}"
+        );
+    }
+
+    /// DFlash verify must be bit-exact with AR decode. The verify path uses the
+    /// tape kernel (S>1 block); AR decode uses the plain kernel. With **bf16**
+    /// inputs (the production dtype) both must keep the SSM state in f32 and
+    /// produce identical `y`/`state` — otherwise the verify argmax flips on
+    /// close calls and DFlash diverges from greedy AR. Regression for the bug
+    /// where the tape kernel downcast state to bf16 between timesteps.
+    #[test]
+    #[allow(clippy::print_stderr, clippy::many_single_char_names)]
+    fn test_gdn_tape_forward_matches_plain_forward_bf16() {
+        let (b_, t, nk, dk, nv, dv) = (1, 12, 2, 32, 4, 32);
+        let rnd_bf16 = |s: &[i32]| {
+            mlx_rs::random::uniform::<f32, f32>(-1.0, 1.0, s, None)
+                .unwrap()
+                .as_dtype(Dtype::Bfloat16)
+                .unwrap()
+        };
+        // Production dtypes: q/k/v/a/beta bf16, a_log/dt_bias/state f32.
+        let q = rnd_bf16(&[b_, t, nk, dk]);
+        let k = rnd_bf16(&[b_, t, nk, dk]);
+        let v = rnd_bf16(&[b_, t, nv, dv]);
+        let a = rnd_bf16(&[b_, t, nv]);
+        let beta = rnd_bf16(&[b_, t, nv]);
+        let a_log = Array::zeros::<f32>(&[nv]).unwrap();
+        let dt_bias = Array::zeros::<f32>(&[nv]).unwrap();
+        let s0 = Array::zeros::<f32>(&[b_, nv, dv, dk]).unwrap();
+
+        let (y_plain, st_plain) = gated_delta_kernel_ffi(
+            &q, &k, &v, &a_log, &a, &dt_bias, &beta, &s0, b_, t, nk, dk, nv, dv,
+        )
+        .unwrap();
+        let (y_tape, st_tape, _tape) = gated_delta_kernel_ffi_with_tape(
+            &q, &k, &v, &a_log, &a, &dt_bias, &beta, &s0, b_, t, nk, dk, nv, dv,
+        )
+        .unwrap();
+
+        let dmax = |x: &Array, y: &Array| -> f32 {
+            x.as_dtype(Dtype::Float32)
+                .unwrap()
+                .subtract(&y.as_dtype(Dtype::Float32).unwrap())
+                .unwrap()
+                .abs()
+                .unwrap()
+                .max(None)
+                .unwrap()
+                .item()
+        };
+        let y_diff = dmax(&y_plain, &y_tape);
+        let st_diff = dmax(&st_plain, &st_tape);
+        eprintln!("tape-vs-plain bf16: y_max_diff={y_diff:.2e} state_max_diff={st_diff:.2e}");
+        // y is stored bf16 in both kernels → identical. State is f32 in both →
+        // identical. Anything above bf16 epsilon means a precision divergence.
+        assert!(y_diff < 1e-2, "tape y differs from plain by {y_diff}");
+        assert!(st_diff < 1e-4, "tape state differs from plain by {st_diff}");
+    }
+
+    /// P2a gate (cost): rollback must be cheap vs recompute, or partial accepts
+    /// (every round) erode the spec-decode win. Times the tape-replay kernel vs
+    /// the forward kernel at the accepted length — and note the *real* rollback
+    /// win is bigger still, since replay skips all the QLinear projections.
+    #[test]
+    #[ignore = "bench: GDN tape-replay rollback kernel cost vs forward kernel"]
+    #[allow(
+        clippy::print_stderr,
+        clippy::cast_precision_loss,
+        clippy::many_single_char_names
+    )]
+    fn bench_gdn_tape_replay_rollback_cost() {
+        // Real Qwen3.6-35B-A3B GDN dims: 16 k-heads, 32 v-heads, 128 head dims.
+        let (b_, kk, j, nk, dk, nv, dv) = (1, 16, 10, 16, 128, 32, 128);
+        let rnd = |s: &[i32]| mlx_rs::random::uniform::<f32, f32>(-1.0, 1.0, s, None).unwrap();
+        let (q, k, v) = (
+            rnd(&[b_, kk, nk, dk]),
+            rnd(&[b_, kk, nk, dk]),
+            rnd(&[b_, kk, nv, dv]),
+        );
+        let (a, beta) = (rnd(&[b_, kk, nv]), rnd(&[b_, kk, nv]));
+        let a_log = Array::zeros::<f32>(&[nv]).unwrap();
+        let dt_bias = Array::zeros::<f32>(&[nv]).unwrap();
+        let s0 = Array::zeros::<f32>(&[b_, nv, dv, dk]).unwrap();
+        let (_y, _sk, tape) = gated_delta_kernel_ffi_with_tape(
+            &q, &k, &v, &a_log, &a, &dt_bias, &beta, &s0, b_, kk, nk, dk, nv, dv,
+        )
+        .unwrap();
+        let sj = |arr: &Array| arr.index((.., ..j, ..));
+        let (tj, kj, aj, qj, vj, bj) = (sj(&tape), sj(&k), sj(&a), sj(&q), sj(&v), sj(&beta));
+
+        let n = 100;
+        // warm
+        tape_replay_kernel_ffi(&tj, &kj, &aj, &a_log, &dt_bias, &s0, b_, j, nk, dk, nv, dv)
+            .unwrap();
+        let t0 = std::time::Instant::now();
+        for _ in 0..n {
+            let s =
+                tape_replay_kernel_ffi(&tj, &kj, &aj, &a_log, &dt_bias, &s0, b_, j, nk, dk, nv, dv)
+                    .unwrap();
+            mlx_rs::transforms::eval([&s]).unwrap();
+        }
+        let t_replay = t0.elapsed().as_secs_f64() / f64::from(n);
+
+        let t1 = std::time::Instant::now();
+        for _ in 0..n {
+            let (_y, s) = gated_delta_kernel_ffi(
+                &qj, &kj, &vj, &a_log, &aj, &dt_bias, &bj, &s0, b_, j, nk, dk, nv, dv,
+            )
+            .unwrap();
+            mlx_rs::transforms::eval([&s]).unwrap();
+        }
+        let t_forward = t1.elapsed().as_secs_f64() / f64::from(n);
+
+        eprintln!(
+            "GDN ROLLBACK KERNEL [accept={j}/{kk}]: replay={:.4}ms forward(SSM-only)={:.4}ms ratio={:.2}x  (real rollback also skips projections -> bigger win)",
+            t_replay * 1e3,
+            t_forward * 1e3,
+            t_replay / t_forward
         );
     }
 


### PR DESCRIPTION
Second split of the DFlash stack (from #204): the block-diffusion **drafter module** — drafter architecture, config parsing, safetensors loading hook, cache-crop helper, and `accept_prefix` tests.

## ⚠️ Stacking — please read
Stacked on #205 (split-1). GitHub cross-repo PRs can only target `main`, so **until #205 merges, this diff is cumulative** (it shows split-1 + split-2). Review the **top commit (`f515b868`)** only — the diff narrows to just the drafter once #205 lands.

Stack order: #205 (foundation) → **this (drafter)** → engine draft-verify loop → config/doctor/docs → per-request selection + streaming.

## Validation
- `cargo clippy` + `cargo fmt --check` — clean
- `cargo test -p higgs-models` (drafter + `accept_prefix`) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new speculative-decoding drafter implementation with configurable settings, drafter cache management, and prefix acceptance with a bonus token.
  * Expanded public model APIs to support forwarding with tap hidden states, returning verification “tape” outputs, and replaying rollback after acceptance.
  * Added hybrid-cache accessors and utilities to back up/restore hybrid state for safer speculative flows.

* **Chores**
  * Updated CI to run key checks on the `macos-15` GitHub-hosted runner for improved consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->