### PR TITLE
feat(bench): context-frontier benchmark with shared cache rollback helper (PR2 / ds4 P8)

### DIFF
--- a/crates/higgs-bench/Cargo.toml
+++ b/crates/higgs-bench/Cargo.toml
@@ -18,7 +18,7 @@ clap = { workspace = true }
 futures = { workspace = true }
 higgs-engine = { workspace = true }
 higgs-models = { workspace = true }
-mlx-rs.workspace = true
+mlx-rs = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -37,6 +37,10 @@ tempfile = "3"
 [[bin]]
 name = "bench_decode"
 path = "src/bin/bench_decode.rs"
+
+[[bin]]
+name = "bench_frontier"
+path = "src/bin/bench_frontier.rs"
 
 [[bin]]
 name = "bench_speculative"

--- a/crates/higgs-bench/src/bin/bench_frontier.rs
+++ b/crates/higgs-bench/src/bin/bench_frontier.rs
@@ -1,0 +1,332 @@
+#![allow(
+    clippy::as_conversions,
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::print_stderr,
+    clippy::print_stdout,
+    clippy::shadow_reuse,
+    clippy::too_many_lines,
+    clippy::unwrap_used
+)]
+//! In-process context-frontier benchmark for decode throughput and KV memory.
+
+use std::fmt::Write as _;
+use std::path::PathBuf;
+use std::process::ExitCode;
+use std::time::Instant;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use higgs_bench::{
+    BENCH_SCHEMA_VERSION, BenchOutput, ModelInfo, OutputFormat, RunMetadata, format_json,
+    format_markdown, persist_result, public_model_ref,
+};
+use higgs_engine::{
+    model_loader::{load_model, load_tokenizer},
+    tokenizers,
+};
+use higgs_models::{AnyCache, turboquant::KvCacheConfig};
+use mlx_rs::{Array, argmax_axis, transforms::eval};
+use serde::Serialize;
+
+const DEFAULT_FRONTIERS: &str = "2048,4096,8192,16384";
+const PREFILL_CHUNK_SIZE: i32 = 512;
+const CORPUS: &str = "The benchmark corpus is deliberately ordinary prose. It creates stable tokenized context while exercising attention cache growth. Local inference performance depends on both cache layout and the cost of reading it during decode. ";
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "bench_frontier",
+    about = "Measure decode and KV memory at context frontiers",
+    version
+)]
+struct Args {
+    /// Local model directory (not a benchmark manifest key).
+    #[arg(long)]
+    model_dir: PathBuf,
+
+    /// Ascending comma-separated context lengths in tokens.
+    #[arg(long, default_value = DEFAULT_FRONTIERS)]
+    frontiers: String,
+
+    /// Greedy decode tokens sampled at each frontier (32-128).
+    #[arg(long, default_value_t = 64)]
+    probe_tokens: usize,
+
+    /// Number of complete frontier sweeps.
+    #[arg(long, default_value_t = 1)]
+    runs: usize,
+
+    /// Verify the first KV frontier against an expected bytes-per-token value.
+    #[arg(long)]
+    verify_kv_analytic: bool,
+
+    /// Expected dense-KV bytes per token; required with --verify-kv-analytic.
+    #[arg(long)]
+    expect_kv_bytes_per_token: Option<f64>,
+
+    #[arg(long, value_enum, default_value_t = OutputFormat::Json)]
+    format: OutputFormat,
+}
+
+#[derive(Debug, Serialize)]
+struct Params {
+    model_dir: String,
+    frontiers: Vec<usize>,
+    probe_tokens: usize,
+    runs: usize,
+    verify_kv_analytic: bool,
+    expect_kv_bytes_per_token: Option<f64>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct FrontierRow {
+    run: usize,
+    frontier: usize,
+    incremental_prefill_ms: f64,
+    prefill_tokps: f64,
+    probe_decode_tokps: f64,
+    kv_bytes: usize,
+    kv_bytes_per_token: f64,
+}
+
+#[derive(Debug, Serialize)]
+struct Results {
+    rows: Vec<FrontierRow>,
+    analytic_verified: Option<bool>,
+}
+
+fn main() -> ExitCode {
+    match run(&Args::parse()) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("error: {error:#}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+fn run(args: &Args) -> Result<()> {
+    if !(32..=128).contains(&args.probe_tokens) {
+        anyhow::bail!("--probe-tokens must be in 32..=128");
+    }
+    if args.runs == 0 {
+        anyhow::bail!("--runs must be >= 1");
+    }
+    let frontiers = parse_frontiers(&args.frontiers)?;
+    let expected_bpt = match (args.verify_kv_analytic, args.expect_kv_bytes_per_token) {
+        (true, Some(value)) if value > 0.0 => Some(value),
+        (true, _) => {
+            anyhow::bail!("--verify-kv-analytic requires positive --expect-kv-bytes-per-token")
+        }
+        (false, _) => None,
+    };
+
+    let mut metadata = RunMetadata::capture("bench_frontier");
+    let started = Instant::now();
+    let model_path = args.model_dir.to_string_lossy().into_owned();
+    metadata.model = Some(ModelInfo {
+        key: args
+            .model_dir
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("local-model")
+            .to_owned(),
+        path: public_model_ref(&model_path, ""),
+        quantization: "local".to_owned(),
+        approx_size_gb: 0.0,
+    });
+
+    let mut model = load_model(&args.model_dir).context("load model")?;
+    let tokenizer = load_tokenizer(&args.model_dir).context("load tokenizer")?;
+    let prompt_tokens =
+        synthetic_prompt(&tokenizer, *frontiers.last().expect("frontiers validated"))?;
+    let mut rows = Vec::with_capacity(args.runs * frontiers.len());
+
+    for run_index in 0..args.runs {
+        let mut cache = model
+            .make_cache_with_config(KvCacheConfig::default())
+            .context("create KV cache")?;
+        let mut previous = 0;
+        for &frontier in &frontiers {
+            let incremental_tokens = frontier - previous;
+            eval(cache.eval_targets()).context("evaluate cache before prefill timing")?;
+            let prefill_started = Instant::now();
+            let logits = model
+                .forward_chunked(
+                    &token_array(&prompt_tokens[previous..frontier])?,
+                    &mut cache,
+                    PREFILL_CHUNK_SIZE,
+                )
+                .context("incremental prefill")?;
+            eval([&logits]).context("evaluate prefill logits")?;
+            let prefill_ms = prefill_started.elapsed().as_secs_f64() * 1_000.0;
+            previous = frontier;
+
+            let kv_bytes = cache.eval_targets().into_iter().map(Array::nbytes).sum();
+            let checkpoint = cache.checkpoint_for_rollback();
+            let probe_tokps = decode_probe(&mut model, &mut cache, logits, args.probe_tokens)?;
+            cache.rollback(checkpoint, args.probe_tokens);
+
+            rows.push(FrontierRow {
+                run: run_index + 1,
+                frontier,
+                incremental_prefill_ms: prefill_ms,
+                prefill_tokps: incremental_tokens as f64 / (prefill_ms / 1_000.0),
+                probe_decode_tokps: probe_tokps,
+                kv_bytes,
+                kv_bytes_per_token: kv_bytes as f64 / frontier as f64,
+            });
+        }
+    }
+
+    let first_row = rows.first().context("frontier sweep produced no rows")?;
+    let analytic_verified = expected_bpt
+        .map(|expected| verify_kv_bytes(first_row.kv_bytes, expected, first_row.frontier))
+        .transpose()?
+        .map(|()| true);
+    metadata.duration_ms = started.elapsed().as_millis() as u64;
+    let output = BenchOutput {
+        schema_version: BENCH_SCHEMA_VERSION,
+        metadata,
+        params: Params {
+            model_dir: public_model_ref(&model_path, ""),
+            frontiers,
+            probe_tokens: args.probe_tokens,
+            runs: args.runs,
+            verify_kv_analytic: args.verify_kv_analytic,
+            expect_kv_bytes_per_token: args.expect_kv_bytes_per_token,
+        },
+        results: Results {
+            rows,
+            analytic_verified,
+        },
+    };
+    let path = persist_result(&output)?;
+    eprintln!("[persisted] {}", higgs_bench::path_for_output(&path));
+    println!(
+        "{}",
+        match args.format {
+            OutputFormat::Json => format_json(&output)?,
+            OutputFormat::Markdown => format_frontier_markdown(&output)?,
+        }
+    );
+    Ok(())
+}
+
+fn synthetic_prompt(tokenizer: &tokenizers::Tokenizer, maximum: usize) -> Result<Vec<u32>> {
+    let corpus = tokenizer
+        .encode(CORPUS, false)
+        .map_err(|error| anyhow::anyhow!("tokenize synthetic corpus: {error}"))?;
+    let ids = corpus.get_ids();
+    if ids.is_empty() {
+        anyhow::bail!("synthetic corpus tokenized to zero tokens");
+    }
+    Ok(ids.iter().copied().cycle().take(maximum).collect())
+}
+
+fn token_array(tokens: &[u32]) -> Result<Array> {
+    let tokens: Vec<i32> = tokens
+        .iter()
+        .copied()
+        .map(|id| i32::try_from(id).context("token id exceeds i32 range"))
+        .collect::<Result<_>>()?;
+    let length = i32::try_from(tokens.len()).context("token array exceeds i32 dimensions")?;
+    Ok(Array::from_slice(&tokens, &[1, length]))
+}
+
+fn decode_probe(
+    model: &mut higgs_models::AnyModel,
+    cache: &mut AnyCache,
+    mut logits: Array,
+    probe_tokens: usize,
+) -> Result<f64> {
+    let mut elapsed = 0.0;
+    for step in 0..probe_tokens {
+        let token = argmax_axis!(&logits, -1).context("argmax greedy token")?;
+        eval([&token]).context("evaluate greedy token")?;
+        let input = token_array(&[token.item::<u32>()])?;
+        let started = Instant::now();
+        logits = model
+            .forward_last_token(&input, None, cache)
+            .context("decode probe step")?;
+        eval([&logits]).context("evaluate decode logits")?;
+        if step > 0 {
+            elapsed += started.elapsed().as_secs_f64();
+        }
+    }
+    Ok((probe_tokens - 1) as f64 / elapsed)
+}
+
+fn parse_frontiers(raw: &str) -> Result<Vec<usize>> {
+    let values: Vec<usize> = raw
+        .split(',')
+        .map(str::trim)
+        .map(|value| {
+            value
+                .parse::<usize>()
+                .with_context(|| format!("invalid frontier {value:?}"))
+        })
+        .collect::<Result<_>>()?;
+    if values.is_empty() || values.contains(&0) {
+        anyhow::bail!("--frontiers must contain positive lengths");
+    }
+    if values.windows(2).any(|pair| pair[0] >= pair[1]) {
+        anyhow::bail!("--frontiers must be strictly ascending");
+    }
+    Ok(values)
+}
+
+fn verify_kv_bytes(measured: usize, bytes_per_token: f64, frontier: usize) -> Result<()> {
+    let expected = bytes_per_token * frontier as f64;
+    let relative_error = (measured as f64 - expected).abs() / expected;
+    if relative_error > 0.10 {
+        anyhow::bail!(
+            "KV analytic check failed: measured {measured} bytes, expected {expected:.0} bytes ({:.1}% error)",
+            relative_error * 100.0
+        );
+    }
+    Ok(())
+}
+
+fn format_frontier_markdown(output: &BenchOutput<Params, Results>) -> Result<String> {
+    let mut markdown = format_markdown(output)?;
+    markdown.push_str("\n\n## Frontier rows\n\n| Run | Frontier | Incremental prefill ms | Prefill tok/s | Probe decode tok/s | KV bytes | KV bytes/token |\n|---:|---:|---:|---:|---:|---:|---:|\n");
+    for row in &output.results.rows {
+        writeln!(
+            markdown,
+            "| {} | {} | {:.3} | {:.2} | {:.2} | {} | {:.2} |",
+            row.run,
+            row.frontier,
+            row.incremental_prefill_ms,
+            row.prefill_tokps,
+            row.probe_decode_tokps,
+            row.kv_bytes,
+            row.kv_bytes_per_token
+        )?;
+    }
+    Ok(markdown)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_frontiers, verify_kv_bytes};
+
+    #[test]
+    fn parses_sorted_unique_frontiers() {
+        assert_eq!(
+            parse_frontiers("2048,4096,8192").unwrap(),
+            vec![2048, 4096, 8192]
+        );
+        assert!(parse_frontiers("4096,2048").is_err());
+        assert!(parse_frontiers("2048,2048").is_err());
+    }
+
+    #[test]
+    fn accepts_kv_measurement_within_ten_percent() {
+        assert!(verify_kv_bytes(109, 1.0, 100).is_ok());
+        assert!(verify_kv_bytes(111, 1.0, 100).is_err());
+    }
+}

--- a/crates/higgs-engine/src/mtp.rs
+++ b/crates/higgs-engine/src/mtp.rs
@@ -19,33 +19,12 @@ const fn draft_matches_target(draft_token_id: u32, target_id: u32) -> bool {
     draft_token_id == target_id
 }
 
-/// Capture a backbone-cache rollback point before a speculative verify.
-///
-/// KV caches are rolled back by *trimming the offset* (see [`rollback_backbone`]),
-/// so we deliberately return `None` and never clone them. Cloning a KV cache and
-/// later restoring it (`*cache = base`) makes the checkpoint share the live
-/// cache's underlying MLX buffers; the in-place `slice_update` writes during
-/// verify then let MLX donate a buffer that the checkpoint still references,
-/// corrupting it and double-freeing on drop (the `malloc: pointer being freed
-/// was not allocated` abort). Hybrid SSM/recurrent state cannot be offset-
-/// trimmed, so those still need a full clone-restore.
 fn capture_backbone_checkpoint(cache: &AnyCache) -> Option<AnyCache> {
-    match cache {
-        AnyCache::KV(_) => None,
-        AnyCache::Hybrid(_) => Some(cache.deep_clone()),
-    }
+    cache.checkpoint_for_rollback()
 }
 
-/// Roll the backbone cache back after a rejected speculative verify.
-///
-/// `verify_len` is the number of tokens the verify batch advanced the cache by.
-/// KV caches rewind by `trim_by(verify_len)` (no clone, no buffer aliasing);
-/// hybrid caches restore the clone captured by [`capture_backbone_checkpoint`].
 fn rollback_backbone(cache: &mut AnyCache, checkpoint: Option<AnyCache>, verify_len: usize) {
-    match checkpoint {
-        Some(base) => *cache = base,
-        None => cache.trim_by(verify_len),
-    }
+    cache.rollback(checkpoint, verify_len);
 }
 
 /// Aggregate MTP decode counters.

--- a/crates/higgs-models/src/lib.rs
+++ b/crates/higgs-models/src/lib.rs
@@ -123,6 +123,63 @@ impl AnyCache {
         }
     }
 
+    /// Capture a rollback point before an operation that advances this cache.
+    ///
+    /// KV caches are rolled back by trimming their offset, so they deliberately
+    /// return `None` and are never cloned. Restoring a cloned KV cache would
+    /// make the checkpoint share the live cache's underlying MLX buffers; an
+    /// in-place `slice_update` can then donate a buffer still referenced by the
+    /// checkpoint, corrupting it and causing a double-free on drop. Hybrid SSM/
+    /// recurrent state cannot be offset-trimmed, so it requires a full clone.
+    #[must_use]
+    pub fn checkpoint_for_rollback(&self) -> Option<Self> {
+        match self {
+            Self::KV(_) => None,
+            Self::Hybrid(_) => Some(self.deep_clone()),
+        }
+    }
+
+    /// Undo an operation that advanced this cache by `advanced_by` tokens.
+    ///
+    /// A hybrid checkpoint restores recurrent state exactly. KV-only caches use
+    /// `trim_by`, avoiding MLX buffer aliasing while rewinding their offsets.
+    pub fn rollback(&mut self, checkpoint: Option<Self>, advanced_by: usize) {
+        if let Some(base) = checkpoint {
+            *self = base;
+        } else {
+            self.trim_by(advanced_by);
+        }
+    }
+
+    /// References to every array retained by this cache.
+    #[must_use]
+    pub fn eval_targets(&self) -> Vec<&Array> {
+        let mut targets = Vec::new();
+        match self {
+            Self::KV(layers) => {
+                for layer in layers.iter().flatten() {
+                    targets.extend(layer.eval_targets());
+                }
+            }
+            Self::Hybrid(layers) => {
+                for layer in layers.iter().flatten() {
+                    match layer {
+                        LayerCache::KV(kv) => targets.extend(kv.eval_targets()),
+                        LayerCache::Arrays(arrays) => {
+                            if let Some(conv_state) = &arrays.conv_state {
+                                targets.push(conv_state);
+                            }
+                            if let Some(ssm_state) = &arrays.ssm_state {
+                                targets.push(ssm_state);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        targets
+    }
+
     /// An **independent** deep copy for use as a speculative-decode checkpoint.
     /// KV layers are deep-cloned (their in-place `slice_update` buffers must not
     /// be shared — see [`cache::SteppingKeyValueCache::deep_clone`]); GDN/SSM
@@ -2166,5 +2223,16 @@ mod tests {
         } else {
             panic!("expected Hybrid variant");
         }
+    }
+
+    #[test]
+    fn any_cache_checkpoint_uses_trim_for_kv_and_clone_for_hybrid() {
+        let kv = AnyCache::KV(vec![Some(cache::SteppingKeyValueCache::new())]);
+        assert!(kv.checkpoint_for_rollback().is_none());
+
+        let hybrid = AnyCache::Hybrid(vec![Some(LayerCache::KV(
+            cache::SteppingKeyValueCache::new(),
+        ))]);
+        assert!(hybrid.checkpoint_for_rollback().is_some());
     }
 }

--- a/scripts/validate/report.py
+++ b/scripts/validate/report.py
@@ -31,6 +31,41 @@ def stats(values):
     }
 
 
+def render_frontier_section(baseline_path, candidate_path):
+    baseline_rows = json.loads(baseline_path.read_text())["results"]["rows"]
+    candidate_rows = json.loads(candidate_path.read_text())["results"]["rows"]
+
+    def by_frontier(rows):
+        grouped = {}
+        for row in rows:
+            grouped.setdefault(row["frontier"], []).append(row)
+        return grouped
+
+    baseline_by_frontier = by_frontier(baseline_rows)
+    candidate_by_frontier = by_frontier(candidate_rows)
+    frontiers = sorted(set(baseline_by_frontier) & set(candidate_by_frontier))
+
+    section = "## Frontier\n\n"
+    section += (
+        "| Frontier | Baseline decode tok/s | Candidate decode tok/s | Delta | "
+        "Baseline KV B/tok | Candidate KV B/tok |\n"
+        "| ---: | ---: | ---: | ---: | ---: | ---: |\n"
+    )
+    for frontier in frontiers:
+        base_rows = baseline_by_frontier[frontier]
+        cand_rows = candidate_by_frontier[frontier]
+        base_decode = statistics.median(row["probe_decode_tokps"] for row in base_rows)
+        cand_decode = statistics.median(row["probe_decode_tokps"] for row in cand_rows)
+        base_kv = statistics.median(row["kv_bytes_per_token"] for row in base_rows)
+        cand_kv = statistics.median(row["kv_bytes_per_token"] for row in cand_rows)
+        delta = (cand_decode / base_decode - 1.0) * 100.0 if base_decode else 0.0
+        section += (
+            f"| {frontier} | {base_decode:.2f} | {cand_decode:.2f} | {delta:+.2f}% | "
+            f"{base_kv:.2f} | {cand_kv:.2f} |\n"
+        )
+    return section
+
+
 def render_quality_section(quality_path):
     payload = json.loads(quality_path.read_text())
     verdict = "PASS" if payload["passed"] else "FAIL"
@@ -54,12 +89,16 @@ def main():
     baseline_path = raw / "baseline.json"
     candidate_path = raw / "candidate.json"
     quality_path = raw / "quality.json"
+    frontier_baseline_path = raw / "frontier-baseline.json"
+    frontier_candidate_path = raw / "frontier-candidate.json"
     has_decode = baseline_path.exists() and candidate_path.exists()
     has_quality = quality_path.exists()
-    if not has_decode and not has_quality:
+    has_frontier = frontier_baseline_path.exists() and frontier_candidate_path.exists()
+    if not has_decode and not has_quality and not has_frontier:
         raise SystemExit(
             f"no results to report: expected decode results at {baseline_path} and {candidate_path}, "
-            f"or a quality gate result at {quality_path}"
+            f"a quality gate result at {quality_path}, or frontier results at "
+            f"{frontier_baseline_path} and {frontier_candidate_path}"
         )
 
     rows = ["side,run,decode_tokps"]
@@ -91,6 +130,11 @@ def main():
         if has_decode:
             report += "\n"
         report += render_quality_section(quality_path)
+
+    if has_frontier:
+        if has_decode or has_quality:
+            report += "\n"
+        report += render_frontier_section(frontier_baseline_path, frontier_candidate_path)
 
     (args.out_dir / "runs.csv").write_text(scrub("\n".join(rows) + "\n"))
     (args.out_dir / "report.md").write_text(scrub(report))

--- a/scripts/validate/run.sh
+++ b/scripts/validate/run.sh
@@ -108,6 +108,12 @@ build_ref() {
     if [[ -n "${build_marker:-}" ]] && [[ -f "$shared_target_dir/release/quality_gate" ]] && [[ "$shared_target_dir/release/quality_gate" -nt "$build_marker" ]]; then
         cp "$shared_target_dir/release/quality_gate" "$build_dir/release/quality_gate"
     fi
+    # bench_frontier postdates some baseline SHAs the same way quality_gate
+    # does; guard against both absence and a stale cross-sha binary left in
+    # the shared target dir by the same marker-freshness check.
+    if [[ -n "${build_marker:-}" ]] && [[ -f "$shared_target_dir/release/bench_frontier" ]] && [[ "$shared_target_dir/release/bench_frontier" -nt "$build_marker" ]]; then
+        cp "$shared_target_dir/release/bench_frontier" "$build_dir/release/bench_frontier"
+    fi
     [[ -n "${build_marker:-}" ]] && rm -f "$build_marker"
     metallib_path="$(find "$shared_target_dir/release/build" -path "*/mlx-sys-*/out/build/lib/mlx.metallib" -type f -exec ls -t {} + 2>/dev/null | head -n 1 || true)"
     if [[ -z "$metallib_path" ]]; then

--- a/scripts/validate/suites/frontier-aa.sh
+++ b/scripts/validate/suites/frontier-aa.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Context-frontier A/A suite contract: mirrors quality-gate.sh's env contract
+# and the run.sh raw/ output convention consumed by report.py.
 set -euo pipefail
 
 : "${BASELINE_BIN_DIR:?BASELINE_BIN_DIR is required}"
@@ -7,7 +9,13 @@ set -euo pipefail
 : "${OUT_DIR:?OUT_DIR is required}"
 : "${RUNS:?RUNS is required}"
 
-mkdir -p "$OUT_DIR"
+raw_dir="$OUT_DIR/raw"
+mkdir -p "$raw_dir"
 
-"$BASELINE_BIN_DIR/bench_frontier" --model-dir "$MODEL_DIR" --runs "$RUNS" --format json > "$OUT_DIR/frontier-baseline.json"
-"$CANDIDATE_BIN_DIR/bench_frontier" --model-dir "$MODEL_DIR" --runs "$RUNS" --format json > "$OUT_DIR/frontier-candidate.json"
+if [[ ! -x "$BASELINE_BIN_DIR/bench_frontier" ]]; then
+    echo "baseline build predates bench_frontier; rerun against a newer --baseline" >&2
+    exit 1
+fi
+
+"$BASELINE_BIN_DIR/bench_frontier" --model-dir "$MODEL_DIR" --runs "$RUNS" --format json > "$raw_dir/frontier-baseline.json"
+"$CANDIDATE_BIN_DIR/bench_frontier" --model-dir "$MODEL_DIR" --runs "$RUNS" --format json > "$raw_dir/frontier-candidate.json"

--- a/scripts/validate/suites/frontier-aa.sh
+++ b/scripts/validate/suites/frontier-aa.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${BASELINE_BIN_DIR:?BASELINE_BIN_DIR is required}"
+: "${CANDIDATE_BIN_DIR:?CANDIDATE_BIN_DIR is required}"
+: "${MODEL_DIR:?MODEL_DIR is required}"
+: "${OUT_DIR:?OUT_DIR is required}"
+: "${RUNS:?RUNS is required}"
+
+mkdir -p "$OUT_DIR"
+
+"$BASELINE_BIN_DIR/bench_frontier" --model-dir "$MODEL_DIR" --runs "$RUNS" --format json > "$OUT_DIR/frontier-baseline.json"
+"$CANDIDATE_BIN_DIR/bench_frontier" --model-dir "$MODEL_DIR" --runs "$RUNS" --format json > "$OUT_DIR/frontier-candidate.json"

--- a/scripts/validate/test_run.sh
+++ b/scripts/validate/test_run.sh
@@ -22,6 +22,8 @@ grep -Fq 'cp "$shared_target_dir/release/mlx.metallib" "$build_dir/release/mlx.m
 grep -Fq 'build_marker="$(mktemp "${TMPDIR:-/tmp}/higgs-validate-build.XXXXXX")"' "$RUNNER"
 grep -Fq '[[ "$shared_target_dir/release/quality_gate" -nt "$build_marker" ]]' "$RUNNER"
 grep -Fq 'cp "$shared_target_dir/release/quality_gate" "$build_dir/release/quality_gate"' "$RUNNER"
+grep -Fq '[[ "$shared_target_dir/release/bench_frontier" -nt "$build_marker" ]]' "$RUNNER"
+grep -Fq 'cp "$shared_target_dir/release/bench_frontier" "$build_dir/release/bench_frontier"' "$RUNNER"
 grep -Fq 'find "$shared_target_dir/release/build" -path "*/mlx-sys-*/out/build/lib/mlx.metallib"' "$RUNNER"
 grep -Fq 'metallib_path="$(find' "$RUNNER"
 grep -Fq 'missing mlx.metallib in shared target directory' "$RUNNER"

--- a/validation/pr2-frontier/report.md
+++ b/validation/pr2-frontier/report.md
@@ -1,0 +1,41 @@
+# Validation report: pr2-frontier
+
+- chip: Apple M4 Max
+- ram_gb: 128
+- macos_version: 26.5.1
+- branch: claude/ds4-p2-bench-frontier
+- model: mlx-community/Qwen3-1.7B-4bit
+
+## Pre-registered acceptance criteria
+1. A/A stability < 5% per frontier (median-based, per program methodology: compare medians across runs).
+2. KV-bytes column matches analytic expectation for a known model.
+3. mtp tests still green after the checkpoint-helper refactor.
+
+## Results
+
+### Criterion 2: analytic KV check — PASS
+Qwen3-1.7B: 28 layers x 2 (K,V) x 8 kv-heads x 128 head-dim x 2 bytes (fp16) = 114,688 bytes/token.
+`--verify-kv-analytic --expect-kv-bytes-per-token 114688` -> analytic_verified=true (exact match at the
+2048 frontier; larger frontiers include buffer-capacity rounding, as expected for preallocated caches).
+
+### Criterion 1: A/A stability — PASS (median basis), with noted outliers
+Two independent invocations (3 and 4 sweeps; sweep 1 of each treated as warmup).
+Probe decode tok/s medians per frontier:
+
+| Frontier | Invocation A median | Invocation B median | Median delta |
+| ---: | ---: | ---: | ---: |
+| 2048 | 231.6 | 232.5 | +0.39% |
+| 4096 | 205.3 | 208.0 | +1.32% |
+| 8192 | 170.4 | 173.7 | +1.94% |
+| 16384 | 129.6 | 129.3 | -0.23% |
+
+Honest caveat: individual sweeps show sporadic dips up to ~8.5% (raw min-max spread), attributable to
+background desktop load; medians across >=3 measured sweeps are stable (<2%). A/B comparisons made with
+this tool must therefore always compare medians of >=3 post-warmup sweeps, never single runs.
+
+### Criterion 3: mtp/cache tests — PASS
+cargo test -p higgs-engine -- --test-threads=1: 287 passed.
+cargo test -p higgs-models -- --test-threads=1: 427 passed.
+cargo test -p higgs -- --test-threads=1: passed.
+
+Verdict: PASS


### PR DESCRIPTION
Part of the ds4 -> higgs adoption program (docs/ds4-analysis-2026-08.md). Implements P8: frontier benchmarking — decode throughput and KV memory as a function of context length. This is the measurement tool for the MLA latent-cache PR (P1), which claims wins at 16k+ context.

## What this adds
- Commit 1 (refactor): `AnyCache::checkpoint_for_rollback()` / `AnyCache::rollback()` in higgs-models, unifying the KV-trim vs Hybrid-deep-clone rollback contract; `mtp.rs` speculative-decode rollback now delegates to it, so the two contracts stay provably identical. The MLX buffer-donation safety reasoning moved to the shared API docs. Also adds `AnyCache::eval_targets()`.
- Commit 2: `bench_frontier` binary (higgs-bench, in-process engine): per frontier (default 2048,4096,8192,16384) it incrementally prefills only the interval via `forward_chunked`, checkpoints, runs a greedy decode probe (default 64 tokens, first excluded as warmup), measures KV bytes from cache eval targets, and rolls back — so one pass measures every frontier. `--verify-kv-analytic --expect-kv-bytes-per-token` gates measured bytes against the analytic value (10% tolerance). JSON/markdown output via the existing bench contract (`RunMetadata`, `persist_result`).
- `scripts/validate/suites/frontier-aa.sh` per PR0's (#251) suite contract.

## Pre-registered acceptance criteria
1. A/A stability < 5% per frontier (median basis).
2. KV-bytes matches analytic expectation for a known model.
3. mtp tests green after the refactor.

## Validation results (committed at validation/pr2-frontier/report.md)
Apple M4 Max, 128 GB, macOS 26.5.1, Qwen3-1.7B-4bit:
- Analytic KV: 28x2x8x128x2 = 114,688 bytes/token — exact match at the 2048 frontier, analytic_verified=true. PASS.
- A/A medians across two independent multi-sweep invocations: +0.39% / +1.32% / +1.94% / -0.23% at 2k/4k/8k/16k. PASS. (Honest caveat in the report: single sweeps show sporadic ~8% dips from desktop background load; the methodology therefore mandates medians of >=3 post-warmup sweeps.)
- Tests: higgs-engine 287 passed, higgs-models 427 passed, higgs passed. PASS.

## Process
Implemented by Codex CLI (gpt-5.6-terra, medium reasoning); reviewed by Claude (verified the probe consumes last-position-only logits from forward_chunked; confirmed rollback token accounting; validated analytic bytes on hardware).

🤖 Generated with [Claude Code](https://claude.com/claude-code)