### PR TITLE
feat(models): MLA latent KV cache with weight absorption for DeepSeek-V2 (PR3 / ds4 P1)

### DIFF
--- a/crates/higgs-engine/src/paged_prefix_cache.rs
+++ b/crates/higgs-engine/src/paged_prefix_cache.rs
@@ -4,13 +4,13 @@ use std::time::Instant;
 
 use std::sync::Arc;
 
-use higgs_models::cache::{KeyValueCache, SteppingKeyValueCache, slice_axis1, slice_axis2};
+use higgs_models::cache::{slice_axis1, slice_axis2, KeyValueCache, SteppingKeyValueCache};
 use higgs_models::qwen3_next::ArraysCache;
 use higgs_models::turboquant::TurboQuantContext;
 use higgs_models::{AnyCache, LayerCache};
-use mlx_rs::Array;
 use mlx_rs::error::Exception;
 use mlx_rs::ops::concatenate_axis;
+use mlx_rs::Array;
 
 /// Default block size in tokens for paged caching.
 pub const DEFAULT_BLOCK_SIZE: usize = 32;
@@ -59,6 +59,8 @@ enum CachedLayerData {
     Kv(Vec<KvBlock>),
     /// Attention layer: sequence of `TurboQuant` blocks.
     TurboQuantKv(Vec<TqBlock>),
+    /// Attention layer: compressed MLA latent blocks `[1, 1, T, r + rope]`.
+    MlaLatent(Vec<Array>, i32, i32),
     /// GDN/SSM layer: state snapshot at block boundary.
     Gdn(GdnSnapshot),
     /// Layer had no cache data.
@@ -507,7 +509,9 @@ fn slice_into_blocks(
             let Some(kv) = layer_opt.as_ref() else {
                 return Ok(CachedLayerData::Empty);
             };
-            if kv.is_quantized() {
+            if kv.is_mla() {
+                slice_mla_layer(kv, num_blocks, block_size_i32)
+            } else if kv.is_quantized() {
                 if tq_context.is_none() {
                     tq_context = kv.turbo_arrays().map(|(c, ..)| Arc::clone(c));
                 }
@@ -532,6 +536,32 @@ fn slice_into_blocks(
             is_hybrid: false,
         })
     }
+}
+
+/// Slice a single MLA latent layer into blocks along its sequence axis.
+fn slice_mla_layer(
+    kv: &SteppingKeyValueCache,
+    num_blocks: usize,
+    block_size: i32,
+) -> Result<CachedLayerData, Exception> {
+    let Some(latent) = kv.latent_array() else {
+        return Ok(CachedLayerData::Empty);
+    };
+    let mut blocks = Vec::with_capacity(num_blocks);
+    for i in 0..num_blocks {
+        let start = i32::try_from(i)
+            .map_err(|_| Exception::custom("block index overflow"))?
+            .checked_mul(block_size)
+            .ok_or_else(|| Exception::custom("block start overflow"))?;
+        let end = start
+            .checked_add(block_size)
+            .ok_or_else(|| Exception::custom("block end overflow"))?;
+        blocks.push(slice_axis2(latent, start, end)?);
+    }
+    let (kv_lora_rank, rope_dim) = kv
+        .mla_dimensions()
+        .ok_or_else(|| Exception::custom("MLA cache missing dimensions"))?;
+    Ok(CachedLayerData::MlaLatent(blocks, kv_lora_rank, rope_dim))
 }
 
 /// Slice a single `TurboQuant` KV layer into blocks along axis 1.
@@ -633,6 +663,9 @@ fn materialize_kv(layers: &[CachedLayerData]) -> Result<AnyCache, Exception> {
             CachedLayerData::TurboQuantKv(_) => {
                 Err(Exception::custom("TQ layer in non-TQ materialize"))
             }
+            CachedLayerData::MlaLatent(blocks, r, rope) => {
+                gather_mla_blocks(blocks, *r, *rope).map(Some)
+            }
             CachedLayerData::Empty => Ok(Some(SteppingKeyValueCache::new())),
             CachedLayerData::Gdn(_) => Err(Exception::custom("Unexpected GDN layer in KV cache")),
         })
@@ -649,6 +682,9 @@ fn materialize_tq_kv(
         .map(|layer| match layer {
             CachedLayerData::TurboQuantKv(blocks) => gather_tq_blocks(blocks, context).map(Some),
             CachedLayerData::Kv(blocks) => gather_blocks(blocks).map(Some),
+            CachedLayerData::MlaLatent(blocks, r, rope) => {
+                gather_mla_blocks(blocks, *r, *rope).map(Some)
+            }
             CachedLayerData::Empty => Ok(Some(SteppingKeyValueCache::new())),
             CachedLayerData::Gdn(_) => {
                 Err(Exception::custom("Unexpected GDN layer in TQ KV cache"))
@@ -665,6 +701,9 @@ fn materialize_hybrid(layers: &[CachedLayerData]) -> Result<AnyCache, Exception>
             CachedLayerData::Kv(blocks) => gather_blocks(blocks).map(|kv| Some(LayerCache::KV(kv))),
             CachedLayerData::TurboQuantKv(_) => {
                 Err(Exception::custom("TQ layer in non-TQ hybrid materialize"))
+            }
+            CachedLayerData::MlaLatent(blocks, r, rope) => {
+                gather_mla_blocks(blocks, *r, *rope).map(|kv| Some(LayerCache::KV(kv)))
             }
             CachedLayerData::Gdn(snap) => Ok(Some(LayerCache::Arrays(ArraysCache {
                 conv_state: snap.conv_state.clone(),
@@ -689,6 +728,9 @@ fn materialize_tq_hybrid(
                 gather_tq_blocks(blocks, context).map(|kv| Some(LayerCache::KV(kv)))
             }
             CachedLayerData::Kv(blocks) => gather_blocks(blocks).map(|kv| Some(LayerCache::KV(kv))),
+            CachedLayerData::MlaLatent(blocks, r, rope) => {
+                gather_mla_blocks(blocks, *r, *rope).map(|kv| Some(LayerCache::KV(kv)))
+            }
             CachedLayerData::Gdn(snap) => Ok(Some(LayerCache::Arrays(ArraysCache {
                 conv_state: snap.conv_state.clone(),
                 ssm_state: snap.ssm_state.clone(),
@@ -717,6 +759,23 @@ fn gather_blocks(blocks: &[KvBlock]) -> Result<SteppingKeyValueCache, Exception>
     let values = concatenate_axis(&value_arrays, 2)?;
 
     SteppingKeyValueCache::from_arrays(keys, values)
+}
+
+/// Gather MLA latent blocks into a single contiguous cache.
+fn gather_mla_blocks(
+    blocks: &[Array],
+    kv_lora_rank: i32,
+    rope_dim: i32,
+) -> Result<SteppingKeyValueCache, Exception> {
+    let Some(first) = blocks.first() else {
+        return Ok(SteppingKeyValueCache::new());
+    };
+    let latent = if blocks.len() == 1 {
+        first.clone()
+    } else {
+        concatenate_axis(blocks, 2)?
+    };
+    SteppingKeyValueCache::from_latent_array(latent, kv_lora_rank, rope_dim)
 }
 
 /// Gather TQ blocks into a single `SteppingKeyValueCache` with TQ storage.
@@ -1068,5 +1127,30 @@ mod tests {
         assert_eq!(rk.shape(), &[1, 2, 33, 8]);
         assert_eq!(rv.shape(), &[1, 2, 33, 8]);
         assert_eq!(KeyValueCache::offset(&kv), 33);
+    }
+
+    #[test]
+    fn test_mla_cache_store_lookup_and_continue() {
+        let mut prefix_cache = PagedPrefixCache::new(4, 2);
+        let rows = Array::ones::<f32>(&[1, 1, 4, 6]).unwrap();
+        let layer = SteppingKeyValueCache::from_latent_array(rows, 4, 2).unwrap();
+        let cache = AnyCache::KV(vec![Some(layer)]);
+        let tokens = vec![10, 11, 12, 13];
+        prefix_cache.store(&tokens, &cache);
+
+        let matched = prefix_cache
+            .find_longest_prefix(&[10, 11, 12, 13, 14])
+            .unwrap();
+        assert_eq!(matched.prefix_len, 4);
+        let AnyCache::KV(layers) = matched.cache else {
+            panic!("expected KV cache")
+        };
+        let mut restored = layers.into_iter().next().flatten().unwrap();
+        assert!(restored.is_mla());
+        let (history, offset) = restored
+            .update_latent_and_fetch(Array::zeros::<f32>(&[1, 1, 1, 6]).unwrap())
+            .unwrap();
+        assert_eq!(offset, 5);
+        assert_eq!(history.shape(), &[1, 1, 5, 6]);
     }
 }

--- a/crates/higgs-engine/src/paged_prefix_cache.rs
+++ b/crates/higgs-engine/src/paged_prefix_cache.rs
@@ -4,13 +4,13 @@ use std::time::Instant;
 
 use std::sync::Arc;
 
-use higgs_models::cache::{slice_axis1, slice_axis2, KeyValueCache, SteppingKeyValueCache};
+use higgs_models::cache::{KeyValueCache, SteppingKeyValueCache, slice_axis1, slice_axis2};
 use higgs_models::qwen3_next::ArraysCache;
 use higgs_models::turboquant::TurboQuantContext;
 use higgs_models::{AnyCache, LayerCache};
+use mlx_rs::Array;
 use mlx_rs::error::Exception;
 use mlx_rs::ops::concatenate_axis;
-use mlx_rs::Array;
 
 /// Default block size in tokens for paged caching.
 pub const DEFAULT_BLOCK_SIZE: usize = 32;

--- a/crates/higgs-models/examples/sdpa_mla_smoke.rs
+++ b/crates/higgs-models/examples/sdpa_mla_smoke.rs
@@ -9,7 +9,14 @@ fn main() {
         let k = normal::<f32>(&[1, 1, s, 576], None, None, None).unwrap();
         let v = normal::<f32>(&[1, 1, s, 512], None, None, None).unwrap();
         let scale = 1.0 / (576.0f32).sqrt();
-        match fast::scaled_dot_product_attention(&q, &k, &v, scale, None::<fast::ScaledDotProductAttentionMask>, None::<&Array>) {
+        match fast::scaled_dot_product_attention(
+            &q,
+            &k,
+            &v,
+            scale,
+            None::<fast::ScaledDotProductAttentionMask>,
+            None::<&Array>,
+        ) {
             Ok(out) => {
                 if let Err(e) = eval([&out]) {
                     println!("S={s}: EVAL FAILED: {e}");
@@ -43,7 +50,14 @@ fn main() {
     let k = normal::<f32>(&[1, 1, t, 576], None, None, None).unwrap();
     let v = normal::<f32>(&[1, 1, t, 512], None, None, None).unwrap();
     let scale = 1.0 / (576.0f32).sqrt();
-    match fast::scaled_dot_product_attention(&q, &k, &v, scale, Some(fast::ScaledDotProductAttentionMask::Causal), None::<&Array>) {
+    match fast::scaled_dot_product_attention(
+        &q,
+        &k,
+        &v,
+        scale,
+        Some(fast::ScaledDotProductAttentionMask::Causal),
+        None::<&Array>,
+    ) {
         Ok(out) => {
             eval([&out]).unwrap();
             println!("prefill T={t} causal: OK shape={:?}", out.shape());

--- a/crates/higgs-models/examples/sdpa_mla_smoke.rs
+++ b/crates/higgs-models/examples/sdpa_mla_smoke.rs
@@ -1,4 +1,4 @@
-//! Smoke test: MQA SDPA with qk_dim=576, v_dim=512 on Metal (MLA absorbed shapes).
+//! Smoke test: MQA SDPA with `qk_dim=576`, `v_dim=512` on Metal (MLA absorbed shapes).
 #![allow(clippy::unwrap_used, clippy::print_stdout)]
 use mlx_rs::{Array, fast, ops, random::normal, transforms::eval};
 
@@ -25,7 +25,7 @@ fn main() {
                 println!("S={s}: OK shape={:?}", out.shape());
                 // Cross-check against explicit softmax path.
                 let attn = ops::softmax_axis(
-                    &q.matmul(&k.transpose_axes(&[0, 1, 3, 2]).unwrap())
+                    q.matmul(k.transpose_axes(&[0, 1, 3, 2]).unwrap())
                         .unwrap()
                         .multiply(Array::from_f32(scale))
                         .unwrap(),
@@ -34,7 +34,7 @@ fn main() {
                 )
                 .unwrap();
                 let reference = attn.matmul(&v).unwrap();
-                let diff = ops::abs(&out.subtract(&reference).unwrap())
+                let diff = ops::abs(out.subtract(&reference).unwrap())
                     .unwrap()
                     .max(None)
                     .unwrap();

--- a/crates/higgs-models/examples/sdpa_mla_smoke.rs
+++ b/crates/higgs-models/examples/sdpa_mla_smoke.rs
@@ -1,0 +1,53 @@
+//! Smoke test: MQA SDPA with qk_dim=576, v_dim=512 on Metal (MLA absorbed shapes).
+#![allow(clippy::unwrap_used, clippy::print_stdout)]
+use mlx_rs::{Array, fast, ops, random::normal, transforms::eval};
+
+fn main() {
+    // Decode shape: q [1, H=16, 1, 576], k [1, 1, S, 576], v [1, 1, S, 512]
+    for s in [128, 4096] {
+        let q = normal::<f32>(&[1, 16, 1, 576], None, None, None).unwrap();
+        let k = normal::<f32>(&[1, 1, s, 576], None, None, None).unwrap();
+        let v = normal::<f32>(&[1, 1, s, 512], None, None, None).unwrap();
+        let scale = 1.0 / (576.0f32).sqrt();
+        match fast::scaled_dot_product_attention(&q, &k, &v, scale, None::<fast::ScaledDotProductAttentionMask>, None::<&Array>) {
+            Ok(out) => {
+                if let Err(e) = eval([&out]) {
+                    println!("S={s}: EVAL FAILED: {e}");
+                    continue;
+                }
+                println!("S={s}: OK shape={:?}", out.shape());
+                // Cross-check against explicit softmax path.
+                let attn = ops::softmax_axis(
+                    &q.matmul(&k.transpose_axes(&[0, 1, 3, 2]).unwrap())
+                        .unwrap()
+                        .multiply(Array::from_f32(scale))
+                        .unwrap(),
+                    -1,
+                    true,
+                )
+                .unwrap();
+                let reference = attn.matmul(&v).unwrap();
+                let diff = ops::abs(&out.subtract(&reference).unwrap())
+                    .unwrap()
+                    .max(None)
+                    .unwrap();
+                eval([&diff]).unwrap();
+                println!("S={s}: max|sdpa-explicit|={}", diff.item::<f32>());
+            }
+            Err(e) => println!("S={s}: SDPA REJECTED: {e}"),
+        }
+    }
+    // Prefill shape with causal mask: q [1, 16, T, 576]
+    let t = 64;
+    let q = normal::<f32>(&[1, 16, t, 576], None, None, None).unwrap();
+    let k = normal::<f32>(&[1, 1, t, 576], None, None, None).unwrap();
+    let v = normal::<f32>(&[1, 1, t, 512], None, None, None).unwrap();
+    let scale = 1.0 / (576.0f32).sqrt();
+    match fast::scaled_dot_product_attention(&q, &k, &v, scale, Some(fast::ScaledDotProductAttentionMask::Causal), None::<&Array>) {
+        Ok(out) => {
+            eval([&out]).unwrap();
+            println!("prefill T={t} causal: OK shape={:?}", out.shape());
+        }
+        Err(e) => println!("prefill causal: SDPA REJECTED: {e}"),
+    }
+}

--- a/crates/higgs-models/src/cache.rs
+++ b/crates/higgs-models/src/cache.rs
@@ -1,9 +1,9 @@
 use std::sync::{
-    Arc, OnceLock,
     atomic::{AtomicBool, Ordering},
+    Arc, OnceLock,
 };
 
-use mlx_rs::{Array, Dtype, Stream, error::Exception, ops, ops::concatenate_axis};
+use mlx_rs::{error::Exception, ops, ops::concatenate_axis, Array, Dtype, Stream};
 
 use crate::turboquant::{
     KvCacheConfig, KvCacheMode, QuantizedKey, QuantizedValue, TurboQuantContext,
@@ -249,6 +249,13 @@ pub trait KeyValueCache {
     ) -> Result<(Array, Array), Exception> {
         self.update_and_view(keys, values)?.into_dense()
     }
+
+    /// Append MLA latent rows and return the full latent cache plus prior offset.
+    fn update_latent_and_fetch(&mut self, _rows: Array) -> Result<(Array, i32), Exception> {
+        Err(Exception::custom(
+            "cache does not support MLA latent storage",
+        ))
+    }
 }
 
 impl<T> KeyValueCache for &'_ mut T
@@ -285,6 +292,10 @@ where
         values: Array,
     ) -> Result<(Array, Array), Exception> {
         T::update_and_fetch(self, keys, values)
+    }
+
+    fn update_latent_and_fetch(&mut self, rows: Array) -> Result<(Array, i32), Exception> {
+        T::update_latent_and_fetch(self, rows)
     }
 }
 
@@ -357,9 +368,17 @@ pub struct SteppingKeyValueCache {
     keys: Option<Array>,
     values: Option<Array>,
     turbo: Option<TurboQuantStorage>,
+    mla: Option<MlaStorage>,
     config: KvCacheConfig,
     offset: i32,
     step: i32,
+}
+
+#[derive(Debug, Clone)]
+struct MlaStorage {
+    latent: Option<Array>, // [1, 1, capacity, kv_lora_rank + rope_dim]
+    kv_lora_rank: i32,
+    rope_dim: i32,
 }
 
 #[derive(Debug, Clone)]
@@ -379,6 +398,7 @@ impl Default for SteppingKeyValueCache {
             keys: None,
             values: None,
             turbo: None,
+            mla: None,
             config: KvCacheConfig::default(),
             offset: 0,
             step: 256,
@@ -409,7 +429,37 @@ impl SteppingKeyValueCache {
             keys: None,
             values: None,
             turbo: Some(TurboQuantStorage::new(context)),
+            mla: None,
             config: turbo_config,
+            offset: 0,
+            step: 256,
+        })
+    }
+
+    /// Construct an MLA cache that stores compressed latent plus shared RoPE K.
+    pub fn new_mla(
+        kv_lora_rank: i32,
+        rope_dim: i32,
+        config: KvCacheConfig,
+    ) -> Result<Self, Exception> {
+        if config.is_turboquant() {
+            return Err(Exception::custom(
+                "MLA latent cache cannot be combined with TurboQuant",
+            ));
+        }
+        if kv_lora_rank <= 0 || rope_dim <= 0 {
+            return Err(Exception::custom("MLA latent dimensions must be positive"));
+        }
+        Ok(Self {
+            keys: None,
+            values: None,
+            turbo: None,
+            mla: Some(MlaStorage {
+                latent: None,
+                kv_lora_rank,
+                rope_dim,
+            }),
+            config,
             offset: 0,
             step: 256,
         })
@@ -442,6 +492,11 @@ impl SteppingKeyValueCache {
             keys: self.keys.as_ref().map(eval_deep_clone),
             values: self.values.as_ref().map(eval_deep_clone),
             turbo: self.turbo.as_ref().map(TurboQuantStorage::deep_clone),
+            mla: self.mla.as_ref().map(|m| MlaStorage {
+                latent: m.latent.as_ref().map(eval_deep_clone),
+                kv_lora_rank: m.kv_lora_rank,
+                rope_dim: m.rope_dim,
+            }),
             config: self.config,
             offset: self.offset,
             step: self.step,
@@ -460,6 +515,9 @@ impl SteppingKeyValueCache {
         if let Some(ref turbo) = self.turbo {
             targets.extend(turbo.eval_targets());
         }
+        if let Some(Some(latent)) = self.mla.as_ref().map(|m| m.latent.as_ref()) {
+            targets.push(latent);
+        }
         targets
     }
 
@@ -471,6 +529,19 @@ impl SteppingKeyValueCache {
     /// Read-only access to internal value array (includes allocated-but-unused slots).
     pub const fn values(&self) -> Option<&Array> {
         self.values.as_ref()
+    }
+
+    /// Read-only access to the MLA latent buffer (including unused capacity).
+    pub const fn latent_array(&self) -> Option<&Array> {
+        match &self.mla {
+            Some(storage) => storage.latent.as_ref(),
+            None => None,
+        }
+    }
+
+    /// Whether this cache stores MLA compressed latents instead of dense K/V.
+    pub const fn is_mla(&self) -> bool {
+        self.mla.is_some()
     }
 
     /// Simultaneous mutable access to the key and value arrays.
@@ -491,6 +562,41 @@ impl SteppingKeyValueCache {
             keys: Some(keys),
             values: Some(values),
             turbo: None,
+            mla: None,
+            config: KvCacheConfig::default(),
+            offset,
+            step: 256,
+        })
+    }
+
+    /// Restore a pre-filled MLA latent cache from `[1, 1, T, r + rope]` rows.
+    pub fn from_latent_array(
+        latent: Array,
+        kv_lora_rank: i32,
+        rope_dim: i32,
+    ) -> Result<Self, Exception> {
+        let [b, h, offset, width] = <[i32; 4]>::try_from(latent.shape()).map_err(|_| {
+            Exception::custom("from_latent_array: latent must be [1, 1, T, r + rope]")
+        })?;
+        if b != 1
+            || h != 1
+            || width != kv_lora_rank + rope_dim
+            || kv_lora_rank <= 0
+            || rope_dim <= 0
+        {
+            return Err(Exception::custom(
+                "from_latent_array: invalid MLA latent shape or dimensions",
+            ));
+        }
+        Ok(Self {
+            keys: None,
+            values: None,
+            turbo: None,
+            mla: Some(MlaStorage {
+                latent: Some(latent),
+                kv_lora_rank,
+                rope_dim,
+            }),
             config: KvCacheConfig::default(),
             offset,
             step: 256,
@@ -555,6 +661,7 @@ impl SteppingKeyValueCache {
                 value_norms: Some(value_norms),
                 capacity,
             }),
+            mla: None,
             config,
             offset,
             step: 256,
@@ -725,6 +832,45 @@ impl SteppingKeyValueCache {
             KvCacheView::TurboQuant(turbo_view) => turbo_view.seq_len,
         };
         Ok(new_view)
+    }
+
+    fn update_latent(&mut self, rows: &Array) -> Result<(Array, i32), Exception> {
+        let storage = self
+            .mla
+            .as_mut()
+            .ok_or_else(|| Exception::custom("cache does not support MLA latent storage"))?;
+        let [b, h, new_tokens, width] = <[i32; 4]>::try_from(rows.shape())
+            .map_err(|_| Exception::custom("MLA rows must be [1, 1, T, r + rope]"))?;
+        if b != 1 || h != 1 || width != storage.kv_lora_rank + storage.rope_dim {
+            return Err(Exception::custom(
+                "MLA rows shape does not match cache dimensions",
+            ));
+        }
+        let prev = self.offset;
+        let capacity = storage.latent.as_ref().map_or(0, |a| a.shape()[2]);
+        if prev + new_tokens > capacity {
+            let slots = ((new_tokens + self.step - 1) / self.step) * self.step;
+            let grown = ops::zeros_dtype(&[1, 1, slots, width], rows.dtype())?;
+            storage.latent = Some(match storage.latent.take() {
+                Some(old) => concatenate_axis(&[slice_axis2(&old, 0, prev)?, grown], 2)?,
+                None => grown,
+            });
+        }
+        let latent = storage
+            .latent
+            .as_ref()
+            .ok_or_else(|| Exception::custom("MLA latent missing after grow"))?;
+        storage.latent = Some(slice_update_axis2(latent, rows, prev, new_tokens)?);
+        self.offset = prev + new_tokens;
+        let full = slice_axis2(
+            storage
+                .latent
+                .as_ref()
+                .ok_or_else(|| Exception::custom("MLA latent missing after update"))?,
+            0,
+            self.offset,
+        )?;
+        Ok((full, self.offset))
     }
 }
 
@@ -995,6 +1141,10 @@ impl KeyValueCache for SteppingKeyValueCache {
 
     fn update_and_view(&mut self, keys: Array, values: Array) -> Result<KvCacheView, Exception> {
         self.update_and_view_with_activation_threshold(&keys, &values, turboquant_activate_at())
+    }
+
+    fn update_latent_and_fetch(&mut self, rows: Array) -> Result<(Array, i32), Exception> {
+        self.update_latent(&rows)
     }
 }
 
@@ -1548,7 +1698,7 @@ mod tests {
             .unwrap();
         let turbo = decode_view.turboquant().unwrap();
         assert_eq!(turbo.seq_len, 3); // 2 prefill + 1 decode
-        // head_dim=8, key_bits=2: ceil(8*2/32) = 1 u32 word
+                                      // head_dim=8, key_bits=2: ceil(8*2/32) = 1 u32 word
         assert_eq!(turbo.key_codes.shape(), &[2, 3, 1]);
         // head_dim=8, bits=3: ceil(8*3/32) = 1 u32 word
         assert_eq!(turbo.value_codes.shape(), &[2, 3, 1]);
@@ -1678,5 +1828,37 @@ mod tests {
         assert_eq!(propagated.bits, 4, "bits must be carried from context");
         assert_eq!(propagated.seed, 99, "seed must be carried from context");
         assert!(matches!(propagated.mode, KvCacheMode::Turboquant));
+    }
+
+    #[test]
+    fn mla_storage_appends_trims_and_clones_independently() {
+        let mut cache = SteppingKeyValueCache::new_mla(4, 2, KvCacheConfig::default()).unwrap();
+        let first = Array::ones::<f32>(&[1, 1, 3, 6]).unwrap();
+        let (stored, offset) = cache.update_latent_and_fetch(first).unwrap();
+        assert_eq!(stored.shape(), &[1, 1, 3, 6]);
+        assert_eq!(offset, 3);
+        assert!(cache.is_mla());
+        assert_eq!(cache.eval_targets().len(), 1);
+
+        cache.trim_by(1);
+        let replacement = Array::zeros::<f32>(&[1, 1, 1, 6]).unwrap();
+        let (stored, offset) = cache.update_latent_and_fetch(replacement).unwrap();
+        assert_eq!(stored.shape(), &[1, 1, 3, 6]);
+        assert_eq!(offset, 3);
+
+        let checkpoint = cache.deep_clone();
+        let update = Array::full::<f32>(&[1, 1, 1, 6], &Array::from_f32(2.0)).unwrap();
+        cache.update_latent_and_fetch(update).unwrap();
+        assert_eq!(checkpoint.offset(), 3);
+        assert_eq!(checkpoint.latent_array().unwrap().shape(), &[1, 1, 256, 6]);
+    }
+
+    #[test]
+    fn mla_from_latent_array_round_trips() {
+        let latent = Array::ones::<f32>(&[1, 1, 5, 6]).unwrap();
+        let cache = SteppingKeyValueCache::from_latent_array(latent, 4, 2).unwrap();
+        assert!(cache.is_mla());
+        assert_eq!(cache.offset(), 5);
+        assert_eq!(cache.latent_array().unwrap().shape(), &[1, 1, 5, 6]);
     }
 }

--- a/crates/higgs-models/src/cache.rs
+++ b/crates/higgs-models/src/cache.rs
@@ -544,6 +544,14 @@ impl SteppingKeyValueCache {
         self.mla.is_some()
     }
 
+    /// MLA latent and shared-RoPE widths, when this is an MLA cache.
+    pub const fn mla_dimensions(&self) -> Option<(i32, i32)> {
+        match &self.mla {
+            Some(storage) => Some((storage.kv_lora_rank, storage.rope_dim)),
+            None => None,
+        }
+    }
+
     /// Simultaneous mutable access to the key and value arrays.
     ///
     /// Re-borrows both optional fields from a single `&mut` split to satisfy

--- a/crates/higgs-models/src/cache.rs
+++ b/crates/higgs-models/src/cache.rs
@@ -23,8 +23,11 @@ static MLA_LATENT_CACHE_ENABLED: OnceLock<bool> = OnceLock::new();
 const DEFAULT_MLA_LATENT_CACHE_ENABLED: bool = false;
 
 fn parse_mla_latent_cache_enabled(raw: Option<&str>) -> bool {
-    raw.and_then(|value| value.parse::<bool>().ok())
-        .unwrap_or(DEFAULT_MLA_LATENT_CACHE_ENABLED)
+    match raw.map(str::trim).map(str::to_ascii_lowercase).as_deref() {
+        Some("1" | "true" | "on" | "yes") => true,
+        Some("0" | "false" | "off" | "no") => false,
+        _ => DEFAULT_MLA_LATENT_CACHE_ENABLED,
+    }
 }
 
 /// Whether `DeepSeek` MLA caches should store compressed latent rows.
@@ -1800,6 +1803,16 @@ mod tests {
         );
         assert_eq!(parse_turboquant_activate_at(Some("-5")), 0);
         assert_eq!(parse_turboquant_activate_at(Some("8192")), 8192);
+    }
+
+    #[test]
+    fn parse_mla_latent_cache_enabled_accepts_common_flag_values() {
+        assert!(parse_mla_latent_cache_enabled(Some("1")));
+        assert!(!parse_mla_latent_cache_enabled(Some("0")));
+        assert!(parse_mla_latent_cache_enabled(Some("on")));
+        assert!(parse_mla_latent_cache_enabled(Some("TRUE")));
+        assert!(!parse_mla_latent_cache_enabled(Some("no")));
+        assert!(!parse_mla_latent_cache_enabled(Some("garbage")));
     }
 
     #[test]

--- a/crates/higgs-models/src/cache.rs
+++ b/crates/higgs-models/src/cache.rs
@@ -1,9 +1,9 @@
 use std::sync::{
-    atomic::{AtomicBool, Ordering},
     Arc, OnceLock,
+    atomic::{AtomicBool, Ordering},
 };
 
-use mlx_rs::{error::Exception, ops, ops::concatenate_axis, Array, Dtype, Stream};
+use mlx_rs::{Array, Dtype, Stream, error::Exception, ops, ops::concatenate_axis};
 
 use crate::turboquant::{
     KvCacheConfig, KvCacheMode, QuantizedKey, QuantizedValue, TurboQuantContext,
@@ -19,6 +19,20 @@ pub enum KvCacheView {
 static TURBOQUANT_ACTIVATE_AT: OnceLock<i32> = OnceLock::new();
 static TURBOQUANT_INACTIVE_LOGGED: AtomicBool = AtomicBool::new(false);
 const DEFAULT_TURBOQUANT_ACTIVATE_AT: i32 = 2048;
+static MLA_LATENT_CACHE_ENABLED: OnceLock<bool> = OnceLock::new();
+const DEFAULT_MLA_LATENT_CACHE_ENABLED: bool = false;
+
+fn parse_mla_latent_cache_enabled(raw: Option<&str>) -> bool {
+    raw.and_then(|value| value.parse::<bool>().ok())
+        .unwrap_or(DEFAULT_MLA_LATENT_CACHE_ENABLED)
+}
+
+/// Whether DeepSeek MLA caches should store compressed latent rows.
+pub fn mla_latent_cache_enabled() -> bool {
+    *MLA_LATENT_CACHE_ENABLED.get_or_init(|| {
+        parse_mla_latent_cache_enabled(std::env::var("HIGGS_MLA_LATENT_CACHE").ok().as_deref())
+    })
+}
 
 fn parse_turboquant_activate_at(raw: Option<&str>) -> i32 {
     raw.and_then(|s| s.parse::<i32>().ok())
@@ -217,6 +231,10 @@ impl TurboQuantKvView {
 
 /// Trait for key-value caches used in autoregressive generation.
 pub trait KeyValueCache {
+    /// Whether this cache stores MLA compressed rows.
+    fn is_mla(&self) -> bool {
+        false
+    }
     /// Whether the cache stores quantized KV pairs.
     fn is_quantized(&self) -> bool {
         false
@@ -262,6 +280,10 @@ impl<T> KeyValueCache for &'_ mut T
 where
     T: KeyValueCache,
 {
+    fn is_mla(&self) -> bool {
+        T::is_mla(self)
+    }
+
     fn is_quantized(&self) -> bool {
         T::is_quantized(self)
     }
@@ -1129,6 +1151,9 @@ impl TurboQuantStorage {
 }
 
 impl KeyValueCache for SteppingKeyValueCache {
+    fn is_mla(&self) -> bool {
+        self.is_mla()
+    }
     fn is_quantized(&self) -> bool {
         self.config.is_turboquant()
     }
@@ -1706,7 +1731,7 @@ mod tests {
             .unwrap();
         let turbo = decode_view.turboquant().unwrap();
         assert_eq!(turbo.seq_len, 3); // 2 prefill + 1 decode
-                                      // head_dim=8, key_bits=2: ceil(8*2/32) = 1 u32 word
+        // head_dim=8, key_bits=2: ceil(8*2/32) = 1 u32 word
         assert_eq!(turbo.key_codes.shape(), &[2, 3, 1]);
         // head_dim=8, bits=3: ceil(8*3/32) = 1 u32 word
         assert_eq!(turbo.value_codes.shape(), &[2, 3, 1]);

--- a/crates/higgs-models/src/cache.rs
+++ b/crates/higgs-models/src/cache.rs
@@ -27,7 +27,7 @@ fn parse_mla_latent_cache_enabled(raw: Option<&str>) -> bool {
         .unwrap_or(DEFAULT_MLA_LATENT_CACHE_ENABLED)
 }
 
-/// Whether DeepSeek MLA caches should store compressed latent rows.
+/// Whether `DeepSeek` MLA caches should store compressed latent rows.
 pub fn mla_latent_cache_enabled() -> bool {
     *MLA_LATENT_CACHE_ENABLED.get_or_init(|| {
         parse_mla_latent_cache_enabled(std::env::var("HIGGS_MLA_LATENT_CACHE").ok().as_deref())
@@ -458,7 +458,7 @@ impl SteppingKeyValueCache {
         })
     }
 
-    /// Construct an MLA cache that stores compressed latent plus shared RoPE K.
+    /// Construct an MLA cache that stores compressed latent plus shared `RoPE` K.
     pub fn new_mla(
         kv_lora_rank: i32,
         rope_dim: i32,
@@ -877,7 +877,11 @@ impl SteppingKeyValueCache {
             ));
         }
         let prev = self.offset;
-        let capacity = storage.latent.as_ref().map_or(0, |a| a.shape()[2]);
+        let capacity = storage
+            .latent
+            .as_ref()
+            .and_then(|a| a.shape().get(2).copied())
+            .unwrap_or(0);
         if prev + new_tokens > capacity {
             let slots = ((new_tokens + self.step - 1) / self.step) * self.step;
             let grown = ops::zeros_dtype(&[1, 1, slots, width], rows.dtype())?;
@@ -1875,9 +1879,9 @@ mod tests {
 
         cache.trim_by(1);
         let replacement = Array::zeros::<f32>(&[1, 1, 1, 6]).unwrap();
-        let (stored, offset) = cache.update_latent_and_fetch(replacement).unwrap();
-        assert_eq!(stored.shape(), &[1, 1, 3, 6]);
-        assert_eq!(offset, 3);
+        let (rewritten, rewritten_offset) = cache.update_latent_and_fetch(replacement).unwrap();
+        assert_eq!(rewritten.shape(), &[1, 1, 3, 6]);
+        assert_eq!(rewritten_offset, 3);
 
         let checkpoint = cache.deep_clone();
         let update = Array::full::<f32>(&[1, 1, 1, 6], &Array::from_f32(2.0)).unwrap();

--- a/crates/higgs-models/src/deepseek_v2.rs
+++ b/crates/higgs-models/src/deepseek_v2.rs
@@ -398,15 +398,19 @@ impl DeepSeekV2Attention {
                 self.kv_b_proj.group_size,
                 self.kv_b_proj.bits,
             )?;
-            let k_width = self.num_heads * self.qk_nope_head_dim;
-            let k = weight.index((..k_width, ..)).reshape(&[
-                1,
+            // `kv_b_proj` output rows are contiguous within each head:
+            // [head0 K, head0 V, head1 K, head1 V, ...]. Split after reshaping
+            // so K/V rows remain associated with their original head.
+            let per_head_weight = weight.reshape(&[
                 self.num_heads,
-                self.qk_nope_head_dim,
+                self.qk_nope_head_dim + self.v_head_dim,
                 self.kv_lora_rank,
             ])?;
-            let v = weight
-                .index((k_width.., ..))
+            let k = per_head_weight
+                .index((.., ..self.qk_nope_head_dim, ..))
+                .reshape(&[1, self.num_heads, self.qk_nope_head_dim, self.kv_lora_rank])?;
+            let v = per_head_weight
+                .index((.., self.qk_nope_head_dim.., ..))
                 .reshape(&[1, self.num_heads, self.v_head_dim, self.kv_lora_rank])?
                 .transpose_axes(&[0, 1, 3, 2])?;
             self.absorbed_k = Some(k);
@@ -1027,6 +1031,46 @@ pub fn load_deepseek_v2_model<P: AsRef<Path>>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mlx_rs::module::Param;
+
+    fn random_qlinear(input_dim: i32, output_dim: i32) -> QLinear {
+        let group_size = 32;
+        let bits = 4;
+        let raw =
+            mlx_rs::random::normal::<f32>(&[output_dim, input_dim], None, None, None).unwrap();
+        let (weight, scales, biases) = ops::quantize(&raw, group_size, bits).unwrap();
+        QLinear {
+            weight: Param::new(weight),
+            scales: Param::new(scales),
+            biases: Param::new(biases),
+            group_size,
+            bits,
+        }
+    }
+
+    fn random_attention() -> DeepSeekV2Attention {
+        let args = small_args();
+        let mut attention = DeepSeekV2Attention::new(&args, 64, 4).unwrap();
+        attention.q_proj = Some(random_qlinear(64, 4 * (16 + 8)));
+        attention.kv_a_proj_with_mqa = random_qlinear(64, 32 + 8);
+        attention.kv_b_proj = random_qlinear(32, 4 * (16 + 16));
+        attention.o_proj = random_qlinear(4 * 16, 64);
+        attention
+    }
+
+    fn assert_attention_outputs_close(dense: &Array, absorbed: &Array, step: &str) {
+        assert_eq!(dense.shape(), absorbed.shape());
+        let max_delta = dense
+            .as_slice::<f32>()
+            .iter()
+            .zip(absorbed.as_slice::<f32>().iter())
+            .map(|(left, right)| (left - right).abs())
+            .fold(0.0_f32, f32::max);
+        assert!(
+            max_delta < 1e-2,
+            "{step} absorbed MLA output diverged from dense cache: max_delta={max_delta}"
+        );
+    }
 
     fn v2_lite_args() -> DeepSeekV2ModelArgs {
         DeepSeekV2ModelArgs {
@@ -1097,6 +1141,35 @@ mod tests {
             moe_layer_freq: Some(1),
             quantization: None,
         }
+    }
+
+    #[test]
+    fn absorbed_mla_attention_matches_dense_cache_for_prefill_and_decode() {
+        let mut dense_attention = random_attention();
+        let mut absorbed_attention = dense_attention.clone();
+        let mut dense_cache = SteppingKeyValueCache::new();
+        let mut absorbed_cache =
+            SteppingKeyValueCache::new_mla(32, 8, KvCacheConfig::default()).unwrap();
+
+        let prefill = mlx_rs::random::normal::<f32>(&[1, 6, 64], None, None, None).unwrap();
+        let prefill_mask =
+            create_attention_mask(&prefill, &[Some(SteppingKeyValueCache::new())], None).unwrap();
+        let dense_prefill = dense_attention
+            .forward(&prefill, prefill_mask.as_ref(), Some(&mut dense_cache))
+            .unwrap();
+        let absorbed_prefill = absorbed_attention
+            .forward(&prefill, prefill_mask.as_ref(), Some(&mut absorbed_cache))
+            .unwrap();
+        assert_attention_outputs_close(&dense_prefill, &absorbed_prefill, "prefill");
+
+        let decode = mlx_rs::random::normal::<f32>(&[1, 1, 64], None, None, None).unwrap();
+        let dense_decode = dense_attention
+            .forward(&decode, None, Some(&mut dense_cache))
+            .unwrap();
+        let absorbed_decode = absorbed_attention
+            .forward(&decode, None, Some(&mut absorbed_cache))
+            .unwrap();
+        assert_attention_outputs_close(&dense_decode, &absorbed_decode, "decode");
     }
 
     #[test]

--- a/crates/higgs-models/src/deepseek_v2.rs
+++ b/crates/higgs-models/src/deepseek_v2.rs
@@ -26,6 +26,7 @@ use crate::{
     qwen3_next::{
         QEmbedding, QLinear, QuantizationConfig, SwitchMlpWeights, new_mlp_projections, swiglu,
     },
+    turboquant::KvCacheConfig,
     utils::{AttentionMask, create_attention_mask},
 };
 
@@ -268,7 +269,7 @@ struct DeepSeekV2Attention {
     kv_lora_rank: i32,
     qk_nope_head_dim: i32,
     qk_rope_head_dim: i32,
-    _v_head_dim: i32,
+    v_head_dim: i32,
     scale: f32,
     rope_base: f32,
     yarn_freqs: Option<Array>,
@@ -377,7 +378,7 @@ impl DeepSeekV2Attention {
             kv_lora_rank: args.kv_lora_rank,
             qk_nope_head_dim: args.qk_nope_head_dim,
             qk_rope_head_dim: args.qk_rope_head_dim,
-            _v_head_dim: args.v_head_dim,
+            v_head_dim: args.v_head_dim,
             scale,
             rope_base: args.rope_theta,
             yarn_freqs,
@@ -406,24 +407,24 @@ impl DeepSeekV2Attention {
             ])?;
             let v = weight
                 .index((k_width.., ..))
-                .reshape(&[1, self.num_heads, self._v_head_dim, self.kv_lora_rank])?
+                .reshape(&[1, self.num_heads, self.v_head_dim, self.kv_lora_rank])?
                 .transpose_axes(&[0, 1, 3, 2])?;
             self.absorbed_k = Some(k);
             self.absorbed_v = Some(v);
         }
-        let k = self
+        let cached_k = self
             .absorbed_k
             .as_ref()
             .ok_or_else(|| Exception::custom("absorbed K missing"))?;
-        let v = self
+        let cached_v = self
             .absorbed_v
             .as_ref()
             .ok_or_else(|| Exception::custom("absorbed V missing"))?;
         // Keep this cast here: MLX scalar/rope operations can promote fp16 inputs
         // to fp32, which otherwise changes both cache residency and QLinear input dtype.
-        if k.dtype() != dtype || v.dtype() != dtype {
-            self.absorbed_k = Some(k.as_dtype(dtype)?);
-            self.absorbed_v = Some(v.as_dtype(dtype)?);
+        if cached_k.dtype() != dtype || cached_v.dtype() != dtype {
+            self.absorbed_k = Some(cached_k.as_dtype(dtype)?);
+            self.absorbed_v = Some(cached_v.as_dtype(dtype)?);
         }
         let k = self
             .absorbed_k
@@ -436,7 +437,7 @@ impl DeepSeekV2Attention {
         Ok((k, v))
     }
 
-    #[allow(non_snake_case)]
+    #[allow(non_snake_case, clippy::too_many_lines)]
     fn forward<C: KeyValueCache>(
         &mut self,
         x: &Array,
@@ -896,7 +897,7 @@ impl DeepSeekV2CausalLM {
                     SteppingKeyValueCache::new_mla(
                         self.args.kv_lora_rank,
                         self.args.qk_rope_head_dim,
-                        Default::default(),
+                        KvCacheConfig::default(),
                     )
                 } else {
                     Ok(SteppingKeyValueCache::new())
@@ -927,7 +928,7 @@ impl DeepSeekV2CausalLM {
                         SteppingKeyValueCache::new_mla(
                             self.args.kv_lora_rank,
                             self.args.qk_rope_head_dim,
-                            Default::default(),
+                            KvCacheConfig::default(),
                         )
                     } else {
                         Ok(SteppingKeyValueCache::new())

--- a/crates/higgs-models/src/deepseek_v2.rs
+++ b/crates/higgs-models/src/deepseek_v2.rs
@@ -21,7 +21,7 @@ use mlx_rs::{
 use serde::Deserialize;
 
 use crate::{
-    cache::{KeyValueCache, SteppingKeyValueCache},
+    cache::{KeyValueCache, SteppingKeyValueCache, mla_latent_cache_enabled},
     error::ModelError,
     qwen3_next::{
         QEmbedding, QLinear, QuantizationConfig, SwitchMlpWeights, new_mlp_projections, swiglu,
@@ -274,6 +274,8 @@ struct DeepSeekV2Attention {
     yarn_freqs: Option<Array>,
     yarn_mscale: f32,
     use_compressed_query: bool,
+    absorbed_k: Option<Array>,
+    absorbed_v: Option<Array>,
 }
 
 impl DeepSeekV2Attention {
@@ -381,7 +383,57 @@ impl DeepSeekV2Attention {
             yarn_freqs,
             yarn_mscale,
             use_compressed_query,
+            absorbed_k: None,
+            absorbed_v: None,
         })
+    }
+
+    fn absorbed_weights(&mut self, dtype: mlx_rs::Dtype) -> Result<(&Array, &Array), Exception> {
+        if self.absorbed_k.is_none() || self.absorbed_v.is_none() {
+            let weight = ops::dequantize(
+                &self.kv_b_proj.weight,
+                &self.kv_b_proj.scales,
+                &*self.kv_b_proj.biases,
+                self.kv_b_proj.group_size,
+                self.kv_b_proj.bits,
+            )?;
+            let k_width = self.num_heads * self.qk_nope_head_dim;
+            let k = weight.index((..k_width, ..)).reshape(&[
+                1,
+                self.num_heads,
+                self.qk_nope_head_dim,
+                self.kv_lora_rank,
+            ])?;
+            let v = weight
+                .index((k_width.., ..))
+                .reshape(&[1, self.num_heads, self._v_head_dim, self.kv_lora_rank])?
+                .transpose_axes(&[0, 1, 3, 2])?;
+            self.absorbed_k = Some(k);
+            self.absorbed_v = Some(v);
+        }
+        let k = self
+            .absorbed_k
+            .as_ref()
+            .ok_or_else(|| Exception::custom("absorbed K missing"))?;
+        let v = self
+            .absorbed_v
+            .as_ref()
+            .ok_or_else(|| Exception::custom("absorbed V missing"))?;
+        // Keep this cast here: MLX scalar/rope operations can promote fp16 inputs
+        // to fp32, which otherwise changes both cache residency and QLinear input dtype.
+        if k.dtype() != dtype || v.dtype() != dtype {
+            self.absorbed_k = Some(k.as_dtype(dtype)?);
+            self.absorbed_v = Some(v.as_dtype(dtype)?);
+        }
+        let k = self
+            .absorbed_k
+            .as_ref()
+            .ok_or_else(|| Exception::custom("absorbed K missing after cast"))?;
+        let v = self
+            .absorbed_v
+            .as_ref()
+            .ok_or_else(|| Exception::custom("absorbed V missing after cast"))?;
+        Ok((k, v))
     }
 
     #[allow(non_snake_case)]
@@ -441,14 +493,8 @@ impl DeepSeekV2Attention {
             .reshape(&[B, L, 1, self.qk_rope_head_dim])?
             .transpose_axes(&[0, 2, 1, 3])?;
 
-        // Decompress KV
-        let kv = self
-            .kv_b_proj
-            .forward(&self.kv_a_layernorm.forward(&kv_latent)?)?
-            .reshape(&[B, L, self.num_heads, -1])?
-            .transpose_axes(&[0, 2, 1, 3])?;
-        let k_nope = kv.index((.., .., .., ..self.qk_nope_head_dim));
-        let v_decompressed = kv.index((.., .., .., self.qk_nope_head_dim..));
+        let use_absorbed = cache.as_ref().is_some_and(|c| KeyValueCache::is_mla(*c));
+        let latent = self.kv_a_layernorm.forward(&kv_latent)?;
 
         // Apply RoPE
         let offset = cache.as_ref().map_or(0, |c| KeyValueCache::offset(*c));
@@ -469,6 +515,42 @@ impl DeepSeekV2Attention {
             self.yarn_mscale,
             offset,
         )?;
+
+        if use_absorbed {
+            let kv_lora_rank = self.kv_lora_rank;
+            let scale = self.scale;
+            let (absorbed_k, absorbed_v) = self.absorbed_weights(q_nope.dtype())?;
+            let q_latent = q_nope.matmul(absorbed_k)?;
+            let queries = ops::concatenate_axis(&[&q_latent, &q_pe], -1)?;
+            let rows =
+                ops::concatenate_axis(&[&latent.reshape(&[B, 1, L, kv_lora_rank])?, &k_pe], -1)?;
+            let (history, _) = cache
+                .ok_or_else(|| Exception::custom("MLA latent path requires a cache"))?
+                .update_latent_and_fetch(rows)?;
+            let values = history.index((.., .., .., ..kv_lora_rank));
+            let sdpa_mask = mask.map(fast::ScaledDotProductAttentionMask::from);
+            let output = fast::scaled_dot_product_attention(
+                queries,
+                history,
+                values,
+                scale,
+                sdpa_mask,
+                None::<&Array>,
+            )?
+            .matmul(absorbed_v)?
+            .transpose_axes(&[0, 2, 1, 3])?
+            .reshape(&[B, L, -1])?;
+            return self.o_proj.forward(&output);
+        }
+
+        // Decompress KV (the legacy dense cache path).
+        let kv = self
+            .kv_b_proj
+            .forward(&latent)?
+            .reshape(&[B, L, self.num_heads, -1])?
+            .transpose_axes(&[0, 2, 1, 3])?;
+        let k_nope = kv.index((.., .., .., ..self.qk_nope_head_dim));
+        let v_decompressed = kv.index((.., .., .., self.qk_nope_head_dim..));
 
         // Repeat k_pe for all heads: [B, 1, L, D] -> [B, num_heads, L, D]
         let k_pe_expanded =
@@ -807,6 +889,23 @@ impl DeepSeekV2CausalLM {
         })
     }
 
+    pub fn make_cache(&self) -> Result<Vec<Option<SteppingKeyValueCache>>, Exception> {
+        (0..self.args.num_hidden_layers)
+            .map(|_| {
+                if mla_latent_cache_enabled() {
+                    SteppingKeyValueCache::new_mla(
+                        self.args.kv_lora_rank,
+                        self.args.qk_rope_head_dim,
+                        Default::default(),
+                    )
+                } else {
+                    Ok(SteppingKeyValueCache::new())
+                }
+                .map(Some)
+            })
+            .collect()
+    }
+
     #[allow(non_snake_case)]
     pub fn forward_hidden(
         &mut self,
@@ -823,8 +922,19 @@ impl DeepSeekV2CausalLM {
 
         if kv_cache.is_empty() {
             *kv_cache = (0..self.model.layers.len())
-                .map(|_| Some(SteppingKeyValueCache::new()))
-                .collect();
+                .map(|_| {
+                    if mla_latent_cache_enabled() {
+                        SteppingKeyValueCache::new_mla(
+                            self.args.kv_lora_rank,
+                            self.args.qk_rope_head_dim,
+                            Default::default(),
+                        )
+                    } else {
+                        Ok(SteppingKeyValueCache::new())
+                    }
+                    .map(Some)
+                })
+                .collect::<Result<_, _>>()?;
         } else if kv_cache.len() != self.model.layers.len() {
             return Err(Exception::custom(format!(
                 "kv_cache length ({}) must match num layers ({})",

--- a/crates/higgs-models/src/lib.rs
+++ b/crates/higgs-models/src/lib.rs
@@ -832,7 +832,7 @@ impl AnyModel {
                         "TurboQuant is only supported for standard KV transformer models",
                     ));
                 }
-                Ok(make_kv_cache(m.args.num_hidden_layers))
+                Ok(AnyCache::KV(m.make_cache()?))
             }
             Self::Qwen3Next(m) => {
                 if kv_cache_config.is_turboquant() {

--- a/validation/pr3-mla/report.md
+++ b/validation/pr3-mla/report.md
@@ -1,0 +1,61 @@
+# Validation report: pr3-mla (MLA latent KV cache with weight absorption)
+
+- chip: Apple M4 Max
+- ram_gb: 128
+- macos_version: 26.5.1
+- branch: claude/ds4-p3-mla-latent-cache
+- model: mlx-community/DeepSeek-Coder-V2-Lite-Instruct-4bit-mlx (MoE, 27 layers, kv_lora_rank 512, rope 64)
+- tools: bench_frontier (PR2) + quality_gate (PR1), built from a local merge of this branch with those branches
+
+## Pre-registered acceptance criteria
+1. >= 1.25x decode t/s at 16k+ context (MLA on vs off).
+2. >= 5x measured KV bytes/token reduction.
+3. PR1 quality gates green (token-exact or documented max-logprob-delta).
+4. Prefix-cache store -> lookup -> continue test passes.
+
+## Results
+
+### Criterion 1: decode throughput — PASS
+bench_frontier, greedy 64-token probes, medians of 3 sweeps (dense 32k: 1 sweep, see caveat):
+
+| Context | Dense median t/s | MLA median t/s | Speedup |
+| ---: | ---: | ---: | ---: |
+| 2048 | 121.0 | 122.4 | 1.01x |
+| 8192 | 77.5 | 105.5 | 1.36x |
+| 16384 | 52.5 | 90.0 | 1.71x |
+| 32768 | 32.6 | 71.3 | 2.19x |
+
+Caveat honestly noted: the dense-mode 3-sweep run through 32k was killed by the OS (exit 137, memory
+pressure: ~11.3 GB dense KV on top of 9.5 GB weights, repeated sweeps); the dense 32k number is from a
+single sweep. The MLA-mode 3x32k run completed without incident — itself evidence of the memory win.
+
+### Criterion 2: KV memory — PASS
+Measured kv_bytes/token: dense 276,480-285,120 (capacity rounding); MLA 31,104 = exactly
+27 layers x (512+64) x 2 bytes. Reduction: 8.9x.
+
+### Criterion 3: quality gates — PASS with documented drift
+quality_gate check vs the PR1 committed baseline (recorded via the decompressed path), 12 prompts x 64
+greedy tokens, teacher-forced:
+- MLA off (control): token-exact 12/12, max |delta logprob| = 0.0.
+- MLA on: token-exact 11/12; per-prompt max |delta logprob| 0.010-0.062 for the 11 exact prompts;
+  one prompt flips a near-tie argmax and compounds to 0.227.
+The drift is the expected consequence of absorption: the absorbed path multiplies by the dequantized
+fp16 kv_b_proj instead of running the fused 4-bit quantized matmul. The plan's a-priori estimate
+(~1e-3) was optimistic for a 4-bit checkpoint; observed typical drift is ~3e-2 to 6e-2 logprob.
+Documented here per the pre-registered "token-exact or documented max-logprob-delta" criterion.
+Rollout remains opt-in (HIGGS_MLA_LATENT_CACHE, default off).
+
+### Criterion 4: prefix cache — PASS
+test_mla_cache_store_lookup_and_continue (paged_prefix_cache.rs) covers store -> multi-block lookup ->
+from_latent_array materialization -> continued append. cargo test -p higgs-engine: 288 passed.
+
+### Additional correctness
+- SDPA smoke (examples/sdpa_mla_smoke.rs): fused SDPA accepts MQA 576/512 decode + causal prefill,
+  max diff vs explicit softmax ~2e-7.
+- Absorbed-vs-decompressed parity unit test (H=4 synthetic weights): fails on a scrambled weight
+  layout (delta 210), passes on the per-head split (< 1e-2), for both L=6 prefill and 1-token decode.
+- Review found and fixed a real per-head weight-layout bug before any hardware run; the parity test
+  now guards it.
+
+Verdict: PASS — recommend merge with default OFF; flip-on decision belongs to a follow-up after
+longer-context soak and the config-surface (doctor/README/init) work.


### PR DESCRIPTION
Part of the ds4 -> higgs adoption program (docs/ds4-analysis-2026-08.md). Implements P1, the program's flagship perf item: cache only the compressed MLA latent (kv_lora_rank + shared RoPE K = 576 values/token) instead of decompressed per-head K/V, and absorb kv_b_proj into the query/output paths so attention runs as MQA directly against the latent.

Opt-in via `HIGGS_MLA_LATENT_CACHE` (0/1/on/off/true/false/yes/no), default OFF. Config-surface work (doctor/README/init) intentionally deferred to the default-flip follow-up.

## Measured results (DeepSeek-Coder-V2-Lite-4bit, Apple M4 Max 128 GB — full report at validation/pr3-mla/report.md)

| Context | Dense t/s | MLA t/s | Speedup |
| ---: | ---: | ---: | ---: |
| 2048 | 121.0 | 122.4 | 1.01x |
| 8192 | 77.5 | 105.5 | 1.36x |
| 16384 | 52.5 | 90.0 | **1.71x** |
| 32768 | 32.6 | 71.3 | **2.19x** |

KV bytes/token: 276,480 -> 31,104 (**8.9x**, exactly 27 x 576 x 2). The dense 3-sweep 32k benchmark was OOM-killed by the OS; the MLA equivalent completed without incident.

Pre-registered criteria: >=1.25x at 16k+ (PASS: 1.71x/2.19x), >=5x KV reduction (PASS: 8.9x), quality gates (PASS with documented drift: 11/12 prompts token-exact vs the decompressed baseline, typical logprob drift 0.01-0.06 from dequantized-fp16 vs fused-4bit matmul; one near-tie argmax flip; control run with MLA off is bit-exact), prefix-cache store->lookup->continue (PASS, unit-tested).

## Implementation
- `MlaStorage` mode inside `SteppingKeyValueCache` (mirrors the TurboQuant storage-mode precedent; offset/trim/deep_clone/eval_targets all preserved), `update_latent_and_fetch` on the `KeyValueCache` trait, `new_mla`/`from_latent_array`/`latent_array`/`is_mla`.
- Absorbed attention path in deepseek_v2.rs for ALL shapes (prefill + decode) via fused SDPA — commit 1 is a smoke example proving MLX SDPA on Metal accepts MQA qk=576/v=512 (max diff vs explicit softmax ~2e-7), so no fallback path exists.
- Lazy one-time dequantization of kv_b_proj into non-param absorbed_k/absorbed_v (per-head split; guarded by a parity test that fails loudly on layout mistakes), cast to compute dtype per the file's fp16-promotion hazard.
- Paged prefix cache: `MlaLatent` blocks (~9x smaller), store/lookup/materialize covered by test.
- MLA + TurboQuant combination rejected at cache construction.

## Review notes (Codex CLI gpt-5.6-terra medium implemented; Claude reviewed)
The review cycle caught a real correctness bug before any hardware run: the kv_b_proj dequantized weight was split as [all K rows | all V rows] when the layout is per-head [K_h | V_h] interleaved — scrambling attention for every real checkpoint (parity delta 210 on the H=4 test). Fixed; the mandated parity test now guards it. Also fixed: env knob accepted only "true"/"false" (now matches the repo's 0/1/on/off convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)