### PR TITLE
perf(turboquant): raise KV activation threshold 2048 → 100K

### DIFF
--- a/crates/higgs-models/src/cache.rs
+++ b/crates/higgs-models/src/cache.rs
@@ -18,7 +18,27 @@ pub enum KvCacheView {
 
 static TURBOQUANT_ACTIVATE_AT: OnceLock<i32> = OnceLock::new();
 static TURBOQUANT_INACTIVE_LOGGED: AtomicBool = AtomicBool::new(false);
-const DEFAULT_TURBOQUANT_ACTIVATE_AT: i32 = 2048;
+/// KV token count at which TurboQuant quantization activates for decode.
+///
+/// Default high because TurboQuant's custom Metal decode kernels are slower
+/// than MLX's dense SDPA. Benchmarked on Qwen3.5-9B-4bit (M4 32 GB), forcing
+/// activation via `HIGGS_TURBOQUANT_MIN_TOKENS=0`:
+///
+/// | context | dense | turboquant | Δ decode |
+/// |---------|-------|------------|----------|
+/// | ~15 tok | 15.6 tok/s | 11.7 tok/s | −25% |
+/// | ~7K tok | 12.5 tok/s | 10.1 tok/s | −19% |
+///
+/// (plus a multi-second first-token stall at 7K when the prefilled KV is
+/// bulk-quantized: TTFT 0.4 s → 6.4 s.) Dense KV costs only ~10 KB/token, so
+/// ~100K tokens fit in ~1 GB — TurboQuant's memory saving only pays for its
+/// decode tax near that scale. Lower via `HIGGS_TURBOQUANT_MIN_TOKENS` when
+/// context length genuinely threatens memory.
+// ponytail: fixed default; the real fix is a faster fused decode kernel
+// (turboquant.rs values kernel is O(T)/thread, no SIMD reduction) — until then
+// dense wins below ~100K, so gate TurboQuant off by default.
+#[allow(clippy::doc_markdown)]
+pub const DEFAULT_TURBOQUANT_ACTIVATE_AT: i32 = 100_000;
 
 fn parse_turboquant_activate_at(raw: Option<&str>) -> i32 {
     raw.and_then(|s| s.parse::<i32>().ok())

--- a/crates/higgs/src/doctor.rs
+++ b/crates/higgs/src/doctor.rs
@@ -284,6 +284,19 @@ fn check_models(config: &HiggsConfig, result: &mut DoctorResult) {
             );
             continue;
         }
+        if model.kv_cache_config().is_turboquant() {
+            let tq_default = higgs_models::cache::DEFAULT_TURBOQUANT_ACTIVATE_AT;
+            warn(
+                &format!(
+                    "model {label} sets kv_cache=turboquant: its custom Metal decode kernels are \
+                     ~20-25% slower than dense SDPA until the activation threshold (default \
+                     {tq_default} tokens; override with HIGGS_TURBOQUANT_MIN_TOKENS), plus a \
+                     first-token stall when prefilled KV is bulk-quantized. Dense KV is only \
+                     ~10 KB/token — prefer it unless very long context threatens memory."
+                ),
+                result,
+            );
+        }
         match model_resolver::resolve(&model.path) {
             Ok(resolved) => {
                 if model.batch {


### PR DESCRIPTION
## What

Raises the default TurboQuant KV activation threshold from **2048 → 100K** tokens, and adds a `doctor` warning for `kv_cache = "turboquant"`.

## Why

TurboQuant's custom Metal decode kernels (`decode_scores` / `decode_weighted_values`) are measurably slower than MLX's built-in dense SDPA. At the current `2048` default, any model configured with `kv_cache = "turboquant"` silently drops onto the slow path from ~2K tokens of context onward — exactly where you'd enable it.

Benchmarked with `bench_decode` on Qwen3.5-9B-4bit (M4 32 GB), same server, `--kv-cache off` vs `turboquant` (+ `HIGGS_TURBOQUANT_MIN_TOKENS=0` to force activation):

| context | dense decode | turboquant decode | Δ |
|---|---|---|---|
| ~15 tok | 15.6 tok/s | 11.7 tok/s | **−25%** |
| ~7K tok | 12.5 tok/s | 10.1 tok/s | **−19%** |

Plus a multi-second first-token stall at 7K when the prefilled KV is bulk-quantized (TTFT 0.4 s → 6.4 s). TurboQuant never wins in the tested range.

Dense KV costs only ~10 KB/token — ~1 GB at 100K context — so TurboQuant's memory saving only pays for its decode tax near that scale. The new default keeps decode on the fast dense path; set `HIGGS_TURBOQUANT_MIN_TOKENS` to opt back in when context length genuinely threatens memory.

## Changes
- `cache.rs`: `DEFAULT_TURBOQUANT_ACTIVATE_AT` `2048 → 100_000`, with the bench data in the doc comment.
- `doctor.rs`: `warn()` when a model sets `kv_cache = turboquant`.

## Follow-up
The real fix is a faster fused decode kernel — the values kernel is O(T)/thread with no SIMD-group reduction (flagged with a `ponytail:` marker in `cache.rs`). This PR just closes the footgun until then.

## Test
- `cargo fmt` + `cargo clippy -p higgs -p higgs-models` clean
- `cargo test -p higgs doctor -- --test-threads=1` → 42 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a warning in model checks when TurboQuant is enabled, highlighting expected performance behavior and the token-threshold override option.

* **Bug Fixes**
  * Increased the default TurboQuant activation threshold, so decoding stays in the standard mode for longer before switching behavior.
  * Kept existing validation behavior unchanged for invalid cache settings and unsupported batch/TurboQuant combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->