### PR TITLE
[NEGATIVE RESULT] exact tool-call replay (PR5 / ds4 P5) — do not merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ graph.json
 benchmarks/*.txt
 benchmarks/*.safetensors
 benchmarks/*.py
+validation/**/raw/

--- a/crates/higgs-engine/src/chat_template.rs
+++ b/crates/higgs-engine/src/chat_template.rs
@@ -11,6 +11,15 @@ pub struct ChatMessage {
     pub content: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_calls: Option<Vec<serde_json::Value>>,
+    /// Exact model-emitted `<tool_call>…</tool_call>` text, when it is safe
+    /// to replay instead of the template's normalized serialization.
+    ///
+    /// This is intentionally not exposed to the Jinja template. After normal
+    /// rendering, [`ChatTemplateRenderer`] replaces only a matching tool-call
+    /// wrapper region. Thus replay is an optimization: a template without the
+    /// expected wrapper remains byte-for-byte on its normal rendering path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub raw_tool_call_text: Option<Vec<Option<String>>>,
 }
 
 /// Upper bound on template-engine instructions per render. Generous enough
@@ -176,9 +185,50 @@ impl ChatTemplateRenderer {
             },
         );
 
-        tmpl.render(context)
-            .map_err(|e| EngineError::Template(e.to_string()))
+        let rendered = tmpl
+            .render(context)
+            .map_err(|e| EngineError::Template(e.to_string()))?;
+        Ok(replay_tool_call_text(rendered, messages))
     }
+}
+
+/// Replace normalized Qwen-style tool-call regions with the exact bytes the
+/// model previously emitted. The replacement is deliberately narrow: if the
+/// rendered prompt does not contain a complete `<tool_call>…</tool_call>`
+/// region for a requested replay, it is left unchanged. This guarantees that
+/// replay cannot alter semantic prompt content for templates it does not
+/// recognize.
+fn replay_tool_call_text(mut rendered: String, messages: &[ChatMessage]) -> String {
+    const OPEN: &str = "<tool_call>";
+    const CLOSE: &str = "</tool_call>";
+    let mut search_from = 0;
+
+    for message in messages {
+        let call_count = message.tool_calls.as_ref().map_or(0, Vec::len);
+        for call_index in 0..call_count {
+            let Some(start_relative) = rendered.get(search_from..).and_then(|s| s.find(OPEN))
+            else {
+                return rendered;
+            };
+            let start = search_from + start_relative;
+            let Some(end_relative) = rendered.get(start..).and_then(|s| s.find(CLOSE)) else {
+                return rendered;
+            };
+            let end = start + end_relative + CLOSE.len();
+            let replay_text = message
+                .raw_tool_call_text
+                .as_ref()
+                .and_then(|calls| calls.get(call_index))
+                .and_then(Option::as_deref);
+            if let Some(raw) = replay_text {
+                rendered.replace_range(start..end, raw);
+                search_from = start.saturating_add(raw.len());
+            } else {
+                search_from = end;
+            }
+        }
+    }
+    rendered
 }
 
 /// Normalise a tool-call JSON object so Qwen-Hermes-style chat templates
@@ -308,6 +358,7 @@ mod tests {
             role: role.to_owned(),
             content: content.to_owned(),
             tool_calls: None,
+            raw_tool_call_text: None,
         }
     }
 
@@ -510,9 +561,75 @@ TOOLS:{{ tools | length }}
                 "type": "function",
                 "function": {"name": "get_weather", "arguments": "{\"city\":\"NYC\"}"}
             })]),
+            raw_tool_call_text: None,
         }];
         let result = renderer.apply(&messages, None, false).unwrap();
         assert!(result.contains("[tools]"));
+    }
+
+    #[test]
+    fn replayed_tool_call_is_rendered_verbatim() {
+        let template = "{% for message in messages %}{{ message.role }}: {% for tool_call in message.tool_calls %}<tool_call>\n{{ tool_call | tojson }}\n</tool_call>{% endfor %}{% endfor %}";
+        let renderer = ChatTemplateRenderer::new(template).unwrap();
+        let messages = vec![ChatMessage {
+            role: "assistant".to_owned(),
+            content: String::new(),
+            tool_calls: Some(vec![serde_json::json!({
+                "name": "weather",
+                "arguments": {"city": "Denver"}
+            })]),
+            raw_tool_call_text: Some(vec![Some(
+                "<tool_call>\n{\"arguments\":{\"city\":\"Denver\"},\"name\":\"weather\"}\n</tool_call>"
+                    .to_owned(),
+            )]),
+        }];
+
+        assert_eq!(
+            renderer.apply(&messages, None, false).unwrap(),
+            "assistant: <tool_call>\n{\"arguments\":{\"city\":\"Denver\"},\"name\":\"weather\"}\n</tool_call>"
+        );
+    }
+
+    #[test]
+    fn replay_keeps_turn_one_prefix_for_qwen_style_template() {
+        let template = "{% for message in messages %}<|im_start|>{{ message.role }}\n{{ message.content }}{% for tool_call in message.tool_calls %}<tool_call>\n{{ tool_call | tojson }}\n</tool_call>{% endfor %}<|im_end|>\n{% endfor %}{% if add_generation_prompt %}<|im_start|>assistant\n{% endif %}";
+        let renderer = ChatTemplateRenderer::new(template).unwrap();
+        let turn_one = vec![ChatMessage {
+            role: "user".to_owned(),
+            content: "weather?".to_owned(),
+            tool_calls: None,
+            raw_tool_call_text: None,
+        }];
+        let generated = "<tool_call>\n{\"name\": \"weather\", \"arguments\": {\"city\": \"Denver\"}}\n</tool_call>";
+        let turn_one_prefix = format!(
+            "{}{}",
+            renderer.apply(&turn_one, None, true).unwrap(),
+            generated
+        );
+        let turn_two = vec![
+            turn_one.first().cloned().unwrap(),
+            ChatMessage {
+                role: "assistant".to_owned(),
+                content: String::new(),
+                tool_calls: Some(vec![serde_json::json!({
+                    "name": "weather",
+                    "arguments": {"city": "Denver"}
+                })]),
+                raw_tool_call_text: Some(vec![Some(generated.to_owned())]),
+            },
+            ChatMessage {
+                role: "tool".to_owned(),
+                content: "sunny".to_owned(),
+                tool_calls: None,
+                raw_tool_call_text: None,
+            },
+        ];
+        let turn_two_prompt = renderer.apply(&turn_two, None, true).unwrap();
+        assert!(
+            turn_two_prompt
+                .as_bytes()
+                .starts_with(turn_one_prefix.as_bytes())
+        );
     }
 
     #[test]

--- a/crates/higgs-engine/src/chat_template.rs
+++ b/crates/higgs-engine/src/chat_template.rs
@@ -192,12 +192,11 @@ impl ChatTemplateRenderer {
     }
 }
 
-/// Replace normalized Qwen-style tool-call regions with the exact bytes the
-/// model previously emitted. The replacement is deliberately narrow: if the
-/// rendered prompt does not contain a complete `<tool_call>…</tool_call>`
-/// region for a requested replay, it is left unchanged. This guarantees that
-/// replay cannot alter semantic prompt content for templates it does not
-/// recognize.
+/// Replace matching normalized Qwen-style tool-call regions with the exact
+/// bytes the model previously emitted. The replacement is deliberately narrow:
+/// a region is replaced only when its parsed function name and arguments match
+/// the stored raw call. This ensures literal wrapper text in user or tool
+/// content remains untouched.
 fn replay_tool_call_text(mut rendered: String, messages: &[ChatMessage]) -> String {
     const OPEN: &str = "<tool_call>";
     const CLOSE: &str = "</tool_call>";
@@ -206,29 +205,68 @@ fn replay_tool_call_text(mut rendered: String, messages: &[ChatMessage]) -> Stri
     for message in messages {
         let call_count = message.tool_calls.as_ref().map_or(0, Vec::len);
         for call_index in 0..call_count {
-            let Some(start_relative) = rendered.get(search_from..).and_then(|s| s.find(OPEN))
-            else {
-                return rendered;
-            };
-            let start = search_from + start_relative;
-            let Some(end_relative) = rendered.get(start..).and_then(|s| s.find(CLOSE)) else {
-                return rendered;
-            };
-            let end = start + end_relative + CLOSE.len();
             let replay_text = message
                 .raw_tool_call_text
                 .as_ref()
                 .and_then(|calls| calls.get(call_index))
                 .and_then(Option::as_deref);
-            if let Some(raw) = replay_text {
-                rendered.replace_range(start..end, raw);
-                search_from = start.saturating_add(raw.len());
-            } else {
-                search_from = end;
+            let Some(raw) = replay_text else {
+                continue;
+            };
+            let Some(raw_identity) = tool_call_identity(raw) else {
+                continue;
+            };
+
+            let mut candidate_from = search_from;
+            while let Some((start, end)) =
+                find_tool_call_region(&rendered, candidate_from, OPEN, CLOSE)
+            {
+                if tool_call_identity(&rendered[start..end]) == Some(raw_identity.clone()) {
+                    rendered.replace_range(start..end, raw);
+                    search_from = start.saturating_add(raw.len());
+                    break;
+                }
+                candidate_from = end;
             }
         }
     }
     rendered
+}
+
+fn find_tool_call_region(
+    rendered: &str,
+    search_from: usize,
+    open: &str,
+    close: &str,
+) -> Option<(usize, usize)> {
+    let start_relative = rendered.get(search_from..)?.find(open)?;
+    let start = search_from + start_relative;
+    let end_relative = rendered.get(start..)?.find(close)?;
+    Some((start, start + end_relative + close.len()))
+}
+
+fn tool_call_identity(wrapper: &str) -> Option<(String, serde_json::Value)> {
+    let json = wrapper
+        .strip_prefix("<tool_call>")?
+        .strip_suffix("</tool_call>")?
+        .trim();
+    let call: serde_json::Value = serde_json::from_str(json).ok()?;
+    let object = call.as_object()?;
+    let function_object = object
+        .get("function")
+        .and_then(serde_json::Value::as_object);
+    let name = object
+        .get("name")
+        .or_else(|| function_object.and_then(|function| function.get("name")))
+        .and_then(serde_json::Value::as_str)?;
+    let argument_value = object
+        .get("arguments")
+        .or_else(|| function_object.and_then(|function| function.get("arguments")))?;
+    let parsed_arguments = match argument_value.as_str() {
+        Some(argument_text) => serde_json::from_str(argument_text).ok()?,
+        None => argument_value.clone(),
+    };
+    Some((name.to_owned(), parsed_arguments))
 }
 
 /// Normalise a tool-call JSON object so Qwen-Hermes-style chat templates
@@ -588,6 +626,35 @@ TOOLS:{{ tools | length }}
             renderer.apply(&messages, None, false).unwrap(),
             "assistant: <tool_call>\n{\"arguments\":{\"city\":\"Denver\"},\"name\":\"weather\"}\n</tool_call>"
         );
+    }
+
+    #[test]
+    fn replay_skips_user_tool_call_text_until_it_finds_the_matching_call() {
+        let template = "{% for message in messages %}{{ message.role }}: {{ message.content }}{% for tool_call in message.tool_calls %}<tool_call>{{ tool_call | tojson }}</tool_call>{% endfor %}\n{% endfor %}";
+        let renderer = ChatTemplateRenderer::new(template).unwrap();
+        let decoy = r#"<tool_call>{"name": "decoy", "arguments": {"value": 1}}</tool_call>"#;
+        let raw =
+            r#"<tool_call>{"name": "weather", "arguments": { "city": "Denver" }}</tool_call>"#;
+        let messages = vec![
+            msg("user", &format!("Please do not run this example: {decoy}")),
+            ChatMessage {
+                role: "assistant".to_owned(),
+                content: String::new(),
+                tool_calls: Some(vec![serde_json::json!({
+                    "name": "weather",
+                    "arguments": {"city": "Denver"}
+                })]),
+                raw_tool_call_text: Some(vec![Some(raw.to_owned())]),
+            },
+        ];
+
+        let result = renderer.apply(&messages, None, false).unwrap();
+
+        assert!(result.contains(decoy));
+        assert!(result.contains(raw));
+        assert!(!result.contains(
+            r#"<tool_call>{"arguments":{"city":"Denver"},"name":"weather"}</tool_call>"#
+        ));
     }
 
     #[test]

--- a/crates/higgs-engine/src/simple.rs
+++ b/crates/higgs-engine/src/simple.rs
@@ -352,6 +352,7 @@ impl SimpleEngine {
                     role: "user".to_owned(),
                     content: "x".to_owned(),
                     tool_calls: None,
+                    raw_tool_call_text: None,
                 }];
                 let with_gen = tmpl
                     .apply_with_thinking(&test_msg, None, true, enable_thinking)

--- a/crates/higgs-engine/src/tool_parser.rs
+++ b/crates/higgs-engine/src/tool_parser.rs
@@ -33,6 +33,8 @@
 pub struct ParsedToolCall {
     pub name: String,
     pub arguments: serde_json::Value,
+    /// Exact model-emitted call text, including its wrapper tags.
+    pub raw_text: String,
 }
 
 /// Result of parsing model output for tool calls.
@@ -88,7 +90,8 @@ pub fn parse_tool_calls(text: &str, schema: Option<&ToolSchema>) -> ToolParseRes
                 let raw_block = after_open.get(..end_pos).unwrap_or_default();
                 let call_content = raw_block.trim();
 
-                if let Some(parsed) = parse_tool_call_block(call_content, schema) {
+                if let Some(mut parsed) = parse_tool_call_block(call_content, schema) {
+                    parsed.raw_text = format!("{TOOL_CALL_OPEN}{raw_block}{TOOL_CALL_CLOSE}");
                     tool_calls.push(parsed);
                 } else {
                     result_text.push_str(TOOL_CALL_OPEN);
@@ -127,7 +130,11 @@ fn try_parse_tool_call(content: &str) -> Option<ParsedToolCall> {
         .cloned()
         .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new()));
 
-    Some(ParsedToolCall { name, arguments })
+    Some(ParsedToolCall {
+        name,
+        arguments,
+        raw_text: String::new(),
+    })
 }
 
 const FUNCTION_OPEN: &str = "<function=";
@@ -337,6 +344,7 @@ fn parse_xml_tool_call(content: &str, schema: Option<&ToolSchema>) -> Option<Par
     Some(ParsedToolCall {
         name,
         arguments: serde_json::Value::Object(map),
+        raw_text: String::new(),
     })
 }
 
@@ -450,6 +458,7 @@ fn parse_minicpm_function(block: &str, schema: Option<&ToolSchema>) -> Option<Pa
     Some(ParsedToolCall {
         name,
         arguments: serde_json::Value::Object(map),
+        raw_text: String::new(),
     })
 }
 
@@ -475,7 +484,8 @@ fn parse_minicpm_tool_calls(text: &str, schema: Option<&ToolSchema>) -> ToolPars
         };
 
         let block = block_region.get(..end).unwrap_or_default();
-        if let Some(parsed) = parse_minicpm_function(block, schema) {
+        if let Some(mut parsed) = parse_minicpm_function(block, schema) {
+            parsed.raw_text = format!("{block}{FUNCTION_CLOSE}");
             tool_calls.push(parsed);
         } else {
             result_text.push_str(block);
@@ -642,9 +652,11 @@ impl StreamingToolCallTracker {
                     if let Some(end) = self.buffer.find(TOOL_CALL_CLOSE) {
                         let raw_block = self.buffer.get(..end).unwrap_or_default();
                         let call_content = raw_block.trim();
-                        if let Some(parsed) =
+                        if let Some(mut parsed) =
                             parse_tool_call_block(call_content, self.schema.as_ref())
                         {
+                            parsed.raw_text =
+                                format!("{TOOL_CALL_OPEN}{raw_block}{TOOL_CALL_CLOSE}");
                             out.new_tool_calls.push(parsed);
                             self.completed_count += 1;
                         } else {
@@ -677,7 +689,10 @@ impl StreamingToolCallTracker {
                     // CDATA-aware `</function>`.
                     if let Some(end) = minicpm_function_end(&self.buffer) {
                         let block = self.buffer.get(..end).unwrap_or_default();
-                        if let Some(parsed) = parse_minicpm_function(block, self.schema.as_ref()) {
+                        if let Some(mut parsed) =
+                            parse_minicpm_function(block, self.schema.as_ref())
+                        {
+                            parsed.raw_text = format!("{block}{FUNCTION_CLOSE}");
                             out.new_tool_calls.push(parsed);
                             self.completed_count += 1;
                         } else {
@@ -743,6 +758,22 @@ impl StreamingToolCallTracker {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parsed_tool_calls_keep_exact_wrapped_spans() {
+        let text = "before<tool_call>\n{\"name\":\"first\", \"arguments\": {\"b\":2,\"a\":1}}\n</tool_call>middle<tool_call>{\"name\":\"second\",\"arguments\":{}}</tool_call>after";
+        let result = parse_tool_calls(text, None);
+
+        assert_eq!(result.tool_calls.len(), 2);
+        assert_eq!(
+            result.tool_calls[0].raw_text,
+            "<tool_call>\n{\"name\":\"first\", \"arguments\": {\"b\":2,\"a\":1}}\n</tool_call>"
+        );
+        assert_eq!(
+            result.tool_calls[1].raw_text,
+            "<tool_call>{\"name\":\"second\",\"arguments\":{}}</tool_call>"
+        );
+    }
 
     /// Parse input and assert expected tool call count and optional text fragment.
     fn assert_parse(

--- a/crates/higgs/src/anthropic_adapter.rs
+++ b/crates/higgs/src/anthropic_adapter.rs
@@ -22,6 +22,7 @@ pub fn anthropic_messages_to_engine(
             role: "system".to_owned(),
             content: sys.to_text(),
             tool_calls: None,
+            raw_tool_call_text: None,
         });
     }
 
@@ -51,6 +52,7 @@ pub fn anthropic_messages_to_engine(
             role: msg.role.clone(),
             content,
             tool_calls: None,
+            raw_tool_call_text: None,
         });
     }
 

--- a/crates/higgs/src/auto_router.rs
+++ b/crates/higgs/src/auto_router.rs
@@ -115,6 +115,7 @@ pub fn classify_local(
         role: "user".to_owned(),
         content: prompt,
         tool_calls: None,
+        raw_tool_call_text: None,
     }];
 
     let prompt_tokens = match engine.prepare_chat_prompt(&chat_messages, None) {

--- a/crates/higgs/src/lib.rs
+++ b/crates/higgs/src/lib.rs
@@ -17,6 +17,7 @@ pub mod routes;
 #[doc(hidden)]
 pub mod sse;
 pub mod state;
+pub mod tool_replay;
 pub mod translate;
 pub mod tui;
 pub mod types;

--- a/crates/higgs/src/main.rs
+++ b/crates/higgs/src/main.rs
@@ -220,6 +220,7 @@ async fn cmd_serve(cli: &Cli, args: &ServeArgs) -> Result<(), Box<dyn std::error
         config: higgs_config,
         http_client,
         metrics,
+        tool_replay: higgs::tool_replay::ToolReplayRegistry::from_env(),
     });
 
     // Build router with middleware

--- a/crates/higgs/src/routes/chat.rs
+++ b/crates/higgs/src/routes/chat.rs
@@ -266,7 +266,7 @@ async fn chat_completions_non_streaming(
         inject_image_placeholders(&req.messages)
     };
 
-    let messages = convert_messages(&effective_messages);
+    let messages = convert_messages(&effective_messages, &state.tool_replay, &req.model);
     // Treat an empty `tools: []` as absent (mirrors the streaming path) so it
     // doesn't define `tools` in the template context or trigger tool parsing.
     let tools = req.tools.as_deref().filter(|t| !t.is_empty());
@@ -372,6 +372,11 @@ async fn chat_completions_non_streaming(
                     },
                 })
                 .collect();
+            for (call, parsed_call) in calls.iter().zip(&parsed.tool_calls) {
+                state
+                    .tool_replay
+                    .insert(&req.model, call.id.clone(), parsed_call);
+            }
             let text = if parsed.text.is_empty() {
                 None
             } else {
@@ -448,7 +453,7 @@ fn chat_completions_stream(
         inject_image_placeholders(&req.messages)
     };
 
-    let messages = convert_messages(&effective_messages);
+    let messages = convert_messages(&effective_messages, &state.tool_replay, &req.model);
     let thinking_enabled_stream = crate::reasoning::effective_thinking_enabled(
         engine.enable_thinking(),
         &[engine.model_name(), req.model.as_str()],
@@ -570,10 +575,12 @@ fn chat_completions_stream(
         // Closure that turns a `ParsedToolCall` into the OpenAI streaming
         // delta shape. Index is the running zero-based position of the
         // call in this response.
-        let make_tool_delta = |index: u32, parsed: &higgs_engine::tool_parser::ParsedToolCall| {
+        let make_tool_delta = |index: u32,
+                               id: String,
+                               parsed: &higgs_engine::tool_parser::ParsedToolCall| {
             ToolCallDelta {
                 index,
-                id: Some(format!("call_{index}_{}", uuid::Uuid::new_v4())),
+                id: Some(id),
                 r#type: Some("function".to_owned()),
                 function: Some(ToolCallFunctionDelta {
                     name: Some(parsed.name.clone()),
@@ -632,11 +639,13 @@ fn chat_completions_stream(
             for (i, parsed) in tool_out.new_tool_calls.iter().enumerate() {
                 #[allow(clippy::cast_possible_truncation)]
                 let idx = u32::try_from(base_index + i).unwrap_or(u32::MAX);
+                let id = format!("call_{idx}_{}", uuid::Uuid::new_v4());
+                state.tool_replay.insert(&model, id.clone(), parsed);
                 let d = ChatCompletionDelta {
                     role: None,
                     content: None,
                     reasoning_content: None,
-                    tool_calls: Some(vec![make_tool_delta(idx, parsed)]),
+                    tool_calls: Some(vec![make_tool_delta(idx, id, parsed)]),
                 };
                 emit_delta!(&d, None, None);
             }
@@ -678,11 +687,13 @@ fn chat_completions_stream(
         for (i, parsed) in flush_tool_out.new_tool_calls.iter().enumerate() {
             #[allow(clippy::cast_possible_truncation)]
             let idx = u32::try_from(flush_base_index + i).unwrap_or(u32::MAX);
+            let id = format!("call_{idx}_{}", uuid::Uuid::new_v4());
+            state.tool_replay.insert(&model, id.clone(), parsed);
             let d = ChatCompletionDelta {
                 role: None,
                 content: None,
                 reasoning_content: None,
-                tool_calls: Some(vec![make_tool_delta(idx, parsed)]),
+                tool_calls: Some(vec![make_tool_delta(idx, id, parsed)]),
             };
             emit_delta!(&d, None, None);
         }
@@ -751,6 +762,8 @@ fn chat_completions_stream(
 
 fn convert_messages(
     messages: &[ChatCompletionMessage],
+    replay: &crate::tool_replay::ToolReplayRegistry,
+    model: &str,
 ) -> Vec<higgs_engine::chat_template::ChatMessage> {
     messages
         .iter()
@@ -772,6 +785,16 @@ fn convert_messages(
                     })
                     .collect()
             });
+            let raw_tool_call_text = m.tool_calls.as_ref().and_then(|calls| {
+                let raw_calls: Vec<_> = calls
+                    .iter()
+                    .map(|call| {
+                        let arguments = serde_json::from_str(&call.function.arguments).ok()?;
+                        replay.matching_raw(model, &call.id, &call.function.name, &arguments)
+                    })
+                    .collect();
+                raw_calls.iter().any(Option::is_some).then_some(raw_calls)
+            });
             let content = m
                 .content
                 .as_ref()
@@ -780,6 +803,7 @@ fn convert_messages(
                 role: m.role.clone(),
                 content,
                 tool_calls: tool_calls_json,
+                raw_tool_call_text,
             }
         })
         .collect()
@@ -976,13 +1000,18 @@ mod tests {
         }
     }
 
+    fn replay_registry() -> crate::tool_replay::ToolReplayRegistry {
+        crate::tool_replay::ToolReplayRegistry::new(16)
+    }
+
     #[test]
     fn test_convert_messages() {
         let msgs = vec![
             simple_message("user", Some("Hello")),
             simple_message("assistant", None),
         ];
-        let converted = convert_messages(&msgs);
+        let replay = replay_registry();
+        let converted = convert_messages(&msgs, &replay, "test");
         assert_eq!(converted.len(), 2);
         assert_eq!(converted.first().map(|m| m.role.as_str()), Some("user"));
         assert_eq!(converted.first().map(|m| m.content.as_str()), Some("Hello"));
@@ -1002,7 +1031,8 @@ mod tests {
             "assistant",
             vec![tool_call("call_1", "get_weather", r#"{"city":"NYC"}"#)],
         )];
-        let converted = convert_messages(&msgs);
+        let replay = replay_registry();
+        let converted = convert_messages(&msgs, &replay, "test");
         assert_eq!(converted.len(), 1);
         let calls = converted
             .first()
@@ -1013,14 +1043,16 @@ mod tests {
 
     #[test]
     fn test_convert_messages_empty_list() {
-        let result = convert_messages(&[]);
+        let replay = replay_registry();
+        let result = convert_messages(&[], &replay, "test");
         assert!(result.is_empty());
     }
 
     #[test]
     fn test_convert_messages_with_null_content() {
         let msgs = vec![simple_message("assistant", None)];
-        let converted = convert_messages(&msgs);
+        let replay = replay_registry();
+        let converted = convert_messages(&msgs, &replay, "test");
         assert_eq!(converted.len(), 1);
         assert_eq!(converted.first().map(|m| m.content.as_str()), Some(""));
     }
@@ -1038,13 +1070,60 @@ mod tests {
                 tool_call("call_2", "calculate", r#"{"expression":"2+2"}"#),
             ],
         )];
-        let converted = convert_messages(&msgs);
+        let replay = replay_registry();
+        let converted = convert_messages(&msgs, &replay, "test");
         assert_eq!(converted.len(), 1);
         let calls = converted
             .first()
             .and_then(|m| m.tool_calls.as_ref())
             .unwrap();
         assert_eq!(calls.len(), 2);
+    }
+
+    #[test]
+    fn replays_matching_tool_call_and_rejects_different_arguments() {
+        let replay = replay_registry();
+        replay.insert(
+            "test",
+            "call_1".to_owned(),
+            &higgs_engine::tool_parser::ParsedToolCall {
+                name: "get_weather".to_owned(),
+                arguments: serde_json::json!({"city": "Denver", "units": "c"}),
+                raw_text: "<tool_call>\n{\"name\": \"get_weather\", \"arguments\": {\"units\": \"c\", \"city\": \"Denver\"}}\n</tool_call>".to_owned(),
+            },
+        );
+        let matching = vec![tool_message(
+            "assistant",
+            vec![tool_call(
+                "call_1",
+                "get_weather",
+                r#"{"city":"Denver","units":"c"}"#,
+            )],
+        )];
+        assert!(
+            convert_messages(&matching, &replay, "test")
+                .first()
+                .unwrap()
+                .raw_tool_call_text
+                .is_some()
+        );
+
+        let different = vec![tool_message(
+            "assistant",
+            vec![tool_call(
+                "call_1",
+                "get_weather",
+                r#"{"city":"Boulder","units":"c"}"#,
+            )],
+        )];
+        assert!(
+            convert_messages(&different, &replay, "test")
+                .first()
+                .unwrap()
+                .raw_tool_call_text
+                .is_none()
+        );
+        assert_eq!(replay.counters(), (1, 1));
     }
 
     #[test]

--- a/crates/higgs/src/routes/metrics.rs
+++ b/crates/higgs/src/routes/metrics.rs
@@ -14,6 +14,9 @@ pub struct MetricsResponse {
     pub tokens_per_minute: Vec<u64>,
     pub models: Vec<MetricsGroup>,
     pub providers: Vec<MetricsGroup>,
+    /// Exact tool-call replay cache outcomes across local models.
+    pub tool_replay_hits: u64,
+    pub tool_replay_misses: u64,
 }
 
 #[derive(Debug, Serialize)]
@@ -41,10 +44,13 @@ pub async fn metrics(
     let Some(metrics) = state.metrics.as_ref() else {
         return Err(StatusCode::SERVICE_UNAVAILABLE);
     };
-    Ok(Json(build_metrics_response(metrics)))
+    Ok(Json(build_metrics_response(metrics, &state.tool_replay)))
 }
 
-fn build_metrics_response(metrics: &MetricsStore) -> MetricsResponse {
+fn build_metrics_response(
+    metrics: &MetricsStore,
+    replay: &crate::tool_replay::ToolReplayRegistry,
+) -> MetricsResponse {
     let snapshot = metrics.snapshot();
     let input_tokens: u64 = snapshot.iter().map(|r| r.input_tokens).sum();
     let output_tokens: u64 = snapshot.iter().map(|r| r.output_tokens).sum();
@@ -64,6 +70,8 @@ fn build_metrics_response(metrics: &MetricsStore) -> MetricsResponse {
         tokens_per_minute: MetricsStore::tokens_per_minute(&snapshot, num_buckets),
         models: build_groups(MetricsStore::group_by(&snapshot, |r| r.model.clone())),
         providers: build_groups(MetricsStore::group_by(&snapshot, |r| r.provider.clone())),
+        tool_replay_hits: replay.counters().0,
+        tool_replay_misses: replay.counters().1,
     }
 }
 
@@ -134,7 +142,8 @@ mod tests {
         metrics.record(sample_record("model-a", "higgs", 500));
         metrics.record(sample_record("model-b", "openai", 200));
 
-        let response = build_metrics_response(&metrics);
+        let replay = crate::tool_replay::ToolReplayRegistry::new(16);
+        let response = build_metrics_response(&metrics, &replay);
         assert_eq!(response.totals.requests, 3);
         assert_eq!(response.totals.input_tokens, 30);
         assert_eq!(response.totals.output_tokens, 60);

--- a/crates/higgs/src/state.rs
+++ b/crates/higgs/src/state.rs
@@ -313,6 +313,8 @@ pub struct AppState {
     pub http_client: reqwest::Client,
     /// Request metrics (present in config mode, absent in simple mode).
     pub metrics: Option<Arc<MetricsStore>>,
+    /// Per-model exact tool-call serialization replay state.
+    pub tool_replay: crate::tool_replay::ToolReplayRegistry,
 }
 
 /// Type alias for the shared state used by Axum handlers.

--- a/crates/higgs/src/tool_replay.rs
+++ b/crates/higgs/src/tool_replay.rs
@@ -1,0 +1,189 @@
+//! Exact tool-call replay for preserving prompt-prefix cache identity.
+//!
+//! Clients return normalized `OpenAI` tool calls, while models often generated a
+//! differently formatted JSON payload. A replay entry is used only after the
+//! name and parsed JSON arguments match, so this module never changes the
+//! semantic content presented to the model; it restores only that model's own
+//! serialization.
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use higgs_engine::tool_parser::ParsedToolCall;
+
+const DEFAULT_CAPACITY: usize = 256;
+const MAX_ENTRY_BYTES: usize = 16 * 1024;
+
+#[derive(Debug, Clone)]
+struct ReplayEntry {
+    name: String,
+    arguments: serde_json::Value,
+    raw_text: String,
+}
+
+/// FIFO-bounded cache of raw model output, scoped to one model.
+#[derive(Debug)]
+pub struct ToolReplayStore {
+    capacity: usize,
+    entries: HashMap<String, ReplayEntry>,
+    order: VecDeque<String>,
+}
+
+impl ToolReplayStore {
+    #[must_use]
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            capacity,
+            entries: HashMap::new(),
+            order: VecDeque::new(),
+        }
+    }
+
+    pub fn insert(&mut self, id: String, call: &ParsedToolCall) {
+        if self.capacity == 0 || call.raw_text.len() > MAX_ENTRY_BYTES {
+            return;
+        }
+        if self.entries.remove(&id).is_some() {
+            self.order.retain(|existing| existing != &id);
+        }
+        while self.entries.len() >= self.capacity {
+            if let Some(oldest) = self.order.pop_front() {
+                self.entries.remove(&oldest);
+            } else {
+                break;
+            }
+        }
+        self.order.push_back(id.clone());
+        self.entries.insert(
+            id,
+            ReplayEntry {
+                name: call.name.clone(),
+                arguments: call.arguments.clone(),
+                raw_text: call.raw_text.clone(),
+            },
+        );
+    }
+
+    fn matching_raw(&self, id: &str, name: &str, arguments: &serde_json::Value) -> Option<String> {
+        let entry = self.entries.get(id)?;
+        (entry.name == name && entry.arguments == *arguments).then(|| entry.raw_text.clone())
+    }
+}
+
+/// Thread-safe per-model stores plus replay hit/miss counters.
+#[derive(Debug)]
+pub struct ToolReplayRegistry {
+    capacity: usize,
+    stores: Mutex<HashMap<String, ToolReplayStore>>,
+    hits: AtomicU64,
+    misses: AtomicU64,
+}
+
+impl ToolReplayRegistry {
+    #[must_use]
+    pub fn from_env() -> Self {
+        let capacity = std::env::var("HIGGS_TOOL_REPLAY_CAPACITY")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .unwrap_or(DEFAULT_CAPACITY);
+        Self::new(capacity)
+    }
+
+    #[must_use]
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            capacity,
+            stores: Mutex::new(HashMap::new()),
+            hits: AtomicU64::new(0),
+            misses: AtomicU64::new(0),
+        }
+    }
+
+    pub fn insert(&self, model: &str, id: String, call: &ParsedToolCall) {
+        self.stores
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .entry(model.to_owned())
+            .or_insert_with(|| ToolReplayStore::new(self.capacity))
+            .insert(id, call);
+    }
+
+    /// Return replay text only when the normalized client call is semantically
+    /// identical to the captured model call.
+    pub fn matching_raw(
+        &self,
+        model: &str,
+        id: &str,
+        name: &str,
+        arguments: &serde_json::Value,
+    ) -> Option<String> {
+        let found = self
+            .stores
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(model)
+            .and_then(|store| store.matching_raw(id, name, arguments));
+        if found.is_some() {
+            self.hits.fetch_add(1, Ordering::Relaxed);
+        } else {
+            self.misses.fetch_add(1, Ordering::Relaxed);
+        }
+        found
+    }
+
+    #[must_use]
+    pub fn counters(&self) -> (u64, u64) {
+        (
+            self.hits.load(Ordering::Relaxed),
+            self.misses.load(Ordering::Relaxed),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn call(raw_text: &str) -> ParsedToolCall {
+        ParsedToolCall {
+            name: "weather".to_owned(),
+            arguments: serde_json::json!({"city": "Denver"}),
+            raw_text: raw_text.to_owned(),
+        }
+    }
+
+    #[test]
+    fn evicts_oldest_and_skips_oversized_entries() {
+        let mut store = ToolReplayStore::new(1);
+        store.insert("first".to_owned(), &call("one"));
+        store.insert("second".to_owned(), &call("two"));
+        assert!(
+            store
+                .matching_raw("first", "weather", &serde_json::json!({"city":"Denver"}))
+                .is_none()
+        );
+        assert_eq!(
+            store.matching_raw("second", "weather", &serde_json::json!({"city":"Denver"})),
+            Some("two".to_owned())
+        );
+
+        store.insert("large".to_owned(), &call(&"x".repeat(MAX_ENTRY_BYTES + 1)));
+        assert!(
+            store
+                .matching_raw("large", "weather", &serde_json::json!({"city":"Denver"}))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn zero_capacity_disables_storage() {
+        let mut store = ToolReplayStore::new(0);
+        store.insert("call".to_owned(), &call("raw"));
+        assert!(
+            store
+                .matching_raw("call", "weather", &serde_json::json!({"city":"Denver"}))
+                .is_none()
+        );
+    }
+}

--- a/crates/higgs/tests/integration/api_contract.rs
+++ b/crates/higgs/tests/integration/api_contract.rs
@@ -48,6 +48,7 @@ fn build_test_state(metrics: Option<Arc<MetricsStore>>) -> Arc<AppState> {
         config,
         http_client: reqwest::Client::new(),
         metrics,
+        tool_replay: higgs::tool_replay::ToolReplayRegistry::new(16),
     })
 }
 

--- a/crates/higgs/tests/integration/proxy_e2e.rs
+++ b/crates/higgs/tests/integration/proxy_e2e.rs
@@ -64,6 +64,7 @@ fn build_test_state(mock_url: &str, format: ApiFormat) -> Arc<AppState> {
         config,
         http_client: reqwest::Client::new(),
         metrics: Some(metrics),
+        tool_replay: higgs::tool_replay::ToolReplayRegistry::new(16),
     })
 }
 
@@ -214,6 +215,7 @@ async fn proxy_model_rewrite() {
         config,
         http_client: reqwest::Client::new(),
         metrics: Some(metrics),
+        tool_replay: higgs::tool_replay::ToolReplayRegistry::new(16),
     });
     let app = build_app(state);
 

--- a/validation/pr5-replay/report.md
+++ b/validation/pr5-replay/report.md
@@ -1,0 +1,51 @@
+# Validation report: pr5-replay (exact tool-call replay) — NEGATIVE RESULT
+
+- chip: Apple M4 Max
+- ram_gb: 128
+- macos_version: 26.5.1
+- branch: claude/ds4-p5-toolcall-replay
+- model: mlx-community/Qwen3-1.7B-4bit
+
+## Pre-registered acceptance criteria
+1. Re-render prefix breaks ~0 on a scripted multi-turn tool session.
+2. Turn-2+ TTFT improvement demonstrated.
+3. Final outputs token-identical.
+
+## Mechanism verification (works as designed)
+- End-to-end engagement confirmed: tool_replay_hits=3, misses=0 on a metrics-enabled server run.
+- Byte-identical re-render of the model's original tool-call serialization: unit-tested, including a
+  decoy-region guard (literal <tool_call> in user content is never touched; semantic identity of the
+  region is verified before splicing).
+
+## System-level results: no measurable benefit
+Scripted 2-turn tool sessions (greedy), long shared system prompt, baseline (main) vs candidate:
+
+| Scenario | Baseline median turn-2 TTFT | Candidate | Delta |
+| --- | ---: | ---: | ---: |
+| Small tool call (weather), thinking on, 8 sessions | 57.5 ms | 57.5 ms | ~0 |
+| Large payload (save_document ~300-400 words), thinking on, 6 sessions | 121.0 ms | 102.6 ms | within run noise (spreads overlap) |
+
+Debug-level prefix-cache traces show WHY, three structural reasons in higgs's serving path:
+1. Thinking models: turn-1 generation includes reasoning tokens that are cached but stripped from the
+   re-rendered turn-2 prompt, so the token divergence occurs BEFORE the tool call. Replaying the
+   tool-call bytes cannot extend the prefix past a divergence that precedes it. (Traces: identical
+   prefix_len=1024 hits on both sides in the large-payload scenario.)
+2. The paged prefix cache reuses 64-token blocks; a sub-block extension from replay is invisible.
+   (Traces: both sides hit prefix_len=2176 with the cached sequence ending at ~2234 < the 2240
+   boundary.)
+3. Typical tool calls (~30-60 tokens) span at most one block.
+The remaining beneficiary — multi-block tool payloads with thinking disabled — could not be
+demonstrated: with thinking off, Qwen3-1.7B stopped producing tool calls for document-sized payloads
+(0/12 sessions).
+
+Criterion 1: not achieved in the thinking-on configuration users actually run (divergence precedes
+the call). Criterion 2: FAIL — no demonstrated improvement. Criterion 3: 6/8 sessions byte-identical;
+the 2 diffs stem from replay intentionally restoring the model's original serialization (different
+prompt bytes than the normalized baseline), a semantic-neutral but not byte-neutral change — noted as
+a caveat rather than a pass.
+
+## Verdict: FAIL — do not merge
+The implementation is correct and guarded, but in higgs's current architecture the optimization has
+no measurable effect. Preconditions for revisiting: (a) reasoning-aware prefix caching (cache keyed on
+the re-render form), (b) sub-block prefix reuse, or (c) agentic workloads with multi-block tool
+payloads on non-thinking models. Negative result to be recorded in docs/ds4-analysis-2026-08.md.


### PR DESCRIPTION
Part of the ds4 -> higgs adoption program. Records a negative result with evidence; pre-registered acceptance failed; recommendation: CLOSE without merging.

## Claim tested
ds4 P5: remembering the exact bytes the model emitted for each tool call and splicing them back at prompt render time preserves prefix-cache continuity across tool turns, improving turn-2+ TTFT.

## What was built (works as designed)
Codex CLI (gpt-5.6-terra medium) implemented, Claude-reviewed: capture of exact wrapped spans in tool_parser, bounded per-model replay registry (`HIGGS_TOOL_REPLAY_CAPACITY`, 16 KiB entry cap), semantic-identity-guarded splicing at render (a review round added a decoy-region guard: literal `<tool_call>` in user content can never be overwritten), `tool_replay_hits/misses` metrics. End-to-end engagement verified on hardware (3 hits / 0 misses). All CI gates green.

## Why it fails acceptance (validation/pr5-replay/report.md)
Measured turn-2 TTFT deltas are ~0. Debug traces of the paged prefix cache identify three structural reasons: (1) on thinking models, cached turn-1 reasoning tokens are stripped from the turn-2 re-render, so divergence precedes the tool call — replay cannot help; (2) prefix reuse is quantized to 64-token blocks, hiding sub-block extensions; (3) typical tool calls span at most one block. The one scenario that could benefit (multi-block payloads, thinking off) could not be demonstrated because the test model stops emitting tool calls in that configuration.

## Program disposition
Negative result to be recorded in docs/ds4-analysis-2026-08.md. Revisit preconditions listed in the report (reasoning-aware prefix caching, sub-block reuse, or agentic multi-block payload workloads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)