### PR TITLE
fix: suffix float literals for new float_literal_f32_fallback lint

### DIFF
--- a/crates/higgs-models/src/deepseek_v2.rs
+++ b/crates/higgs-models/src/deepseek_v2.rs
@@ -293,7 +293,7 @@ impl DeepSeekV2Attention {
                     Some(QLinear::new(ql, qb)?),
                     Some(
                         nn::RmsNormBuilder::new(args.q_lora_rank.unwrap_or(0))
-                            .eps(1e-6)
+                            .eps(1e-6_f32)
                             .build()?,
                     ),
                     Some(QLinear::new(ql, qb)?),
@@ -367,7 +367,7 @@ impl DeepSeekV2Attention {
             q_proj,
             kv_a_proj_with_mqa: QLinear::new(ql, qb)?,
             kv_a_layernorm: nn::RmsNormBuilder::new(args.kv_lora_rank)
-                .eps(1e-6)
+                .eps(1e-6_f32)
                 .build()?,
             kv_b_proj: QLinear::new(ql, qb)?,
             o_proj: QLinear::new(ql, qb)?,

--- a/crates/higgs-models/src/gemma2.rs
+++ b/crates/higgs-models/src/gemma2.rs
@@ -173,7 +173,7 @@ impl Gemma2Attention {
         let rope = nn::RopeBuilder::new(head_dim)
             .traditional(false)
             .base(args.rope_theta)
-            .scale(1.0)
+            .scale(1.0_f32)
             .build()
             .map_err(|e| Exception::custom(format!("Failed to build RoPE: {e}")))?;
 

--- a/crates/higgs-models/src/gemma3.rs
+++ b/crates/higgs-models/src/gemma3.rs
@@ -235,7 +235,7 @@ impl Gemma3Attention {
         let rope = nn::RopeBuilder::new(head_dim)
             .traditional(false)
             .base(rope_base)
-            .scale(1.0)
+            .scale(1.0_f32)
             .build()
             .map_err(|e| Exception::custom(format!("Failed to build RoPE: {e}")))?;
 

--- a/crates/higgs-models/src/gemma4.rs
+++ b/crates/higgs-models/src/gemma4.rs
@@ -639,7 +639,7 @@ impl Gemma4Attention {
         let rope = nn::RopeBuilder::new(rope_dims)
             .traditional(false)
             .base(rope_theta)
-            .scale(1.0)
+            .scale(1.0_f32)
             .build()
             .map_err(|e| Exception::custom(format!("Failed to build RoPE: {e}")))?;
 
@@ -686,7 +686,7 @@ impl Gemma4Attention {
         let rope = nn::RopeBuilder::new(rope_dims)
             .traditional(false)
             .base(rope_theta)
-            .scale(1.0)
+            .scale(1.0_f32)
             .build()
             .map_err(|e| Exception::custom(format!("Failed to build RoPE: {e}")))?;
 

--- a/crates/higgs-models/src/phi3.rs
+++ b/crates/higgs-models/src/phi3.rs
@@ -137,7 +137,7 @@ impl Phi3Attention {
         let rope = nn::RopeBuilder::new(head_dim)
             .traditional(false)
             .base(args.rope_theta)
-            .scale(1.0)
+            .scale(1.0_f32)
             .build()
             .map_err(|e| Exception::custom(format!("Failed to build RoPE: {e}")))?;
 

--- a/crates/higgs-models/src/qwen3_moe.rs
+++ b/crates/higgs-models/src/qwen3_moe.rs
@@ -146,7 +146,7 @@ impl Qwen3MoeAttention {
             rope: nn::RopeBuilder::new(head_dim)
                 .traditional(false)
                 .base(args.rope_theta)
-                .scale(1.0)
+                .scale(1.0_f32)
                 .build()
                 .map_err(|e| Exception::custom(format!("Failed to build RoPE: {e}")))?,
             num_attention_heads: args.num_attention_heads,

--- a/crates/higgs-models/src/qwen3_next.rs
+++ b/crates/higgs-models/src/qwen3_next.rs
@@ -1453,7 +1453,7 @@ impl Qwen3NextAttention {
             rope: nn::RopeBuilder::new(partial_dim)
                 .traditional(false)
                 .base(args.rope_theta)
-                .scale(1.0)
+                .scale(1.0_f32)
                 .build()
                 .map_err(|e| Exception::custom(format!("Failed to build RoPE: {e}")))?,
             num_attention_heads: args.num_attention_heads,
@@ -1631,7 +1631,7 @@ impl DenseQwen3NextAttention {
             rope: nn::RopeBuilder::new(partial_dim)
                 .traditional(false)
                 .base(args.rope_theta)
-                .scale(1.0)
+                .scale(1.0_f32)
                 .build()
                 .map_err(|e| Exception::custom(format!("Failed to build RoPE: {e}")))?,
             num_attention_heads: args.num_attention_heads,

--- a/crates/higgs-models/src/starcoder2.rs
+++ b/crates/higgs-models/src/starcoder2.rs
@@ -188,7 +188,7 @@ impl Starcoder2Attention {
         let rope = nn::RopeBuilder::new(head_dim)
             .traditional(false)
             .base(args.rope_theta)
-            .scale(1.0)
+            .scale(1.0_f32)
             .build()
             .map_err(|e| Exception::custom(format!("Failed to build RoPE: {e}")))?;
 

--- a/crates/higgs-models/src/transformer.rs
+++ b/crates/higgs-models/src/transformer.rs
@@ -231,7 +231,7 @@ impl Attention {
         let rope = nn::RopeBuilder::new(head_dim)
             .traditional(false)
             .base(args.rope_theta)
-            .scale(1.0)
+            .scale(1.0_f32)
             .build()
             .map_err(|e| Exception::custom(format!("Failed to build RoPE: {e}")))?;
 

--- a/crates/higgs/src/routes/chat.rs
+++ b/crates/higgs/src/routes/chat.rs
@@ -460,10 +460,7 @@ fn chat_completions_stream(
     // [`StreamingToolCallTracker`] below intercepts `<tool_call>…
     // </tool_call>` blocks the model produces and turns them into
     // structured `ToolCallDelta` SSE events.
-    let prompt_tools = req
-        .tools
-        .as_deref()
-        .filter(|t| !t.is_empty());
+    let prompt_tools = req.tools.as_deref().filter(|t| !t.is_empty());
     let mut prompt_tokens = engine
         .prepare_chat_prompt_with_thinking(&messages, prompt_tools, thinking_enabled_stream)
         .map_err(ServerError::Engine)?;

--- a/crates/higgs/src/routes/chat.rs
+++ b/crates/higgs/src/routes/chat.rs
@@ -463,7 +463,7 @@ fn chat_completions_stream(
     let prompt_tools = req
         .tools
         .as_deref()
-        .and_then(|t| if t.is_empty() { None } else { Some(t) });
+        .filter(|t| !t.is_empty());
     let mut prompt_tokens = engine
         .prepare_chat_prompt_with_thinking(&messages, prompt_tools, thinking_enabled_stream)
         .map_err(ServerError::Engine)?;

--- a/crates/higgs/src/types/openai.rs
+++ b/crates/higgs/src/types/openai.rs
@@ -505,7 +505,7 @@ mod tests {
         }"#;
         let req: ChatCompletionRequest = serde_json::from_str(json).unwrap();
         assert_eq!(req.max_tokens, Some(100));
-        assert!(req.stream == Some(true));
+        assert_eq!(req.stream, Some(true));
         assert!(req.reasoning.is_none());
     }
 


### PR DESCRIPTION
## What
Adds explicit `_f32` suffixes at the 12 call sites (`.scale(1.0)`, `.eps(1e-6)`) flagged by the new `float_literal_f32_fallback` lint (rust-lang/rust#154024), which the latest stable rustc on CI runners now emits and `RUSTFLAGS: -Dwarnings` promotes to an error.

## Why
Every branch — main included — currently fails Build/Lint/Test on fresh CI runs since the runners picked up the new stable toolchain. This unblocks all open PRs. Exact fix suggested by the compiler; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed streaming chat requests with an empty tools list so they are handled consistently with non-streaming requests.
  - Non-empty tool configurations continue to work as before.

- **Refactor**
  - Standardized numerical precision for attention and positional encoding settings across supported models.
  - No user-visible behavior or public API changes are expected from these precision updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->