### PR TITLE
feat(config): first-class config surface for the MLA latent KV cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ benchmarks/*.txt
 benchmarks/*.safetensors
 benchmarks/*.py
 validation/**/raw/
+validation/**/raw/

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,3 @@ benchmarks/*.txt
 benchmarks/*.safetensors
 benchmarks/*.py
 validation/**/raw/
-validation/**/raw/

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Run open-weight MLX models locally on Apple Silicon, route requests across local
 
 For a local model, set `kv_disk_dir` in its `[[models]]` entry to retain block-aligned prefix KV state across restarts. `kv_disk_space_mb` controls its on-disk LRU budget (default `4096`, minimum `64`). The disk tier is model, quantization, configuration, tokenizer, and chat-template bound; incompatible entries are ignored.
 
+For DeepSeek-V2 models, set `mla_latent_cache = true` in its `[[models]]` entry to store the MLA KV cache as compressed latent rows instead of dense per-head tensors (default off). It cannot be combined with `kv_cache = "turboquant"`, and is a no-op for non-DeepSeek-V2 architectures. The `HIGGS_MLA_LATENT_CACHE` env var, when set to a recognized value (`1`/`0`, `true`/`false`, `on`/`off`, `yes`/`no`), overrides the config value either way.
+
 Higgs is a single static Rust binary that serves local models, proxies to providers like OpenAI, Anthropic, and Ollama, and translates between OpenAI and Anthropic-style APIs so your existing tools and apps do not need a new integration.
 
 **Why care**

--- a/crates/higgs-models/src/cache.rs
+++ b/crates/higgs-models/src/cache.rs
@@ -31,10 +31,39 @@ fn parse_mla_latent_cache_enabled(raw: Option<&str>) -> bool {
 }
 
 /// Whether `DeepSeek` MLA caches should store compressed latent rows.
+///
+/// Env-only decision used by the standalone lazy-init cache path
+/// ([`crate::deepseek_v2::DeepSeekV2::make_cache`] and the cache-recreation
+/// branch of `forward_hidden`), which has no `KvCacheConfig` to consult. The
+/// config-aware path is [`resolve_mla_latent_cache`].
 pub fn mla_latent_cache_enabled() -> bool {
     *MLA_LATENT_CACHE_ENABLED.get_or_init(|| {
         parse_mla_latent_cache_enabled(std::env::var("HIGGS_MLA_LATENT_CACHE").ok().as_deref())
     })
+}
+
+fn parse_mla_latent_cache_override(raw: Option<&str>) -> Option<bool> {
+    match raw.map(str::trim).map(str::to_ascii_lowercase).as_deref() {
+        Some("1" | "true" | "on" | "yes") => Some(true),
+        Some("0" | "false" | "off" | "no") => Some(false),
+        _ => None,
+    }
+}
+
+/// Resolve the effective MLA latent-cache decision for engine-managed caches
+/// built from a [`KvCacheConfig`].
+///
+/// Precedence: `HIGGS_MLA_LATENT_CACHE`, when set to a recognized value,
+/// always wins (forcing latent caching on or off); otherwise
+/// `config_enabled` (typically `KvCacheConfig::mla_latent`, derived from
+/// `ModelConfig::mla_latent_cache`) decides; if neither is set, latent
+/// caching stays off.
+///
+/// Unlike [`mla_latent_cache_enabled`], this re-reads the env var on every
+/// call rather than caching it, since the config value can differ per model.
+pub fn resolve_mla_latent_cache(config_enabled: bool) -> bool {
+    parse_mla_latent_cache_override(std::env::var("HIGGS_MLA_LATENT_CACHE").ok().as_deref())
+        .unwrap_or(config_enabled)
 }
 
 fn parse_turboquant_activate_at(raw: Option<&str>) -> i32 {
@@ -1838,6 +1867,45 @@ mod tests {
         assert!(parse_mla_latent_cache_enabled(Some("TRUE")));
         assert!(!parse_mla_latent_cache_enabled(Some("no")));
         assert!(!parse_mla_latent_cache_enabled(Some("garbage")));
+    }
+
+    #[test]
+    fn parse_mla_latent_cache_override_recognizes_explicit_values_only() {
+        assert_eq!(parse_mla_latent_cache_override(Some("1")), Some(true));
+        assert_eq!(parse_mla_latent_cache_override(Some("true")), Some(true));
+        assert_eq!(parse_mla_latent_cache_override(Some("0")), Some(false));
+        assert_eq!(parse_mla_latent_cache_override(Some("off")), Some(false));
+        assert_eq!(parse_mla_latent_cache_override(Some("garbage")), None);
+        assert_eq!(parse_mla_latent_cache_override(None), None);
+    }
+
+    #[test]
+    #[allow(unsafe_code)]
+    fn resolve_mla_latent_cache_prefers_config_when_no_env_override() {
+        // SAFETY: test-only env mutation; higgs-models tests run single-threaded
+        // (--test-threads=1) so there is no cross-test interleaving.
+        unsafe {
+            std::env::remove_var("HIGGS_MLA_LATENT_CACHE");
+        }
+        assert!(resolve_mla_latent_cache(true));
+        assert!(!resolve_mla_latent_cache(false));
+    }
+
+    #[test]
+    #[allow(unsafe_code)]
+    fn resolve_mla_latent_cache_env_override_wins_over_config() {
+        // SAFETY: test-only env mutation; see note above.
+        unsafe {
+            std::env::set_var("HIGGS_MLA_LATENT_CACHE", "0");
+        }
+        assert!(!resolve_mla_latent_cache(true));
+        unsafe {
+            std::env::set_var("HIGGS_MLA_LATENT_CACHE", "1");
+        }
+        assert!(resolve_mla_latent_cache(false));
+        unsafe {
+            std::env::remove_var("HIGGS_MLA_LATENT_CACHE");
+        }
     }
 
     #[test]

--- a/crates/higgs-models/src/deepseek_v2.rs
+++ b/crates/higgs-models/src/deepseek_v2.rs
@@ -954,6 +954,12 @@ pub struct DeepSeekV2CausalLM {
     model: DeepSeekV2Inner,
     #[param]
     lm_head: Option<QLinear>,
+    /// MLA decision resolved by the most recent [`Self::make_cache_with_config`]
+    /// call, if any. `forward_hidden`'s lazy empty-cache re-init uses this
+    /// (when present) instead of re-deriving an env-only decision, so it stays
+    /// consistent with the caches `make_cache_with_config` actually built.
+    /// `Cell` because both methods take `&self`/build on immutable borrows.
+    last_resolved_mla: std::cell::Cell<Option<bool>>,
 }
 
 impl DeepSeekV2CausalLM {
@@ -1000,14 +1006,18 @@ impl DeepSeekV2CausalLM {
             args,
             model,
             lm_head,
+            last_resolved_mla: std::cell::Cell::new(None),
         })
     }
 
     /// Build caches using the env-only MLA decision.
     ///
-    /// This is the standalone lazy-init path: it has no `KvCacheConfig` to
-    /// consult, so it only honors `HIGGS_MLA_LATENT_CACHE`. Callers that have
-    /// a `KvCacheConfig` (e.g. the engine's `make_cache_with_config` flow)
+    /// This is the standalone path: it has no `KvCacheConfig` to consult, so
+    /// it only honors `HIGGS_MLA_LATENT_CACHE`, and it does not record a
+    /// resolved decision for `forward_hidden`'s lazy re-init to reuse — so
+    /// that re-init still falls back to the env-only decision unless
+    /// `make_cache_with_config` has run first. Callers that have a
+    /// `KvCacheConfig` (e.g. the engine's `make_cache_with_config` flow)
     /// should use [`Self::make_cache_with_config`] instead, which is
     /// authoritative for engine-managed caches.
     pub fn make_cache(&self) -> Result<Vec<Option<SteppingKeyValueCache>>, Exception> {
@@ -1036,6 +1046,7 @@ impl DeepSeekV2CausalLM {
         kv_cache_config: KvCacheConfig,
     ) -> Result<Vec<Option<SteppingKeyValueCache>>, Exception> {
         let mla_enabled = resolve_mla_latent_cache(kv_cache_config.mla_latent);
+        self.last_resolved_mla.set(Some(mla_enabled));
         (0..self.args.num_hidden_layers)
             .map(|_| {
                 if mla_enabled {
@@ -1059,17 +1070,26 @@ impl DeepSeekV2CausalLM {
         mask: Option<&Array>,
         kv_cache: &mut Vec<Option<SteppingKeyValueCache>>,
     ) -> Result<Array, Exception> {
-        let mut h = self.model.embed_tokens.forward(inputs)?;
-
-        let computed_mask = match mask {
-            Some(m) => Some(AttentionMask::Array(m.clone())),
-            None => create_attention_mask(&h, kv_cache, None)?,
-        };
-
+        // Validate/lazily populate the cache before running any layers, so a
+        // length mismatch or cache-construction error surfaces before doing
+        // (wasted) embedding/attention work. Freshly built caches all start
+        // at offset 0, matching the empty-slice fallback `create_attention_mask`
+        // below would otherwise use, so reordering this ahead of the mask
+        // computation does not change its result.
         if kv_cache.is_empty() {
+            // Prefer the decision the most recent `make_cache_with_config` call
+            // resolved, so a config-driven `mla_latent_cache=true` (with
+            // HIGGS_MLA_LATENT_CACHE unset) doesn't silently regress to dense
+            // caches here. Callers that never went through
+            // `make_cache_with_config` (e.g. tests exercising `forward_hidden`
+            // directly) fall back to the env-only decision.
+            let mla_enabled = self
+                .last_resolved_mla
+                .get()
+                .unwrap_or_else(mla_latent_cache_enabled);
             *kv_cache = (0..self.model.layers.len())
                 .map(|_| {
-                    if mla_latent_cache_enabled() {
+                    if mla_enabled {
                         SteppingKeyValueCache::new_mla(
                             self.args.kv_lora_rank,
                             self.args.qk_rope_head_dim,
@@ -1088,6 +1108,13 @@ impl DeepSeekV2CausalLM {
                 self.model.layers.len()
             )));
         }
+
+        let mut h = self.model.embed_tokens.forward(inputs)?;
+
+        let computed_mask = match mask {
+            Some(m) => Some(AttentionMask::Array(m.clone())),
+            None => create_attention_mask(&h, kv_cache, None)?,
+        };
 
         for (layer, layer_cache) in self.model.layers.iter_mut().zip(kv_cache.iter_mut()) {
             h = layer.forward(&h, computed_mask.as_ref(), layer_cache.as_mut())?;
@@ -1545,6 +1572,45 @@ mod tests {
         let input = Array::from_slice(&[1_i32], &[1, 1]);
         let result = model.forward(&input, None, &mut cache);
         assert!(result.is_err(), "mismatched cache length should error");
+    }
+
+    /// `forward_hidden`'s lazy empty-cache re-init must reuse the MLA
+    /// decision `make_cache_with_config` resolved, not silently fall back to
+    /// the env-only decision (which would build dense caches here since
+    /// `HIGGS_MLA_LATENT_CACHE` is unset).
+    #[test]
+    #[allow(unsafe_code)]
+    fn test_forward_hidden_lazy_init_reuses_resolved_mla_decision() {
+        // SAFETY: test-only env mutation; higgs-models tests run single-threaded
+        // (--test-threads=1) so there is no cross-test interleaving. Ensure the
+        // env override is unset so the config-resolved decision is exercised.
+        unsafe {
+            std::env::remove_var("HIGGS_MLA_LATENT_CACHE");
+        }
+
+        let args = small_args();
+        let mut model = DeepSeekV2CausalLM::new(args).unwrap();
+
+        let kv_cache_config = KvCacheConfig {
+            mla_latent: true,
+            ..Default::default()
+        };
+        let _ = model.make_cache_with_config(kv_cache_config).unwrap();
+
+        // The cache vec is populated before the per-layer forward pass runs,
+        // so we only need the lazy-init side effect here, not a successful
+        // forward pass (mirrors `test_forward_preserves_pre_initialized_cache`).
+        let mut cache: Vec<Option<SteppingKeyValueCache>> = Vec::new();
+        let input = Array::from_slice(&[1_i32, 2, 3], &[1, 3]);
+        let _ = model.forward_hidden(&input, None, &mut cache);
+
+        assert_eq!(cache.len(), 2);
+        for (i, maybe_cache) in cache.iter().enumerate() {
+            let layer_cache = maybe_cache
+                .as_ref()
+                .unwrap_or_else(|| panic!("layer {i} cache should be Some"));
+            assert!(layer_cache.is_mla(), "layer {i} cache should be MLA");
+        }
     }
 
     #[test]

--- a/crates/higgs-models/src/deepseek_v2.rs
+++ b/crates/higgs-models/src/deepseek_v2.rs
@@ -21,7 +21,9 @@ use mlx_rs::{
 use serde::Deserialize;
 
 use crate::{
-    cache::{KeyValueCache, SteppingKeyValueCache, mla_latent_cache_enabled},
+    cache::{
+        KeyValueCache, SteppingKeyValueCache, mla_latent_cache_enabled, resolve_mla_latent_cache,
+    },
     error::ModelError,
     qwen3_next::{
         QEmbedding, QLinear, QuantizationConfig, SwitchMlpWeights, new_mlp_projections, swiglu,
@@ -1001,6 +1003,13 @@ impl DeepSeekV2CausalLM {
         })
     }
 
+    /// Build caches using the env-only MLA decision.
+    ///
+    /// This is the standalone lazy-init path: it has no `KvCacheConfig` to
+    /// consult, so it only honors `HIGGS_MLA_LATENT_CACHE`. Callers that have
+    /// a `KvCacheConfig` (e.g. the engine's `make_cache_with_config` flow)
+    /// should use [`Self::make_cache_with_config`] instead, which is
+    /// authoritative for engine-managed caches.
     pub fn make_cache(&self) -> Result<Vec<Option<SteppingKeyValueCache>>, Exception> {
         (0..self.args.num_hidden_layers)
             .map(|_| {
@@ -1009,6 +1018,31 @@ impl DeepSeekV2CausalLM {
                         self.args.kv_lora_rank,
                         self.args.qk_rope_head_dim,
                         KvCacheConfig::default(),
+                    )
+                } else {
+                    Ok(SteppingKeyValueCache::new())
+                }
+                .map(Some)
+            })
+            .collect()
+    }
+
+    /// Build caches using `kv_cache_config.mla_latent`, with
+    /// `HIGGS_MLA_LATENT_CACHE` (when set to a recognized value) overriding
+    /// it either way. This is the authoritative path for engine-managed
+    /// caches — see [`AnyModel::make_cache_with_config`](crate::AnyModel::make_cache_with_config).
+    pub fn make_cache_with_config(
+        &self,
+        kv_cache_config: KvCacheConfig,
+    ) -> Result<Vec<Option<SteppingKeyValueCache>>, Exception> {
+        let mla_enabled = resolve_mla_latent_cache(kv_cache_config.mla_latent);
+        (0..self.args.num_hidden_layers)
+            .map(|_| {
+                if mla_enabled {
+                    SteppingKeyValueCache::new_mla(
+                        self.args.kv_lora_rank,
+                        self.args.qk_rope_head_dim,
+                        kv_cache_config,
                     )
                 } else {
                     Ok(SteppingKeyValueCache::new())

--- a/crates/higgs-models/src/lib.rs
+++ b/crates/higgs-models/src/lib.rs
@@ -833,7 +833,7 @@ impl AnyModel {
                         "TurboQuant is only supported for standard KV transformer models",
                     ));
                 }
-                Ok(AnyCache::KV(m.make_cache()?))
+                Ok(AnyCache::KV(m.make_cache_with_config(kv_cache_config)?))
             }
             Self::Qwen3Next(m) => {
                 if kv_cache_config.is_turboquant() {

--- a/crates/higgs-models/src/turboquant.rs
+++ b/crates/higgs-models/src/turboquant.rs
@@ -63,6 +63,10 @@ pub struct KvCacheConfig {
     /// historical default behavior when this field is omitted from config.
     #[serde(default)]
     pub seed: u64,
+    /// Store `DeepSeek`-V2-style MLA caches as compressed latent rows instead
+    /// of dense per-head KV tensors. Mutually exclusive with `TurboQuant`.
+    #[serde(default)]
+    pub mla_latent: bool,
 }
 
 const fn default_bits() -> u8 {
@@ -83,6 +87,7 @@ impl Default for KvCacheConfig {
             norm_correction: true,
             adaptive_dense_layers: 0,
             seed: 0,
+            mla_latent: false,
         }
     }
 }
@@ -93,6 +98,11 @@ impl KvCacheConfig {
     }
 
     pub fn validate(self) -> Result<(), Exception> {
+        if self.mla_latent && self.is_turboquant() {
+            return Err(Exception::custom(
+                "MLA latent cache cannot be combined with TurboQuant KV cache",
+            ));
+        }
         if self.is_turboquant() {
             if self.bits == 0 {
                 return Err(Exception::custom("TurboQuant bits must be >= 1, got 0"));
@@ -1650,6 +1660,30 @@ mod tests {
             ..Default::default()
         };
         assert!(asym.validate().is_ok());
+    }
+
+    #[test]
+    fn test_mla_latent_rejects_turboquant_combination() {
+        let conflicting = KvCacheConfig {
+            mode: KvCacheMode::Turboquant,
+            mla_latent: true,
+            ..Default::default()
+        };
+        let err = conflicting.validate().unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("MLA latent cache cannot be combined with TurboQuant KV cache")
+        );
+    }
+
+    #[test]
+    fn test_mla_latent_alone_is_valid() {
+        let config = KvCacheConfig {
+            mode: KvCacheMode::Off,
+            mla_latent: true,
+            ..Default::default()
+        };
+        assert!(config.validate().is_ok());
     }
 
     #[test]

--- a/crates/higgs-models/src/turboquant.rs
+++ b/crates/higgs-models/src/turboquant.rs
@@ -97,8 +97,18 @@ impl KvCacheConfig {
         matches!(self.mode, KvCacheMode::Turboquant)
     }
 
+    /// Validate this config.
+    ///
+    /// The MLA-latent/`TurboQuant` conflict check evaluates the *resolved*
+    /// MLA decision (see [`crate::cache::resolve_mla_latent_cache`]): if
+    /// `HIGGS_MLA_LATENT_CACHE` is set to a recognized value it overrides
+    /// `self.mla_latent` for this check too, so e.g. `mla_latent=true` with
+    /// the env var forcing it off does not fail validation here (callers
+    /// that want to surface that masking as a warning, like `higgs doctor`,
+    /// should compare `self.mla_latent` against the resolved decision
+    /// themselves).
     pub fn validate(self) -> Result<(), Exception> {
-        if self.mla_latent && self.is_turboquant() {
+        if crate::cache::resolve_mla_latent_cache(self.mla_latent) && self.is_turboquant() {
             return Err(Exception::custom(
                 "MLA latent cache cannot be combined with TurboQuant KV cache",
             ));
@@ -1663,7 +1673,13 @@ mod tests {
     }
 
     #[test]
+    #[allow(unsafe_code)]
     fn test_mla_latent_rejects_turboquant_combination() {
+        // SAFETY: test-only env mutation; higgs-models tests run single-threaded
+        // (--test-threads=1) so there is no cross-test interleaving.
+        unsafe {
+            std::env::remove_var("HIGGS_MLA_LATENT_CACHE");
+        }
         let conflicting = KvCacheConfig {
             mode: KvCacheMode::Turboquant,
             mla_latent: true,
@@ -1677,13 +1693,62 @@ mod tests {
     }
 
     #[test]
+    #[allow(unsafe_code)]
     fn test_mla_latent_alone_is_valid() {
+        // SAFETY: see note above.
+        unsafe {
+            std::env::remove_var("HIGGS_MLA_LATENT_CACHE");
+        }
         let config = KvCacheConfig {
             mode: KvCacheMode::Off,
             mla_latent: true,
             ..Default::default()
         };
         assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    #[allow(unsafe_code)]
+    fn test_mla_latent_env_override_off_masks_turboquant_conflict() {
+        // SAFETY: see note above.
+        unsafe {
+            std::env::set_var("HIGGS_MLA_LATENT_CACHE", "0");
+        }
+        let masked = KvCacheConfig {
+            mode: KvCacheMode::Turboquant,
+            mla_latent: true,
+            ..Default::default()
+        };
+        let result = masked.validate();
+        unsafe {
+            std::env::remove_var("HIGGS_MLA_LATENT_CACHE");
+        }
+        assert!(
+            result.is_ok(),
+            "env forcing MLA off should resolve the conflict away: {result:?}"
+        );
+    }
+
+    #[test]
+    #[allow(unsafe_code)]
+    fn test_mla_latent_env_override_on_triggers_turboquant_conflict() {
+        // SAFETY: see note above.
+        unsafe {
+            std::env::set_var("HIGGS_MLA_LATENT_CACHE", "1");
+        }
+        let config = KvCacheConfig {
+            mode: KvCacheMode::Turboquant,
+            mla_latent: false,
+            ..Default::default()
+        };
+        let result = config.validate();
+        unsafe {
+            std::env::remove_var("HIGGS_MLA_LATENT_CACHE");
+        }
+        assert!(
+            result.is_err(),
+            "env forcing MLA on should trigger the conflict even with mla_latent=false in config"
+        );
     }
 
     #[test]

--- a/crates/higgs/src/config.rs
+++ b/crates/higgs/src/config.rs
@@ -424,6 +424,14 @@ pub struct ModelConfig {
     /// Maximum disk-prefix-store size in MiB.
     #[serde(default = "default_kv_disk_space_mb")]
     pub kv_disk_space_mb: u64,
+    /// Store `DeepSeek`-V2 MLA caches as compressed latent rows.
+    ///
+    /// `None` defers to the `HIGGS_MLA_LATENT_CACHE` env var (default off).
+    /// When set, `HIGGS_MLA_LATENT_CACHE` (if also set to a recognized
+    /// value) still overrides this either way. Ignored for non-`DeepSeek`-V2
+    /// architectures. Mutually exclusive with `kv_cache = "turboquant"`.
+    #[serde(default)]
+    pub mla_latent_cache: Option<bool>,
 }
 
 const fn default_norm_correction() -> bool {
@@ -464,6 +472,10 @@ impl ModelConfig {
             norm_correction: self.kv_norm_correction,
             adaptive_dense_layers: self.kv_adaptive_dense_layers,
             seed: self.kv_seed,
+            mla_latent: match self.mla_latent_cache {
+                Some(v) => v,
+                None => false,
+            },
         }
     }
 
@@ -699,6 +711,7 @@ pub fn build_simple_config(args: &ServeArgs) -> Result<HiggsConfig, String> {
             kv_seed: args.kv_seed.unwrap_or_default(),
             kv_disk_dir: None,
             kv_disk_space_mb: default_kv_disk_space_mb(),
+            mla_latent_cache: None,
         })
         .collect();
 
@@ -789,6 +802,7 @@ pub fn load_config_file(path: &Path, args: Option<&ServeArgs>) -> Result<HiggsCo
                     kv_seed: serve_args.kv_seed.unwrap_or_default(),
                     kv_disk_dir: None,
                     kv_disk_space_mb: default_kv_disk_space_mb(),
+                    mla_latent_cache: None,
                 })
                 .collect();
             let mut existing = figment
@@ -963,6 +977,7 @@ fn ensure_auto_router_model(config: &mut HiggsConfig) {
         kv_seed: 0,
         kv_disk_dir: None,
         kv_disk_space_mb: default_kv_disk_space_mb(),
+        mla_latent_cache: None,
     });
     config.auto_router.model = name;
 }
@@ -1696,6 +1711,64 @@ mod tests {
         assert_eq!(model.kv_cache, KvCacheMode::Turboquant);
         assert_eq!(model.kv_bits, 4);
         assert_eq!(model.kv_seed, 123);
+    }
+
+    #[test]
+    fn test_config_file_parses_mla_latent_cache_field() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            r#"
+            [[models]]
+            path = "some/model"
+            mla_latent_cache = true
+            "#,
+        )
+        .unwrap();
+
+        let config = load_config_file(&path, None).unwrap();
+        let model = config.models.first().unwrap();
+        assert_eq!(model.mla_latent_cache, Some(true));
+        assert!(model.kv_cache_config().mla_latent);
+    }
+
+    #[test]
+    fn test_config_file_defaults_mla_latent_cache_to_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            r#"
+            [[models]]
+            path = "some/model"
+            "#,
+        )
+        .unwrap();
+
+        let config = load_config_file(&path, None).unwrap();
+        let model = config.models.first().unwrap();
+        assert_eq!(model.mla_latent_cache, None);
+        assert!(!model.kv_cache_config().mla_latent);
+    }
+
+    #[test]
+    fn test_config_file_rejects_mla_latent_cache_with_turboquant() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            r#"
+            [[models]]
+            path = "some/model"
+            kv_cache = "turboquant"
+            mla_latent_cache = true
+            "#,
+        )
+        .unwrap();
+
+        let err = load_config_file(&path, None).unwrap_err();
+        assert!(err.contains("MLA latent cache cannot be combined with TurboQuant KV cache"));
     }
 
     #[test]

--- a/crates/higgs/src/daemon.rs
+++ b/crates/higgs/src/daemon.rs
@@ -158,6 +158,7 @@ port = 8000
 # kv_disk_dir = "/var/lib/higgs/prefix-kv" # optional durable prefix cache
 # kv_disk_space_mb = 4096                # LRU budget; minimum 64 MiB
 # prefill_yield_tokens = 512 # optional: interleave decode during long prefills
+# mla_latent_cache = true # DeepSeek-V2 only: compressed latent KV cache; cannot combine with kv_cache = "turboquant"
 
 # --- Remote providers ---
 # Forward requests to external APIs via proxy routes.

--- a/crates/higgs/src/doctor.rs
+++ b/crates/higgs/src/doctor.rs
@@ -286,18 +286,25 @@ fn check_prefill_yield_tokens(
     true
 }
 
-/// Warn (not fail) when `mla_latent_cache=true` is set for a model whose
-/// architecture isn't `deepseek_v2`. The flag is a no-op for other
+/// Warn (not fail) when the *resolved* MLA decision is enabled for a model
+/// whose architecture isn't `deepseek_v2`. The flag is a no-op for other
 /// architectures at runtime -- `KvCacheConfig::mla_latent` is only consulted
 /// by `DeepSeekV2::make_cache_with_config` -- so this is advisory, not a
 /// hard failure.
+///
+/// Uses [`higgs_models::cache::resolve_mla_latent_cache`] rather than the raw
+/// `model.mla_latent_cache` field, so this matches runtime behavior: e.g.
+/// `HIGGS_MLA_LATENT_CACHE=1` with `mla_latent_cache` unset in config still
+/// warns (the flag is effectively on), and `HIGGS_MLA_LATENT_CACHE=0` with
+/// `mla_latent_cache=true` in config does not warn (the flag is effectively
+/// off).
 fn check_mla_latent_cache_architecture(
     label: &str,
     model: &crate::config::ModelConfig,
     resolved: &std::path::Path,
     result: &mut DoctorResult,
 ) {
-    if model.mla_latent_cache != Some(true) {
+    if !higgs_models::cache::resolve_mla_latent_cache(model.kv_cache_config().mla_latent) {
         return;
     }
     match model_loader::ModelConfig::from_dir(resolved) {
@@ -341,8 +348,26 @@ fn check_models(config: &HiggsConfig, result: &mut DoctorResult) {
         if !check_prefill_yield_tokens(&label, model.prefill_yield_tokens, result) {
             continue;
         }
-        match model.kv_cache_config().validate() {
-            Ok(()) => {}
+        let kv_cache_config = model.kv_cache_config();
+        match kv_cache_config.validate() {
+            Ok(()) => {
+                // `validate()` only rejects the MLA/TurboQuant combination
+                // using the *resolved* decision (env-aware), so a
+                // config-declared conflict that HIGGS_MLA_LATENT_CACHE
+                // overrides away passes silently there. Surface that as an
+                // advisory warning rather than staying silent.
+                if model.mla_latent_cache == Some(true)
+                    && kv_cache_config.is_turboquant()
+                    && !higgs_models::cache::resolve_mla_latent_cache(kv_cache_config.mla_latent)
+                {
+                    warn(
+                        &format!(
+                            "model {label} sets mla_latent_cache=true with kv_cache=turboquant, but HIGGS_MLA_LATENT_CACHE overrides MLA off; the conflict is masked at runtime"
+                        ),
+                        result,
+                    );
+                }
+            }
             Err(err) => {
                 fail(
                     &format!("model {label} has invalid KV cache config: {err}"),
@@ -351,7 +376,7 @@ fn check_models(config: &HiggsConfig, result: &mut DoctorResult) {
                 continue;
             }
         }
-        if model.batch && model.kv_cache_config().is_turboquant() {
+        if model.batch && kv_cache_config.is_turboquant() {
             fail(
                 &format!(
                     "model {label} enables unsupported combination: TurboQuant with batch=true"
@@ -1390,62 +1415,177 @@ mod tests {
         .unwrap();
     }
 
+    /// Run `f` with `HIGGS_MLA_LATENT_CACHE` set to `env_value` (or unset,
+    /// for `None`), restoring the prior value afterward. Serialized via
+    /// `crate::test_env_lock()` since this mutates process-global state;
+    /// combined with `--test-threads=1` (the repo's mandated test-runner
+    /// flag for this crate) there is no interleaving risk, but the lock
+    /// keeps the guarantee explicit and independent of that flag.
+    #[allow(unsafe_code)]
+    fn with_mla_env<R>(env_value: Option<&str>, f: impl FnOnce() -> R) -> R {
+        let _guard = crate::test_env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let previous = std::env::var("HIGGS_MLA_LATENT_CACHE").ok();
+        match env_value {
+            Some(v) => unsafe { std::env::set_var("HIGGS_MLA_LATENT_CACHE", v) },
+            None => unsafe { std::env::remove_var("HIGGS_MLA_LATENT_CACHE") },
+        }
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+
+        match previous.as_deref() {
+            Some(v) => unsafe { std::env::set_var("HIGGS_MLA_LATENT_CACHE", v) },
+            None => unsafe { std::env::remove_var("HIGGS_MLA_LATENT_CACHE") },
+        }
+        result.unwrap_or_else(|payload| std::panic::resume_unwind(payload))
+    }
+
     #[test]
     fn test_mla_latent_cache_turboquant_conflict_fails_in_check_models() {
-        let dir = tempfile::tempdir().unwrap();
-        write_model_config_json(dir.path(), "deepseek_v2");
-        let mut model = model_with_path(dir.path().to_str().unwrap().to_owned());
-        model.kv_cache = higgs_models::turboquant::KvCacheMode::Turboquant;
-        model.mla_latent_cache = Some(true);
-        let config = HiggsConfig {
-            models: vec![model],
-            ..HiggsConfig::default()
-        };
-        let mut result = empty_result();
-        check_models(&config, &mut result);
-        assert_eq!(result.failures, 1);
-        assert_eq!(result.warnings, 0);
+        with_mla_env(None, || {
+            let dir = tempfile::tempdir().unwrap();
+            write_model_config_json(dir.path(), "deepseek_v2");
+            let mut model = model_with_path(dir.path().to_str().unwrap().to_owned());
+            model.kv_cache = higgs_models::turboquant::KvCacheMode::Turboquant;
+            model.mla_latent_cache = Some(true);
+            let config = HiggsConfig {
+                models: vec![model],
+                ..HiggsConfig::default()
+            };
+            let mut result = empty_result();
+            check_models(&config, &mut result);
+            assert_eq!(result.failures, 1);
+            assert_eq!(result.warnings, 0);
+        });
+    }
+
+    #[test]
+    fn test_mla_latent_cache_env_off_masks_turboquant_conflict_as_warning() {
+        with_mla_env(Some("0"), || {
+            let dir = tempfile::tempdir().unwrap();
+            write_model_config_json(dir.path(), "deepseek_v2");
+            let mut model = model_with_path(dir.path().to_str().unwrap().to_owned());
+            model.kv_cache = higgs_models::turboquant::KvCacheMode::Turboquant;
+            model.mla_latent_cache = Some(true);
+            let config = HiggsConfig {
+                models: vec![model],
+                ..HiggsConfig::default()
+            };
+            let mut result = empty_result();
+            check_models(&config, &mut result);
+            assert_eq!(
+                result.failures, 0,
+                "HIGGS_MLA_LATENT_CACHE=0 should resolve the conflict away, not fail"
+            );
+            assert_eq!(
+                result.warnings, 1,
+                "the masked conflict should still surface as a warning"
+            );
+        });
+    }
+
+    #[test]
+    fn test_mla_latent_cache_env_on_triggers_turboquant_conflict() {
+        with_mla_env(Some("1"), || {
+            let dir = tempfile::tempdir().unwrap();
+            write_model_config_json(dir.path(), "deepseek_v2");
+            let mut model = model_with_path(dir.path().to_str().unwrap().to_owned());
+            model.kv_cache = higgs_models::turboquant::KvCacheMode::Turboquant;
+            // mla_latent_cache left unset in config -- the env var alone
+            // must be enough to trigger the conflict.
+            let config = HiggsConfig {
+                models: vec![model],
+                ..HiggsConfig::default()
+            };
+            let mut result = empty_result();
+            check_models(&config, &mut result);
+            assert_eq!(result.failures, 1);
+            assert_eq!(result.warnings, 0);
+        });
     }
 
     #[test]
     fn test_mla_latent_cache_architecture_passes_for_deepseek_v2() {
-        let dir = tempfile::tempdir().unwrap();
-        write_model_config_json(dir.path(), "deepseek_v2");
-        let model = ModelConfig {
-            mla_latent_cache: Some(true),
-            ..model_with_path(dir.path().to_str().unwrap().to_owned())
-        };
-        let mut result = empty_result();
-        check_mla_latent_cache_architecture("test-model", &model, dir.path(), &mut result);
-        assert_eq!(result.passes, 1);
-        assert_eq!(result.warnings, 0);
-        assert_eq!(result.failures, 0);
+        with_mla_env(None, || {
+            let dir = tempfile::tempdir().unwrap();
+            write_model_config_json(dir.path(), "deepseek_v2");
+            let model = ModelConfig {
+                mla_latent_cache: Some(true),
+                ..model_with_path(dir.path().to_str().unwrap().to_owned())
+            };
+            let mut result = empty_result();
+            check_mla_latent_cache_architecture("test-model", &model, dir.path(), &mut result);
+            assert_eq!(result.passes, 1);
+            assert_eq!(result.warnings, 0);
+            assert_eq!(result.failures, 0);
+        });
     }
 
     #[test]
     fn test_mla_latent_cache_architecture_warns_for_non_deepseek() {
-        let dir = tempfile::tempdir().unwrap();
-        write_model_config_json(dir.path(), "qwen2");
-        let model = ModelConfig {
-            mla_latent_cache: Some(true),
-            ..model_with_path(dir.path().to_str().unwrap().to_owned())
-        };
-        let mut result = empty_result();
-        check_mla_latent_cache_architecture("test-model", &model, dir.path(), &mut result);
-        assert_eq!(result.passes, 0);
-        assert_eq!(result.warnings, 1);
-        assert_eq!(result.failures, 0);
+        with_mla_env(None, || {
+            let dir = tempfile::tempdir().unwrap();
+            write_model_config_json(dir.path(), "qwen2");
+            let model = ModelConfig {
+                mla_latent_cache: Some(true),
+                ..model_with_path(dir.path().to_str().unwrap().to_owned())
+            };
+            let mut result = empty_result();
+            check_mla_latent_cache_architecture("test-model", &model, dir.path(), &mut result);
+            assert_eq!(result.passes, 0);
+            assert_eq!(result.warnings, 1);
+            assert_eq!(result.failures, 0);
+        });
+    }
+
+    #[test]
+    fn test_mla_latent_cache_architecture_env_on_warns_for_non_deepseek() {
+        with_mla_env(Some("1"), || {
+            let dir = tempfile::tempdir().unwrap();
+            write_model_config_json(dir.path(), "qwen2");
+            // config leaves mla_latent_cache unset -- the env override alone
+            // must be enough to trigger the architecture warning.
+            let model = model_with_path(dir.path().to_str().unwrap().to_owned());
+            let mut result = empty_result();
+            check_mla_latent_cache_architecture("test-model", &model, dir.path(), &mut result);
+            assert_eq!(result.passes, 0);
+            assert_eq!(result.warnings, 1);
+            assert_eq!(result.failures, 0);
+        });
+    }
+
+    #[test]
+    fn test_mla_latent_cache_architecture_env_off_suppresses_warning() {
+        with_mla_env(Some("0"), || {
+            let dir = tempfile::tempdir().unwrap();
+            write_model_config_json(dir.path(), "qwen2");
+            let model = ModelConfig {
+                mla_latent_cache: Some(true),
+                ..model_with_path(dir.path().to_str().unwrap().to_owned())
+            };
+            let mut result = empty_result();
+            check_mla_latent_cache_architecture("test-model", &model, dir.path(), &mut result);
+            assert_eq!(result.passes, 0);
+            assert_eq!(
+                result.warnings, 0,
+                "env forcing MLA off should suppress the architecture warning"
+            );
+            assert_eq!(result.failures, 0);
+        });
     }
 
     #[test]
     fn test_mla_latent_cache_architecture_noop_when_unset() {
-        let dir = tempfile::tempdir().unwrap();
-        write_model_config_json(dir.path(), "qwen2");
-        let model = model_with_path(dir.path().to_str().unwrap().to_owned());
-        let mut result = empty_result();
-        check_mla_latent_cache_architecture("test-model", &model, dir.path(), &mut result);
-        assert_eq!(result.passes, 0);
-        assert_eq!(result.warnings, 0);
-        assert_eq!(result.failures, 0);
+        with_mla_env(None, || {
+            let dir = tempfile::tempdir().unwrap();
+            write_model_config_json(dir.path(), "qwen2");
+            let model = model_with_path(dir.path().to_str().unwrap().to_owned());
+            let mut result = empty_result();
+            check_mla_latent_cache_architecture("test-model", &model, dir.path(), &mut result);
+            assert_eq!(result.passes, 0);
+            assert_eq!(result.warnings, 0);
+            assert_eq!(result.failures, 0);
+        });
     }
 }

--- a/crates/higgs/src/doctor.rs
+++ b/crates/higgs/src/doctor.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::time::Instant;
 
-use higgs_engine::mlx_tuning::resolve_effective_mlx_profile;
+use higgs_engine::{mlx_tuning::resolve_effective_mlx_profile, model_loader};
 
 use crate::config::HiggsConfig;
 use crate::model_resolver;
@@ -286,6 +286,47 @@ fn check_prefill_yield_tokens(
     true
 }
 
+/// Warn (not fail) when `mla_latent_cache=true` is set for a model whose
+/// architecture isn't `deepseek_v2`. The flag is a no-op for other
+/// architectures at runtime -- `KvCacheConfig::mla_latent` is only consulted
+/// by `DeepSeekV2::make_cache_with_config` -- so this is advisory, not a
+/// hard failure.
+fn check_mla_latent_cache_architecture(
+    label: &str,
+    model: &crate::config::ModelConfig,
+    resolved: &std::path::Path,
+    result: &mut DoctorResult,
+) {
+    if model.mla_latent_cache != Some(true) {
+        return;
+    }
+    match model_loader::ModelConfig::from_dir(resolved) {
+        Ok(inspected) if inspected.model_type == "deepseek_v2" => {
+            pass(
+                &format!("model {label} mla_latent_cache=true (deepseek_v2)"),
+                result,
+            );
+        }
+        Ok(inspected) => {
+            warn(
+                &format!(
+                    "model {label} enables mla_latent_cache=true but architecture '{}' is not deepseek_v2; the flag is a no-op at runtime",
+                    inspected.model_type
+                ),
+                result,
+            );
+        }
+        Err(err) => {
+            warn(
+                &format!(
+                    "model {label} enables mla_latent_cache=true but its architecture could not be determined: {err}"
+                ),
+                result,
+            );
+        }
+    }
+}
+
 fn check_models(config: &HiggsConfig, result: &mut DoctorResult) {
     for model in &config.models {
         let label = model_label(model);
@@ -342,6 +383,7 @@ fn check_models(config: &HiggsConfig, result: &mut DoctorResult) {
                         }
                     }
                 }
+                check_mla_latent_cache_architecture(&label, model, &resolved, result);
                 let requested_profile = model.requested_mlx_profile(&config.local);
                 let profile_msg = if model.batch {
                     "batch=true; batched decode supported".to_owned()
@@ -662,6 +704,7 @@ mod tests {
                     kv_adaptive_dense_layers: 0,
                     kv_disk_dir: None,
                     kv_disk_space_mb: 4096,
+                    mla_latent_cache: None,
                 },
                 ModelConfig {
                     path: "org/model-b".to_owned(),
@@ -678,6 +721,7 @@ mod tests {
                     kv_adaptive_dense_layers: 0,
                     kv_disk_dir: None,
                     kv_disk_space_mb: 4096,
+                    mla_latent_cache: None,
                 },
             ],
             ..HiggsConfig::default()
@@ -707,6 +751,7 @@ mod tests {
                     kv_adaptive_dense_layers: 0,
                     kv_disk_dir: None,
                     kv_disk_space_mb: 4096,
+                    mla_latent_cache: None,
                 },
                 ModelConfig {
                     path: "org/model-a".to_owned(),
@@ -723,6 +768,7 @@ mod tests {
                     kv_adaptive_dense_layers: 0,
                     kv_disk_dir: None,
                     kv_disk_space_mb: 4096,
+                    mla_latent_cache: None,
                 },
             ],
             ..HiggsConfig::default()
@@ -1201,6 +1247,7 @@ mod tests {
                 kv_adaptive_dense_layers: 0,
                 kv_disk_dir: None,
                 kv_disk_space_mb: 4096,
+                mla_latent_cache: None,
             }],
             ..HiggsConfig::default()
         };
@@ -1234,6 +1281,7 @@ mod tests {
                 kv_adaptive_dense_layers: 0,
                 kv_disk_dir: None,
                 kv_disk_space_mb: 4096,
+                mla_latent_cache: None,
             }],
             ..HiggsConfig::default()
         };
@@ -1269,6 +1317,7 @@ mod tests {
                 kv_adaptive_dense_layers: 0,
                 kv_disk_dir: None,
                 kv_disk_space_mb: 4096,
+                mla_latent_cache: None,
             }],
             routes: vec![RouteConfig {
                 name: Some("test".to_owned()),
@@ -1309,5 +1358,94 @@ mod tests {
         check_providers(&config, &mut result).await;
         assert_eq!(result.warnings, 1);
         assert_eq!(result.passes, 0);
+    }
+
+    // -- mla_latent_cache --
+
+    fn model_with_path(path: String) -> ModelConfig {
+        ModelConfig {
+            path,
+            name: None,
+            mlx_profile: None,
+            batch: false,
+            prefill_yield_tokens: None,
+            kv_cache: higgs_models::turboquant::KvCacheMode::Off,
+            kv_bits: 3,
+            kv_seed: 0,
+            kv_key_bits: None,
+            kv_value_bits: None,
+            kv_norm_correction: true,
+            kv_adaptive_dense_layers: 0,
+            kv_disk_dir: None,
+            kv_disk_space_mb: 4096,
+            mla_latent_cache: None,
+        }
+    }
+
+    fn write_model_config_json(dir: &std::path::Path, model_type: &str) {
+        std::fs::write(
+            dir.join("config.json"),
+            format!(r#"{{"model_type": "{model_type}"}}"#),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_mla_latent_cache_turboquant_conflict_fails_in_check_models() {
+        let dir = tempfile::tempdir().unwrap();
+        write_model_config_json(dir.path(), "deepseek_v2");
+        let mut model = model_with_path(dir.path().to_str().unwrap().to_owned());
+        model.kv_cache = higgs_models::turboquant::KvCacheMode::Turboquant;
+        model.mla_latent_cache = Some(true);
+        let config = HiggsConfig {
+            models: vec![model],
+            ..HiggsConfig::default()
+        };
+        let mut result = empty_result();
+        check_models(&config, &mut result);
+        assert_eq!(result.failures, 1);
+        assert_eq!(result.warnings, 0);
+    }
+
+    #[test]
+    fn test_mla_latent_cache_architecture_passes_for_deepseek_v2() {
+        let dir = tempfile::tempdir().unwrap();
+        write_model_config_json(dir.path(), "deepseek_v2");
+        let model = ModelConfig {
+            mla_latent_cache: Some(true),
+            ..model_with_path(dir.path().to_str().unwrap().to_owned())
+        };
+        let mut result = empty_result();
+        check_mla_latent_cache_architecture("test-model", &model, dir.path(), &mut result);
+        assert_eq!(result.passes, 1);
+        assert_eq!(result.warnings, 0);
+        assert_eq!(result.failures, 0);
+    }
+
+    #[test]
+    fn test_mla_latent_cache_architecture_warns_for_non_deepseek() {
+        let dir = tempfile::tempdir().unwrap();
+        write_model_config_json(dir.path(), "qwen2");
+        let model = ModelConfig {
+            mla_latent_cache: Some(true),
+            ..model_with_path(dir.path().to_str().unwrap().to_owned())
+        };
+        let mut result = empty_result();
+        check_mla_latent_cache_architecture("test-model", &model, dir.path(), &mut result);
+        assert_eq!(result.passes, 0);
+        assert_eq!(result.warnings, 1);
+        assert_eq!(result.failures, 0);
+    }
+
+    #[test]
+    fn test_mla_latent_cache_architecture_noop_when_unset() {
+        let dir = tempfile::tempdir().unwrap();
+        write_model_config_json(dir.path(), "qwen2");
+        let model = model_with_path(dir.path().to_str().unwrap().to_owned());
+        let mut result = empty_result();
+        check_mla_latent_cache_architecture("test-model", &model, dir.path(), &mut result);
+        assert_eq!(result.passes, 0);
+        assert_eq!(result.warnings, 0);
+        assert_eq!(result.failures, 0);
     }
 }

--- a/crates/higgs/src/tui/mod.rs
+++ b/crates/higgs/src/tui/mod.rs
@@ -656,6 +656,7 @@ mod tests {
                 kv_adaptive_dense_layers: 0,
                 kv_disk_dir: None,
                 kv_disk_space_mb: 4096,
+                mla_latent_cache: None,
             }],
             ..HiggsConfig::default()
         }

--- a/validation/mla-config/report.md
+++ b/validation/mla-config/report.md
@@ -1,0 +1,40 @@
+# Validation report: mla-config (MLA latent cache config surface)
+
+- chip: Apple M4 Max
+- ram_gb: 128
+- macos_version: 26.5.1
+- branch: claude/ds4-mla-config-surface
+- model: mlx-community/DeepSeek-Coder-V2-Lite-Instruct-4bit-mlx
+
+## Pre-registered success metrics
+1. All cargo gates green; doctor coverage (valid / turboquant conflict / non-deepseek warn).
+2. Hardware sanity: config mla_latent_cache=true (env unset) activates MLA in the serving engine,
+   equivalently to the env knob; config absent stays dense.
+3. Reviewer (codex sol, medium) MERGE OK.
+
+## Results
+
+### Metric 1 — PASS
+cargo test: higgs 484+2+99, higgs-models 459, higgs-engine 299, all green. clippy -Dwarnings clean for
+higgs-models/higgs-engine; the single higgs failure (metrics.rs unchecked_time_subtraction lint rename)
+reproduces identically on unmodified main with the local toolchain and is not introduced by this change
+(CI's pinned toolchain is authoritative). fmt clean. Doctor: turboquant+mla conflict errors via
+KvCacheConfig::validate (single source of truth); non-deepseek_v2 model_type warns (runtime no-op).
+
+### Metric 2 — PASS (instrument note)
+Three server runs, ~7100-token greedy request each. RSS proved insensitive (Metal buffer allocations do
+not show; all runs ~8.5 GB), so a binary-decisive instrument was used instead: the merged disk prefix
+store persists dense prefixes as .hkv files but explicitly rejects MLA-mode prefixes with a debug log.
+| Case | .hkv files written | MLA-reject logs |
+| --- | ---: | ---: |
+| config absent (dense) | 1 | 0 |
+| config mla_latent_cache=true, env unset | 0 | 1 |
+| env HIGGS_MLA_LATENT_CACHE=true, config absent | 0 | 1 |
+The config-knob and env-knob runs also produced byte-identical greedy outputs. This proves the config
+field reaches the engine's cache construction and behaves identically to the already-validated env path.
+
+### Precedence (documented, unit-tested)
+Explicitly-set env var wins in either direction; otherwise the config field decides; otherwise off.
+Default remains OFF; the default-flip still requires a longer soak and is out of scope.
+
+Verdict: PASS (pending reviewer verdict)


### PR DESCRIPTION
Follow-up to #254 (ds4 program): the MLA latent cache was env-knob-only; this gives it the full repo config pattern. Default remains OFF (the default-flip still awaits a longer soak).

- `mla_latent_cache: Option<bool>` on [[models]] -> `KvCacheConfig.mla_latent` -> DeepSeek-V2 cache construction via `make_cache_with_config`. Precedence (unit-tested): an explicitly-set `HIGGS_MLA_LATENT_CACHE` env var wins in either direction; otherwise the config field; otherwise off.
- Doctor: turboquant+MLA conflict errors once in `KvCacheConfig::validate` (shared by config load and doctor); non-deepseek_v2 models warn (runtime no-op). README + `higgs init` template updated per repo policy.
- Hardware proof (validation/mla-config/report.md): RSS proved insensitive to KV mode (Metal allocations), so a binary-decisive instrument was used — the disk prefix store persists dense prefixes (.hkv written) but rejects MLA prefixes (debug log). Config-knob run: 0 files + 1 reject log, identical to the env-knob run (byte-identical greedy output); config-absent run: 1 file + 0 reject logs. The config field provably reaches the serving engine.
- Gates: higgs 484+2+99, higgs-models 459, higgs-engine 299 tests green; fmt clean; clippy -Dwarnings clean except a pre-existing metrics.rs lint-rename issue reproducible on unmodified main with the local toolchain.

Process: implemented by a Sonnet agent, reviewed by codex sol (medium) pre-merge, per program conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional MLA latent-cache setting for DeepSeek-V2 models.
  - Added environment-variable overrides, with explicit overrides taking precedence over configuration.
  - Added validation checks to confirm architecture support and detect incompatible TurboQuant settings.

- **Documentation**
  - Documented defaults, supported model scope, environment overrides, and configuration limitations.
  - Added a validation report covering configuration behavior and runtime checks.

- **Bug Fixes**
  - Cache creation now respects the configured MLA latent-cache setting instead of always using default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->