### PR TITLE
[NEGATIVE RESULT] structural greedy sampling for tool calls (PR4 / ds4 P3) — do not merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ graph.json
 benchmarks/*.txt
 benchmarks/*.safetensors
 benchmarks/*.py
+validation/**/raw/

--- a/crates/higgs-engine/src/batch_engine.rs
+++ b/crates/higgs-engine/src/batch_engine.rs
@@ -310,6 +310,7 @@ impl BatchEngine {
             false,
             constraint,
             pixel_values,
+            crate::simple::StructuralGreedy::Disabled,
         )
     }
 
@@ -329,6 +330,9 @@ impl BatchEngine {
         _return_progress: bool,
         constraint: Option<crate::constrained::ConstrainedGenerator>,
         pixel_values: Option<mlx_rs::Array>,
+        // Structural greedy is currently implemented by SimpleEngine's normal
+        // decode loop; batched/speculative verification keeps target sampling.
+        _structural_greedy: crate::simple::StructuralGreedy,
     ) -> Result<(), EngineError> {
         if pixel_values.is_some() {
             return Err(EngineError::Generation(

--- a/crates/higgs-engine/src/simple.rs
+++ b/crates/higgs-engine/src/simple.rs
@@ -30,11 +30,68 @@ use crate::{
     model_loader,
     paged_prefix_cache::{DEFAULT_BLOCK_SIZE, PagedPrefixCache},
     scheduler::RoundRobinScheduler,
+    tool_parser::{ToolCallRegion, ToolCallRegionClassifier},
 };
 
 /// Default maximum number of cached prefixes.
 const DEFAULT_PREFIX_CACHE_SIZE: usize = 8;
 const DEFAULT_PAGED_KV_BLOCK_SIZE: usize = 64;
+
+/// Whether generation should greedily select JSON structure in tool calls.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StructuralGreedy {
+    /// Preserve the configured sampling policy throughout generation.
+    Disabled,
+    /// Sample text values but select tool-call JSON structure greedily.
+    Enabled,
+}
+
+impl From<bool> for StructuralGreedy {
+    fn from(enabled: bool) -> Self {
+        if enabled {
+            Self::Enabled
+        } else {
+            Self::Disabled
+        }
+    }
+}
+
+fn structural_greedy_enabled() -> bool {
+    std::env::var("HIGGS_STRUCTURAL_GREEDY").map_or(true, |value| {
+        !matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "0" | "off" | "false" | "no"
+        )
+    })
+}
+
+struct StructuralSamplingController {
+    enabled: bool,
+    classifier: ToolCallRegionClassifier,
+}
+
+impl StructuralSamplingController {
+    fn new(policy: StructuralGreedy) -> Self {
+        Self {
+            enabled: policy == StructuralGreedy::Enabled && structural_greedy_enabled(),
+            classifier: ToolCallRegionClassifier::new(),
+        }
+    }
+
+    fn observe(&mut self, text: &str) {
+        if self.enabled {
+            self.classifier.push_str(text);
+        }
+    }
+
+    const fn should_sample(&self) -> bool {
+        !self.enabled
+            || matches!(
+                self.classifier.region(),
+                ToolCallRegion::Outside | ToolCallRegion::Value
+            )
+    }
+}
 
 /// Acquire a `Mutex` lock, recovering from poison by reusing the inner data.
 /// Used in this crate to keep session-management methods infallible while
@@ -2151,6 +2208,7 @@ impl SimpleEngine {
             false,
             constraint,
             pixel_values,
+            StructuralGreedy::Disabled,
         )
     }
 
@@ -2168,6 +2226,7 @@ impl SimpleEngine {
         return_progress: bool,
         constraint: Option<crate::constrained::ConstrainedGenerator>,
         pixel_values: Option<Array>,
+        structural_greedy: StructuralGreedy,
     ) -> Result<(), EngineError> {
         if prompt_tokens.is_empty() {
             return Err(EngineError::Generation("Prompt is empty".to_owned()));
@@ -2199,6 +2258,7 @@ impl SimpleEngine {
                 return_progress,
                 constraint,
                 pixel_values,
+                structural_greedy,
             )
         })
     }
@@ -2221,6 +2281,7 @@ impl SimpleEngine {
         return_progress: bool,
         mut constraint: Option<crate::constrained::ConstrainedGenerator>,
         pixel_values: Option<Array>,
+        structural_greedy: StructuralGreedy,
     ) -> Result<(), EngineError> {
         let logprob_top_n = logprobs.then(|| top_logprobs.unwrap_or(0));
 
@@ -2298,6 +2359,7 @@ impl SimpleEngine {
             0,
             std::sync::Arc::clone(&self.decode_skip_ids),
         );
+        let mut structural_sampling = StructuralSamplingController::new(structural_greedy);
         let first_new_text = detok.append(&self.tokenizer, &all_tokens)?;
         let first_emitted_before = detok.text.len() - first_new_text.len();
         let (mut first_text, first_hit_stop) = if stop_sequences.is_empty() {
@@ -2327,6 +2389,8 @@ impl SimpleEngine {
             .as_ref()
             .map(|lp| lp.materialize(first_token_id));
 
+        structural_sampling.observe(&first_text);
+
         if sender
             .blocking_send(StreamingOutput {
                 new_text: first_text,
@@ -2351,6 +2415,9 @@ impl SimpleEngine {
         if finished {
             return Ok(());
         }
+
+        let mut greedy_params = params.clone();
+        greedy_params.temperature = 0.0;
 
         // MTP speculative decode (streaming): greedy, no constraints, no logprobs.
         #[allow(clippy::float_cmp)]
@@ -2394,7 +2461,11 @@ impl SimpleEngine {
             &current_token,
             &mut prepared.model,
             &mut prepared.cache,
-            params,
+            if structural_sampling.should_sample() {
+                params
+            } else {
+                &greedy_params
+            },
             &all_tokens,
             logprob_top_n,
             constraint.as_ref(),
@@ -2423,7 +2494,11 @@ impl SimpleEngine {
                 &next_token,
                 &mut prepared.model,
                 &mut prepared.cache,
-                params,
+                if structural_sampling.should_sample() {
+                    params
+                } else {
+                    &greedy_params
+                },
                 &all_tokens,
                 logprob_top_n,
                 constraint.as_ref(),
@@ -2471,6 +2546,7 @@ impl SimpleEngine {
             let completion_len = Self::completion_len(&all_tokens)?;
 
             let new_text = detok.append(&self.tokenizer, &all_tokens)?;
+            structural_sampling.observe(&new_text);
             let emitted_before = detok.text.len() - new_text.len();
 
             let (mut final_new_text, hit_stop_seq) = if stop_sequences.is_empty() {
@@ -2935,10 +3011,38 @@ fn chat_template_mentions_enable_thinking(model_dir: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        IncrementalDetok, Tokenizer, adaptive_draft_depth_for_cap, check_stop_sequences,
-        derive_model_name, detect_thinking_support, estimate_paged_kv_blocks, extract_eos_tokens,
-        find_stop_in_tail, parse_enabled_flag,
+        IncrementalDetok, StructuralSamplingController, Tokenizer, adaptive_draft_depth_for_cap,
+        check_stop_sequences, derive_model_name, detect_thinking_support, estimate_paged_kv_blocks,
+        extract_eos_tokens, find_stop_in_tail, parse_enabled_flag,
     };
+
+    #[test]
+    fn structural_greedy_decision_follows_scripted_decode() {
+        let mut controller = StructuralSamplingController {
+            enabled: true,
+            classifier: crate::tool_parser::ToolCallRegionClassifier::new(),
+        };
+        let script = [
+            ("text ", true),
+            ("<tool_call>{\"name\":", false),
+            ("\"", true),
+            ("get_weather\"", false),
+            (",\"arguments\":{\"city\":", false),
+            ("\"", true),
+            ("San Francisco\"", false),
+            (",\"n\":", false),
+            ("3", true),
+            ("}}</tool_call> text", true),
+        ];
+        for (text, expected_sample) in script {
+            controller.observe(text);
+            assert_eq!(
+                controller.should_sample(),
+                expected_sample,
+                "after {text:?}"
+            );
+        }
+    }
     use std::path::Path;
 
     /// Write a config.json file into the given directory with the provided JSON content.

--- a/crates/higgs-engine/src/tool_parser.rs
+++ b/crates/higgs-engine/src/tool_parser.rs
@@ -47,6 +47,180 @@ pub struct ToolParseResult {
 const TOOL_CALL_OPEN: &str = "<tool_call>";
 const TOOL_CALL_CLOSE: &str = "</tool_call>";
 
+/// The sampling policy appropriate at the current generated-text position.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolCallRegion {
+    Outside,
+    Structural,
+    Value,
+}
+
+#[derive(Clone, Copy)]
+enum JsonContainer {
+    Object { expecting_key: bool },
+    Array,
+}
+
+#[derive(Clone, Copy)]
+enum JsonScan {
+    Structural,
+    Key { escaped: bool },
+    StringValue { escaped: bool },
+    Number,
+}
+
+/// Incrementally classifies generated tool-call JSON without retaining output.
+///
+/// Feed the stable text emitted by `IncrementalDetok`; call [`Self::region`]
+/// before choosing the next token's sampling policy.
+pub struct ToolCallRegionClassifier {
+    in_tool_call: bool,
+    suffix: String,
+    scan: JsonScan,
+    containers: Vec<JsonContainer>,
+}
+
+impl ToolCallRegionClassifier {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            in_tool_call: false,
+            suffix: String::new(),
+            scan: JsonScan::Structural,
+            containers: Vec::new(),
+        }
+    }
+
+    #[must_use]
+    pub const fn region(&self) -> ToolCallRegion {
+        if !self.in_tool_call {
+            ToolCallRegion::Outside
+        } else if matches!(self.scan, JsonScan::StringValue { .. } | JsonScan::Number) {
+            ToolCallRegion::Value
+        } else {
+            ToolCallRegion::Structural
+        }
+    }
+
+    /// Feed stable decoded text. It is intentionally character-based so
+    /// wrapper and JSON tokens may arrive split across tokenizer boundaries.
+    pub fn push_str(&mut self, text: &str) {
+        for ch in text.chars() {
+            self.push_char(ch);
+        }
+    }
+
+    pub fn push_char(&mut self, ch: char) {
+        if !self.in_tool_call {
+            self.push_suffix(ch);
+            if self.suffix.ends_with(TOOL_CALL_OPEN) {
+                self.in_tool_call = true;
+                self.suffix.clear();
+                self.scan = JsonScan::Structural;
+                self.containers.clear();
+            }
+            return;
+        }
+
+        self.push_suffix(ch);
+        if self.suffix.ends_with(TOOL_CALL_CLOSE) {
+            self.in_tool_call = false;
+            self.suffix.clear();
+            self.scan = JsonScan::Structural;
+            self.containers.clear();
+            return;
+        }
+
+        match self.scan {
+            JsonScan::Key { escaped } => {
+                if escaped {
+                    self.scan = JsonScan::Key { escaped: false };
+                } else if ch == '\\' {
+                    self.scan = JsonScan::Key { escaped: true };
+                } else if ch == '"' {
+                    self.scan = JsonScan::Structural;
+                }
+            }
+            JsonScan::StringValue { escaped } => {
+                if escaped {
+                    self.scan = JsonScan::StringValue { escaped: false };
+                } else if ch == '\\' {
+                    self.scan = JsonScan::StringValue { escaped: true };
+                } else if ch == '"' {
+                    self.scan = JsonScan::Structural;
+                    self.value_complete();
+                }
+            }
+            JsonScan::Number => {
+                if !matches!(ch, '0'..='9' | '-' | '+' | '.' | 'e' | 'E') {
+                    self.scan = JsonScan::Structural;
+                    self.value_complete();
+                    self.push_structural(ch);
+                }
+            }
+            JsonScan::Structural => self.push_structural(ch),
+        }
+    }
+
+    fn push_suffix(&mut self, ch: char) {
+        self.suffix.push(ch);
+        let max = TOOL_CALL_CLOSE.len();
+        while self.suffix.len() > max {
+            self.suffix.remove(0);
+        }
+    }
+
+    fn push_structural(&mut self, ch: char) {
+        match ch {
+            '{' => self.containers.push(JsonContainer::Object {
+                expecting_key: true,
+            }),
+            '[' => self.containers.push(JsonContainer::Array),
+            '}' | ']' => {
+                self.containers.pop();
+                self.value_complete();
+            }
+            ':' => {
+                if let Some(JsonContainer::Object { expecting_key }) = self.containers.last_mut() {
+                    *expecting_key = false;
+                }
+            }
+            ',' => {
+                if let Some(JsonContainer::Object { expecting_key }) = self.containers.last_mut() {
+                    *expecting_key = true;
+                }
+            }
+            '"' => {
+                let is_key = matches!(
+                    self.containers.last(),
+                    Some(JsonContainer::Object {
+                        expecting_key: true
+                    })
+                );
+                self.scan = if is_key {
+                    JsonScan::Key { escaped: false }
+                } else {
+                    JsonScan::StringValue { escaped: false }
+                };
+            }
+            '-' | '0'..='9' => self.scan = JsonScan::Number,
+            _ => {}
+        }
+    }
+
+    fn value_complete(&mut self) {
+        if let Some(JsonContainer::Object { expecting_key }) = self.containers.last_mut() {
+            *expecting_key = false;
+        }
+    }
+}
+
+impl Default for ToolCallRegionClassifier {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Hard cap on bytes buffered while inside an unclosed `<tool_call>`.
 ///
 /// Without a cap, a model that emits `<tool_call>` and never closes the tag
@@ -743,6 +917,45 @@ impl StreamingToolCallTracker {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn structural_region_classifier_distinguishes_tool_json_values() {
+        let input = "before <tool_call>{\"name\": \"get_weather\", \"arguments\": {\"city\": \"San Francisco\", \"n\": 3}}</tool_call> after";
+        let mut classifier = ToolCallRegionClassifier::new();
+        let mut regions = Vec::new();
+        for ch in input.chars() {
+            regions.push(classifier.region());
+            classifier.push_char(ch);
+        }
+
+        let at = |needle: &str| input.find(needle).unwrap();
+        assert_eq!(regions[at("before")], ToolCallRegion::Outside);
+        assert_eq!(regions[at("<tool_call>")], ToolCallRegion::Outside);
+        assert_eq!(regions[at("{")], ToolCallRegion::Structural);
+        assert_eq!(regions[at("\"name\"")], ToolCallRegion::Structural);
+        assert_eq!(regions[at("get_weather")], ToolCallRegion::Value);
+        assert_eq!(regions[at("\"arguments\"")], ToolCallRegion::Structural);
+        assert_eq!(regions[at("San Francisco")], ToolCallRegion::Value);
+        assert_eq!(regions[at("3}") + 1], ToolCallRegion::Value);
+        assert_eq!(classifier.region(), ToolCallRegion::Outside);
+    }
+
+    #[test]
+    fn structural_region_classifier_handles_escaped_quotes_and_nested_objects() {
+        let input = "<tool_call>{\"arguments\":{\"nested\":{\"message\":\"say \\\"hi\\\"\"},\"n\":-1.5e2}}</tool_call>";
+        let mut classifier = ToolCallRegionClassifier::new();
+        let mut regions = Vec::new();
+        for ch in input.chars() {
+            regions.push(classifier.region());
+            classifier.push_char(ch);
+        }
+        let at = |needle: &str| input.find(needle).unwrap();
+        assert_eq!(regions[at("nested")], ToolCallRegion::Structural);
+        assert_eq!(regions[at("say")], ToolCallRegion::Value);
+        assert_eq!(regions[at("hi")], ToolCallRegion::Value);
+        assert_eq!(regions[at("-1.5e2") + 1], ToolCallRegion::Value);
+        assert_eq!(classifier.region(), ToolCallRegion::Outside);
+    }
 
     /// Parse input and assert expected tool call count and optional text fragment.
     fn assert_parse(

--- a/crates/higgs/src/routes/anthropic.rs
+++ b/crates/higgs/src/routes/anthropic.rs
@@ -352,6 +352,7 @@ fn create_message_stream(
             false,
             None,
             None,
+            false.into(),
         );
         if let Err(e) = result {
             tracing::error!(error = %e, "Generation error during Anthropic streaming");

--- a/crates/higgs/src/routes/chat.rs
+++ b/crates/higgs/src/routes/chat.rs
@@ -526,6 +526,7 @@ fn chat_completions_stream(
             return_progress,
             constraint,
             pixel_values,
+            (stream_includes_tools && sampling.temperature > 0.0).into(),
         );
         if let Err(e) = result {
             tracing::error!(error = %e, "Generation error during streaming");

--- a/crates/higgs/src/state.rs
+++ b/crates/higgs/src/state.rs
@@ -6,7 +6,7 @@ use higgs_engine::chat_template::ChatMessage;
 use higgs_engine::engine::{GenerationOutput, StreamingOutput};
 use higgs_engine::error::EngineError;
 use higgs_engine::mlx_tuning::MlxRuntimeTuning;
-use higgs_engine::simple::SimpleEngine;
+use higgs_engine::simple::{SimpleEngine, StructuralGreedy};
 use higgs_engine::tokenizers::Tokenizer;
 use higgs_models::SamplingParams;
 use higgs_models::turboquant::KvCacheConfig;
@@ -243,6 +243,7 @@ impl Engine {
             false,
             constraint,
             pixel_values,
+            StructuralGreedy::Disabled,
         )
     }
 
@@ -260,6 +261,7 @@ impl Engine {
         return_progress: bool,
         constraint: Option<higgs_engine::constrained::ConstrainedGenerator>,
         pixel_values: Option<Array>,
+        structural_greedy: StructuralGreedy,
     ) -> Result<(), EngineError> {
         match self {
             Self::Simple(e) => e.generate_streaming_with_thinking(
@@ -274,6 +276,7 @@ impl Engine {
                 return_progress,
                 constraint,
                 pixel_values,
+                structural_greedy,
             ),
             Self::Batch(e) => e.generate_streaming_with_thinking(
                 prompt_tokens,
@@ -287,6 +290,7 @@ impl Engine {
                 return_progress,
                 constraint,
                 pixel_values,
+                structural_greedy,
             ),
             #[cfg(test)]
             Self::Stub(_) => Err(EngineError::Generation("test stub".to_owned())),

--- a/validation/pr4-toolgreedy/report.md
+++ b/validation/pr4-toolgreedy/report.md
@@ -1,0 +1,45 @@
+# Validation report: pr4-toolgreedy (structural greedy sampling) — NEGATIVE RESULT
+
+- chip: Apple M4 Max
+- ram_gb: 128
+- macos_version: 26.5.1
+- branch: claude/ds4-p4-structural-greedy
+- model: mlx-community/Qwen3-1.7B-4bit
+
+## Pre-registered acceptance criteria
+1. Malformed tool-call rate strictly decreases at temp 0.8/1.0.
+2. Throughput regression <= 2%.
+3. Payload diversity preserved (no degenerate repetition).
+
+## Method
+100-150 tool-call prompts per condition against a live server (two tools, varied cities/products),
+scoring each response: well-formed tool_calls with valid JSON + required args, vs malformed.
+Round 1 (max_tokens 256) was invalidated by a measurement confound: Qwen3 thinking mode consumed the
+budget and truncated calls mid-JSON (nearly all "malformed" cases had exactly 256 completion tokens).
+Round 2 removed it (max_tokens 1024, temp 1.0, N=150/side).
+
+## Results (round 2)
+| Side | Well-formed | Malformed | Rate | Throughput tok/s |
+| --- | ---: | ---: | ---: | ---: |
+| Baseline (main) | 148/150 | 2 | 1.33% | 301.9 |
+| Candidate (structural greedy) | 147/150 | 3 | 2.00% | 302.1 |
+
+Criterion 1 FAIL: no decrease (difference is within noise; nominally worse).
+Criterion 2 PASS: throughput unchanged (+0.06%).
+Criterion 3 PASS: argument payloads vary across prompts on both sides.
+
+## Failure taxonomy (the decisive finding)
+Every residual malformed case on BOTH sides is the same mode: syntactically VALID JSON emitted
+without the <tool_call> wrapper, so the parser does not lift it into tool_calls. Zero cases of
+corrupted JSON syntax (the failure mode structural greedy targets) were observed in 300 samples.
+Wrapper omission happens in the "outside" region where request sampling is intentionally preserved —
+by design out of this mechanism's reach. The dominant failure in round 1 (45-51% "no tool call") is
+tool-avoidance, also out of reach.
+
+## Verdict: FAIL — do not merge
+The mechanism is implemented and unit-tested (region classifier handles nested JSON/escapes), but on
+Qwen3-class instruct models the structural-syntax malformation it prevents effectively does not occur
+(~0% base rate at temp 1.0). Adding a per-step classifier to the hot decode loop is not justified by
+zero measured benefit. Negative result to be recorded in docs/ds4-analysis-2026-08.md. A plausible
+rework (out of scope here): address wrapper omission instead, e.g. constrained emission of the wrapper
+once arguments-JSON begins.


### PR DESCRIPTION
Part of the ds4 -> higgs adoption program. This PR exists to record a negative result with its evidence; the pre-registered acceptance criterion failed and the recommendation is to CLOSE without merging.

## Claim tested
ds4 P3: forcing greedy sampling during tool-call structural syntax (wrappers, braces, keys) while sampling argument values reduces malformed tool calls at temperature.

## What was built
Working implementation (Codex CLI gpt-5.6-terra medium; Claude-reviewed): incremental `ToolCallRegionClassifier` in tool_parser.rs (nested JSON, escaped strings; unit-tested), wired into the normal decode loop, auto-enabled when a sampled request declares tools, `HIGGS_STRUCTURAL_GREEDY` kill switch. All CI gates pass.

## Why it fails acceptance (validation/pr4-toolgreedy/report.md)
On Qwen3-1.7B-4bit at temp 1.0, N=150/side with the truncation confound removed: baseline 2/150 malformed (1.33%) vs candidate 3/150 (2.00%) — no decrease. Decisively: all residual failures on both sides are *wrapper omission around valid JSON* (out of this mechanism's reach by design), and zero corrupted-JSON-syntax cases occurred in 300 samples. The failure mode this technique prevents effectively does not exist on modern instruct models at these temperatures. Throughput was unchanged (+0.06%), so the loss is not perf — it is unjustified hot-loop complexity.

An earlier measurement round showed a large apparent malformed rate that turned out to be max_tokens truncation via thinking mode — documented in the report as a methodology caveat.

## Program disposition
Negative result to be recorded in docs/ds4-analysis-2026-08.md results table. Plausible future rework targeting the failure mode that WAS observed: constrained wrapper emission when arguments-JSON begins without one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)