### PR TITLE
ci: pin macOS runners to macos-15 + bust poisoned mlx-sys cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   test:
     name: Test
-    runs-on: macos-latest
+    runs-on: macos-15 # pinned: macos-latest (macOS 26/Xcode 26.5) breaks MLX metallib link — deployment-target mismatch
     permissions:
       contents: read
 
@@ -33,13 +33,17 @@ jobs:
 
       - name: Cache cargo registry and build
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          # Bust cache poisoned by mlx-sys .air built on a different Xcode/macOS
+          # image (AIR 2.8 vs 2.7 link mismatch). Bump when the pinned image changes.
+          prefix-key: "v1-mlx-air-macos15"
 
       - name: Run tests
         run: cargo test --all-features -- --test-threads=1
 
   build:
     name: Build
-    runs-on: macos-latest
+    runs-on: macos-15 # pinned: macos-latest (macOS 26/Xcode 26.5) breaks MLX metallib link — deployment-target mismatch
     permissions:
       contents: read
 
@@ -54,13 +58,17 @@ jobs:
 
       - name: Cache cargo registry and build
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          # Bust cache poisoned by mlx-sys .air built on a different Xcode/macOS
+          # image (AIR 2.8 vs 2.7 link mismatch). Bump when the pinned image changes.
+          prefix-key: "v1-mlx-air-macos15"
 
       - name: Build release
         run: cargo build --release
 
   lint:
     name: Lint
-    runs-on: macos-latest
+    runs-on: macos-15 # pinned: macos-latest (macOS 26/Xcode 26.5) breaks MLX metallib link — deployment-target mismatch
     permissions:
       contents: read
 
@@ -76,6 +84,10 @@ jobs:
 
       - name: Cache cargo registry and build
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          # Bust cache poisoned by mlx-sys .air built on a different Xcode/macOS
+          # image (AIR 2.8 vs 2.7 link mismatch). Bump when the pinned image changes.
+          prefix-key: "v1-mlx-air-macos15"
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -85,7 +97,7 @@ jobs:
 
   msrv:
     name: MSRV
-    runs-on: macos-latest
+    runs-on: macos-15 # pinned: macos-latest (macOS 26/Xcode 26.5) breaks MLX metallib link — deployment-target mismatch
     permissions:
       contents: read
 
@@ -100,13 +112,17 @@ jobs:
 
       - name: Cache cargo registry and build
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          # Bust cache poisoned by mlx-sys .air built on a different Xcode/macOS
+          # image (AIR 2.8 vs 2.7 link mismatch). Bump when the pinned image changes.
+          prefix-key: "v1-mlx-air-macos15"
 
       - name: Check MSRV
         run: cargo check --all-features
 
   coverage:
     name: Coverage
-    runs-on: macos-latest
+    runs-on: macos-15 # pinned: macos-latest (macOS 26/Xcode 26.5) breaks MLX metallib link — deployment-target mismatch
     permissions:
       contents: read
 
@@ -126,6 +142,10 @@ jobs:
 
       - name: Cache cargo registry and build
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          # Bust cache poisoned by mlx-sys .air built on a different Xcode/macOS
+          # image (AIR 2.8 vs 2.7 link mismatch). Bump when the pinned image changes.
+          prefix-key: "v1-mlx-air-macos15"
 
       - name: Generate coverage and enforce threshold
         run: |


### PR DESCRIPTION
## What
Fix the macOS CI failures, two root causes:
1. **Pin** all macOS jobs `macos-latest → macos-15`.
2. **Bust** the `Swatinem/rust-cache` cache (bump `prefix-key`) to evict poisoned mlx-sys `.air` artifacts.

## Why
`macos-latest` is rolling to **macOS 26 / Xcode 26.5** unevenly — different jobs in the same run land on different images, producing two distinct failures:

- **macОS 26 runners** — Metal toolchain can't link MLX's metallib for the `macosx15.0` deployment target:
  ```
  LLVM ERROR: Cannot link symbol 'air.normalize_function_constant_predicate.i8':
  Used in deployment target macosx15.0.0 but defined in deployment target macosx26.0.0
  ```
- **macОS 15 runners** — reuse mlx-sys `.air` files that a prior macOS 26 run compiled as **AIR 2.8** and cached; the 2.7 metallib linker rejects them:
  ```
  error: air version set to 2.8.0 ... but expecting 2.7 in steel_attention_...
  ```

Pinning to `macos-15` gives a consistent Xcode 16.4; the `prefix-key` bump clears the cross-image `.air` poison so it rebuilds fresh. Reproduced on every PR (including unrelated renovate ones) since ~2026-06-24 — not any code change. `ubuntu-latest` job unchanged.

Temporary — revert the pin (and bump `prefix-key` again) once `mlx-rs` supports the macOS 26 Metal toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
