### PR TITLE
refactor(models): version-tolerant model adapter registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ benchmarks/*.txt
 benchmarks/*.safetensors
 benchmarks/*.py
 validation/**/raw/
+validation/**/raw/

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ curl http://localhost:8000/v1/chat/completions \
 ### Run open-weight models locally on Apple Silicon
 
 - Serve MLX models from Hugging Face IDs or local paths.
-- Support current model families including Qwen 3.6, Qwen 3.x, Llama, Mistral, Gemma 2, Phi-3, Starcoder2, DeepSeek-V2, and LLaVA-Qwen2.
+- Support current model families including Qwen 3.8, Qwen 3.x, Llama, Mistral, Gemma 2, Phi-3, Starcoder2, DeepSeek-V2, and LLaVA-Qwen2. Qwen 3.5+ checkpoints (3.5, 3.6, and 3.8; dense and MoE) use the Qwen 3.5 adapters, including `*ForConditionalGeneration` wrappers whose text-model config lives in `text_config`. Unknown newer versions in a supported family use the nearest structurally compatible adapter and log an untested-version warning; unknown families are rejected with the supported family/version list.
 - Expose local serving through OpenAI and Anthropic-compatible endpoints.
 
 ### Use one endpoint for local and remote models

--- a/benchmarks/models.toml
+++ b/benchmarks/models.toml
@@ -46,6 +46,15 @@ context = 32768
 tags = ["large", "moe"]
 
 [[models]]
+key = "qwen3.8-27B-4bit"
+label = "Qwen3.8-27B-4bit (Dense)"
+path = "mlx-community/Qwen3.8-27B-4bit"
+quantization = "4bit"
+approx_size_gb = 15.5
+context = 32768
+tags = ["large", "dense"]
+
+[[models]]
 key = "qwen3.6-27B-mtp-8bit"
 label = "Qwen3.6-27B MTP 8-bit"
 path = "trevon/Qwen3.6-27B-mtp"

--- a/crates/higgs-engine/src/model_loader.rs
+++ b/crates/higgs-engine/src/model_loader.rs
@@ -1,7 +1,9 @@
 use std::path::{Path, PathBuf};
 
 use higgs_models::{
-    AnyModel, error::ModelError, load_tokenizer as shared_load_tokenizer, registry, transformer,
+    AnyModel,
+    adapter::{self, Capabilities, ModelFamily, ModelVersion},
+    load_tokenizer as shared_load_tokenizer,
 };
 
 use crate::error::EngineError;
@@ -11,138 +13,36 @@ use crate::error::EngineError;
 pub struct ModelConfig {
     pub model_dir: PathBuf,
     pub model_type: String,
+    pub adapter_id: &'static str,
+    pub family: ModelFamily,
+    pub version: Option<ModelVersion>,
+    pub capabilities: Capabilities,
 }
 
 impl ModelConfig {
     /// Detect model type and create a config from a model directory.
     pub fn from_dir<P: AsRef<Path>>(dir: P) -> Result<Self, EngineError> {
         let model_dir = dir.as_ref().to_path_buf();
-        let model_type = registry::detect_model_type(&model_dir)?;
-
-        if !registry::is_supported(&model_type) {
-            return Err(EngineError::Model(
-                higgs_models::error::ModelError::UnsupportedModel(model_type),
-            ));
-        }
+        let detected = adapter::detect(&model_dir)?;
+        let resolved = adapter::resolve(&detected)?;
+        let info = resolved.describe();
 
         Ok(Self {
             model_dir,
-            model_type,
+            model_type: detected.model_type,
+            adapter_id: info.id,
+            family: detected.family,
+            version: detected.version,
+            capabilities: info.capabilities,
         })
     }
 }
 
 /// Load a model from a directory, auto-detecting the architecture.
 pub fn load_model<P: AsRef<Path>>(model_dir: P) -> Result<AnyModel, EngineError> {
-    let config = ModelConfig::from_dir(&model_dir)?;
-
-    match config.model_type.as_str() {
-        "qwen2" | "qwen3" | "llama" | "mistral" => {
-            // Packed 1.25-bpw Bonsai-Q1 checkpoints declare model_type="qwen3"
-            // but the weights are quantized to bits=1. Route them to the
-            // dedicated packed engine, whose bits=1 matvec/dequant run through
-            // runtime JIT Metal kernels (higgs-models::metal_kernel) — so it
-            // runs on stock oxideai/mlx-rs with no forked bits=1 MLX kernel.
-            if is_bonsai_q1(&config.model_dir)? {
-                let gpu = higgs_models::bonsai_q1::load_bonsai_q1(&config.model_dir)
-                    .map_err(EngineError::Model)?;
-                return Ok(AnyModel::BonsaiQ1(gpu));
-            }
-            let model = transformer::load_model(&config.model_dir).map_err(EngineError::Model)?;
-            Ok(AnyModel::Transformer(model))
-        }
-        "qwen3_next" => {
-            let model = higgs_models::qwen3_next::load_qwen3_next_model(&config.model_dir)
-                .map_err(EngineError::Model)?;
-            Ok(AnyModel::Qwen3Next(model))
-        }
-        "qwen3_5" => {
-            let model = higgs_models::qwen3_next::load_qwen3_5_model(&config.model_dir)
-                .map_err(EngineError::Model)?;
-            Ok(AnyModel::Qwen3Next(model))
-        }
-        "qwen3_5_moe" => {
-            let model = higgs_models::qwen3_next::load_qwen3_5_moe_model(&config.model_dir)
-                .map_err(EngineError::Model)?;
-            Ok(AnyModel::Qwen3Next(model))
-        }
-        "qwen3_moe" => {
-            let model = higgs_models::qwen3_moe::load_qwen3_moe_model(&config.model_dir)
-                .map_err(EngineError::Model)?;
-            Ok(AnyModel::Qwen3Moe(model))
-        }
-        "gemma2" => {
-            let model = higgs_models::gemma2::load_gemma2_model(&config.model_dir)
-                .map_err(EngineError::Model)?;
-            Ok(AnyModel::Gemma2(model))
-        }
-        "gemma3" | "gemma3_text" => {
-            let model = higgs_models::gemma3::load_gemma3_model(&config.model_dir)
-                .map_err(EngineError::Model)?;
-            Ok(AnyModel::Gemma3(model))
-        }
-        "gemma4" | "gemma4_text" | "gemma4_unified" => {
-            let model = higgs_models::gemma4::load_gemma4_model(&config.model_dir)
-                .map_err(EngineError::Model)?;
-            Ok(AnyModel::Gemma4(model))
-        }
-        "phi3" => {
-            let model = higgs_models::phi3::load_phi3_model(&config.model_dir)
-                .map_err(EngineError::Model)?;
-            Ok(AnyModel::Phi3(model))
-        }
-        "starcoder2" => {
-            let model = higgs_models::starcoder2::load_starcoder2_model(&config.model_dir)
-                .map_err(EngineError::Model)?;
-            Ok(AnyModel::Starcoder2(model))
-        }
-        "llava-qwen2" => {
-            let model = higgs_models::llava_qwen2::load_llava_qwen2_model(&config.model_dir)
-                .map_err(EngineError::Model)?;
-            Ok(AnyModel::LlavaQwen2(model))
-        }
-        "deepseek_v2" => {
-            let model = higgs_models::deepseek_v2::load_deepseek_v2_model(&config.model_dir)
-                .map_err(EngineError::Model)?;
-            Ok(AnyModel::DeepSeekV2(model))
-        }
-        other => Err(EngineError::Model(
-            higgs_models::error::ModelError::UnsupportedModel(other.to_owned()),
-        )),
-    }
-}
-
-/// Peek into `config.json` to detect packed 1-bit Bonsai-Q1 checkpoints.
-///
-/// Returns `true` for Qwen3-shaped `quantization.bits == 1` checkpoints using
-/// the expected group size. Returns `false` for any other model type or
-/// quantization config. A missing / malformed `config.json` propagates as an
-/// IO / JSON error — we never mask it.
-fn is_bonsai_q1(dir: &Path) -> Result<bool, EngineError> {
-    let cfg_path = dir.join("config.json");
-    let txt = std::fs::read_to_string(&cfg_path).map_err(|e| {
-        EngineError::Model(higgs_models::error::ModelError::Io(std::io::Error::new(
-            e.kind(),
-            format!("{}: {e}", cfg_path.display()),
-        )))
-    })?;
-    let cfg: serde_json::Value = serde_json::from_str(&txt)
-        .map_err(|e| EngineError::Model(higgs_models::error::ModelError::Json(e)))?;
-    let bonsai_group_size = u64::try_from(higgs_models::bonsai_q1::GROUP_SIZE)
-        .map_err(|e| EngineError::Model(ModelError::ShapeMismatch(e.to_string())))?;
-    Ok(
-        cfg.get("model_type").and_then(serde_json::Value::as_str) == Some("qwen3")
-            && cfg
-                .get("quantization")
-                .and_then(|q| q.get("bits"))
-                .and_then(serde_json::Value::as_u64)
-                == Some(1)
-            && cfg
-                .get("quantization")
-                .and_then(|q| q.get("group_size"))
-                .and_then(serde_json::Value::as_u64)
-                == Some(bonsai_group_size),
-    )
+    let detected = adapter::detect(model_dir.as_ref()).map_err(EngineError::Model)?;
+    let resolved = adapter::resolve(&detected).map_err(EngineError::Model)?;
+    resolved.load(&detected).map_err(EngineError::Model)
 }
 
 /// Load a tokenizer from a model directory.
@@ -307,44 +207,6 @@ mod tests {
             err,
             EngineError::Model(ModelError::UnsupportedModel(_))
         ));
-    }
-
-    #[test]
-    fn is_bonsai_q1_requires_qwen3_model_type_and_group_size() {
-        let (qwen3_dir, _qwen3_result) = config_from_raw(
-            r#"{
-                "model_type": "qwen3",
-                "quantization": {"bits": 1, "group_size": 128}
-            }"#,
-        );
-        assert!(is_bonsai_q1(qwen3_dir.path()).unwrap());
-
-        let (llama_dir, _llama_result) = config_from_raw(
-            r#"{
-                "model_type": "llama",
-                "quantization": {"bits": 1, "group_size": 128}
-            }"#,
-        );
-        assert!(!is_bonsai_q1(llama_dir.path()).unwrap());
-
-        let (wrong_group_dir, _wrong_group_result) = config_from_raw(
-            r#"{
-                "model_type": "qwen3",
-                "quantization": {"bits": 1, "group_size": 64}
-            }"#,
-        );
-        assert!(!is_bonsai_q1(wrong_group_dir.path()).unwrap());
-
-        let (q4_dir, _q4_result) = config_from_raw(
-            r#"{
-                "model_type": "qwen3",
-                "quantization": {"bits": 4, "group_size": 128}
-            }"#,
-        );
-        assert!(
-            !is_bonsai_q1(q4_dir.path()).unwrap(),
-            "regular Q4 Qwen3 must not be misclassified as Bonsai-Q1"
-        );
     }
 
     #[test]

--- a/crates/higgs-engine/src/model_loader.rs
+++ b/crates/higgs-engine/src/model_loader.rs
@@ -11,11 +11,17 @@ use crate::error::EngineError;
 /// Configuration for loading a model from a directory.
 #[derive(Debug)]
 pub struct ModelConfig {
+    /// Local checkpoint directory used for model and tokenizer loading.
     pub model_dir: PathBuf,
+    /// Effective model type, using nested `text_config.model_type` for wrappers.
     pub model_type: String,
+    /// Stable identifier of the adapter selected for this checkpoint.
     pub adapter_id: &'static str,
+    /// Broad family detected from the effective model type.
     pub family: ModelFamily,
+    /// Numeric version parsed from `model_type`, or `None` when no numeric version parses.
     pub version: Option<ModelVersion>,
+    /// Capabilities of the resolved adapter implementation, not claims copied from the checkpoint.
     pub capabilities: Capabilities,
 }
 

--- a/crates/higgs-models/src/adapter.rs
+++ b/crates/higgs-models/src/adapter.rs
@@ -1,9 +1,13 @@
 //! Model-family detection and loading adapters.
 //!
-//! Resolution chooses the adapter with the highest score. Equal scores are
-//! resolved by registry order, which is stable and therefore deterministic.
+//! Detection preserves both nested text-backbone and top-level wrapper model
+//! types as resolution candidates. Resolution scores every adapter across all
+//! candidates: special structural matches beat exact matches, exact matches on
+//! any candidate beat tolerant matches on any candidate, and equal scores are
+//! resolved by stable registry order.
 
 use std::{
+    borrow::Cow,
     fmt,
     path::{Path, PathBuf},
     sync::OnceLock,
@@ -75,6 +79,12 @@ pub struct DetectedModel {
 }
 
 impl DetectedModel {
+    /// Candidate model types in diagnostic order: effective/nested first,
+    /// followed by the top-level wrapper type when present.
+    fn model_type_candidates(&self) -> impl Iterator<Item = &str> {
+        std::iter::once(self.model_type.as_str()).chain(self.wrapper_model_type.as_deref())
+    }
+
     /// The config object consumed by the effective text loader.
     #[must_use]
     pub fn resolved_config(&self) -> &Value {
@@ -317,16 +327,22 @@ static BUILTINS: [&BuiltinAdapter; 13] = [
 
 impl BuiltinAdapter {
     fn is_exact(&self, model_type: &str) -> bool {
+        let text_alias = strip_text_alias(model_type);
         match self.kind {
-            LoadKind::Transformer => matches!(model_type, "qwen2" | "qwen3" | "llama" | "mistral"),
-            LoadKind::Bonsai => model_type == "qwen3",
-            LoadKind::Qwen3Next => model_type == "qwen3_next",
-            LoadKind::Qwen35Dense => model_type == "qwen3_5",
-            LoadKind::Qwen35Moe => model_type == "qwen3_5_moe",
-            LoadKind::Qwen3Moe => model_type == "qwen3_moe",
+            LoadKind::Transformer => {
+                matches!(text_alias.as_ref(), "qwen2" | "qwen3")
+                    || matches!(model_type, "llama" | "mistral")
+            }
+            LoadKind::Bonsai => text_alias == "qwen3",
+            LoadKind::Qwen3Next => text_alias == "qwen3_next",
+            LoadKind::Qwen35Dense => text_alias == "qwen3_5",
+            LoadKind::Qwen35Moe => text_alias == "qwen3_5_moe",
+            LoadKind::Qwen3Moe => text_alias == "qwen3_moe",
             LoadKind::Gemma2 => model_type == "gemma2",
-            LoadKind::Gemma3 => matches!(model_type, "gemma3" | "gemma3_text"),
-            LoadKind::Gemma4 => matches!(model_type, "gemma4" | "gemma4_text" | "gemma4_unified"),
+            LoadKind::Gemma3 => text_alias == "gemma3",
+            LoadKind::Gemma4 => {
+                matches!(text_alias.as_ref(), "gemma4" | "gemma4_unified")
+            }
             LoadKind::Phi3 => model_type == "phi3",
             LoadKind::Starcoder2 => model_type == "starcoder2",
             LoadKind::LlavaQwen2 => model_type == "llava-qwen2",
@@ -334,16 +350,16 @@ impl BuiltinAdapter {
         }
     }
 
-    fn tolerant_match(&self, model: &DetectedModel) -> bool {
+    fn tolerant_match(&self, model_type: &str) -> bool {
         match self.kind {
             LoadKind::Qwen35Dense => {
-                qwen_revision(&model.model_type).is_some_and(|(minor, moe)| minor >= 5 && !moe)
+                qwen_revision(model_type).is_some_and(|(minor, moe)| minor >= 5 && !moe)
             }
             LoadKind::Qwen35Moe => {
-                qwen_revision(&model.model_type).is_some_and(|(minor, moe)| minor >= 5 && moe)
+                qwen_revision(model_type).is_some_and(|(minor, moe)| minor >= 5 && moe)
             }
-            LoadKind::Gemma3 => gemma_revision(&model.model_type).is_some_and(|major| major >= 3),
-            LoadKind::Gemma4 => gemma_revision(&model.model_type).is_some_and(|major| major >= 4),
+            LoadKind::Gemma3 => gemma_revision(model_type).is_some_and(|major| major >= 3),
+            LoadKind::Gemma4 => gemma_revision(model_type).is_some_and(|major| major >= 4),
             LoadKind::Transformer
             | LoadKind::Bonsai
             | LoadKind::Qwen3Next
@@ -356,8 +372,14 @@ impl BuiltinAdapter {
         }
     }
 
+    fn has_exact_candidate(&self, model: &DetectedModel) -> bool {
+        model
+            .model_type_candidates()
+            .any(|model_type| self.is_exact(model_type))
+    }
+
     fn validate_tolerant(&self, model: &DetectedModel) -> Result<(), ModelError> {
-        if self.is_exact(&model.model_type) {
+        if self.has_exact_candidate(model) {
             return Ok(());
         }
         let config = model.resolved_config();
@@ -449,14 +471,17 @@ impl ModelAdapter for BuiltinAdapter {
         if matches!(self.kind, LoadKind::Bonsai) {
             let group_size = u64::try_from(crate::bonsai_q1::GROUP_SIZE).ok()?;
             let quantization = model.raw.get("quantization")?;
-            return (model.model_type == "qwen3"
+            return (self.has_exact_candidate(model)
                 && quantization.get("bits").and_then(Value::as_u64) == Some(1)
                 && quantization.get("group_size").and_then(Value::as_u64) == Some(group_size))
             .then_some(2_000);
         }
-        if self.is_exact(&model.model_type) {
+        if self.has_exact_candidate(model) {
             Some(1_000)
-        } else if self.tolerant_match(model) {
+        } else if model
+            .model_type_candidates()
+            .any(|model_type| self.tolerant_match(model_type))
+        {
             Some(if matches!(self.kind, LoadKind::Gemma4) {
                 120
             } else {
@@ -468,7 +493,7 @@ impl ModelAdapter for BuiltinAdapter {
     }
     fn load(&self, model: &DetectedModel) -> Result<AnyModel, ModelError> {
         self.validate_tolerant(model)?;
-        if !self.is_exact(&model.model_type) {
+        if !self.has_exact_candidate(model) {
             tracing::warn!(model_type = %model.model_type, adapter = self.id, "loading an untested model version through a structurally compatible adapter");
         }
         let dir = &model.dir;
@@ -566,21 +591,14 @@ pub fn detect(dir: &Path) -> Result<DetectedModel, ModelError> {
                 .map(ToOwned::to_owned)
                 .collect()
         });
-    let is_wrapper = architectures
-        .iter()
-        .any(|name| name.ends_with("ForConditionalGeneration"));
     let nested_type = raw
         .get("text_config")
         .and_then(|value| value.get("model_type"))
         .and_then(Value::as_str);
-    let (model_type, wrapper_model_type) = if is_wrapper {
-        nested_type.map_or_else(
-            || (top_model_type.to_owned(), None),
-            |nested| (nested.to_owned(), Some(top_model_type.to_owned())),
-        )
-    } else {
-        (top_model_type.to_owned(), None)
-    };
+    let (model_type, wrapper_model_type) = nested_type.map_or_else(
+        || (top_model_type.to_owned(), None),
+        |nested| (nested.to_owned(), Some(top_model_type.to_owned())),
+    );
     let (family, version) = classify(&model_type);
     Ok(DetectedModel {
         model_type,
@@ -593,8 +611,10 @@ pub fn detect(dir: &Path) -> Result<DetectedModel, ModelError> {
     })
 }
 
-/// Resolve the most-specific adapter, validating structural compatibility for
-/// version-tolerant matches.
+/// Resolve the most-specific adapter across all detected model-type candidates.
+///
+/// Exact matches on either the nested or wrapper candidate take precedence over
+/// every version-tolerant match. Tolerant selections retain structural checks.
 pub fn resolve(model: &DetectedModel) -> Result<&'static dyn ModelAdapter, ModelError> {
     let selected = registry()
         .iter()
@@ -636,7 +656,9 @@ pub fn supported() -> Vec<AdapterInfo> {
 /// Whether resolution selected a structurally gated, not-exactly-known version.
 #[must_use]
 pub fn is_untested_version(adapter: &dyn ModelAdapter, model: &DetectedModel) -> bool {
-    !is_exact_supported_by(adapter.id(), &model.model_type)
+    !model
+        .model_type_candidates()
+        .any(|model_type| is_exact_supported_by(adapter.id(), model_type))
 }
 
 /// Exact-string compatibility used by the legacy registry facade.
@@ -663,7 +685,8 @@ fn unsupported_error(model_type: &str) -> ModelError {
 }
 
 fn qwen_revision(model_type: &str) -> Option<(u32, bool)> {
-    let rest = model_type.strip_prefix("qwen3_")?;
+    let normalized = strip_text_alias(model_type);
+    let rest = normalized.strip_prefix("qwen3_")?;
     let (minor_text, suffix) = rest
         .split_once('_')
         .map_or((rest, None), |(minor, suffix)| (minor, Some(suffix)));
@@ -676,7 +699,8 @@ fn qwen_revision(model_type: &str) -> Option<(u32, bool)> {
 }
 
 fn gemma_revision(model_type: &str) -> Option<u32> {
-    let rest = model_type.strip_prefix("gemma")?;
+    let normalized = strip_text_alias(model_type);
+    let rest = normalized.strip_prefix("gemma")?;
     let (major, suffix) = rest
         .split_once('_')
         .map_or((rest, None), |(major, suffix)| (major, Some(suffix)));
@@ -684,6 +708,17 @@ fn gemma_revision(model_type: &str) -> Option<u32> {
         return None;
     }
     major.parse().ok()
+}
+
+fn strip_text_alias(model_type: &str) -> Cow<'_, str> {
+    model_type.strip_suffix("_text_moe").map_or_else(
+        || {
+            model_type
+                .strip_suffix("_text")
+                .map_or(Cow::Borrowed(model_type), Cow::Borrowed)
+        },
+        |prefix| Cow::Owned(format!("{prefix}_moe")),
+    )
 }
 
 fn classify(model_type: &str) -> (ModelFamily, Option<ModelVersion>) {

--- a/crates/higgs-models/src/adapter.rs
+++ b/crates/higgs-models/src/adapter.rs
@@ -23,14 +23,23 @@ pub const MAX_CONFIG_SIZE: u64 = 10 * 1024 * 1024;
 /// A broad model family, independent of checkpoint naming revisions.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ModelFamily {
+    /// Alibaba's Qwen language-model family.
     Qwen,
+    /// Google's Gemma language-model family.
     Gemma,
+    /// Meta's Llama language-model family.
     Llama,
+    /// Mistral AI's language-model family.
     Mistral,
+    /// Microsoft's Phi language-model family.
     Phi,
+    /// The `StarCoder` language-model family.
     Starcoder,
+    /// The `DeepSeek` language-model family.
     DeepSeek,
+    /// The `LLaVA` vision-language family with a supported text backbone.
     Llava,
+    /// A detected family for which Higgs has no built-in family variant.
     Other(String),
 }
 
@@ -53,7 +62,9 @@ impl fmt::Display for ModelFamily {
 /// Numeric family version parsed from a checkpoint's effective model type.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ModelVersion {
+    /// Major version parsed from `model_type`.
     pub major: u32,
+    /// Minor version parsed from `model_type`, or zero when only a major version is present.
     pub minor: u32,
 }
 
@@ -66,15 +77,19 @@ impl fmt::Display for ModelVersion {
 /// A config parsed once for adapter resolution and loading.
 #[derive(Debug, Clone)]
 pub struct DetectedModel {
-    /// Effective text model type.
+    /// Effective model type from the config consumed by the selected text loader.
     pub model_type: String,
     /// Top-level wrapper model type when `text_config` was selected.
     pub wrapper_model_type: Option<String>,
+    /// Top-level architecture names declared by the checkpoint.
     pub architectures: Vec<String>,
+    /// Broad family classified from the effective `model_type`.
     pub family: ModelFamily,
+    /// Numeric version parsed from the effective `model_type`, when present.
     pub version: Option<ModelVersion>,
     /// Original, unmodified top-level configuration.
     pub raw: Value,
+    /// Checkpoint directory containing the detected `config.json` and weights.
     pub dir: PathBuf,
 }
 
@@ -100,29 +115,57 @@ impl DetectedModel {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct Capabilities {
+    /// Whether the adapter implements vision or other image inputs.
     pub vision: bool,
+    /// Whether the adapter can load and use multi-token-prediction layers.
     pub mtp: bool,
+    /// Whether the adapter implements mixture-of-experts layers.
     pub moe: bool,
+    /// Whether the adapter can store the compressed MLA latent state in the KV cache.
+    ///
+    /// When false, requesting MLA latent caching is a no-op and diagnostics warn
+    /// that the resolved adapter does not implement it.
     pub mla_latent_cache: bool,
+    /// Whether the adapter supports the true batched-decode engine used by `batch=true`.
+    ///
+    /// This is distinct from serving concurrent requests through the normal,
+    /// non-batched engine.
     pub batch_engine: bool,
 }
 
 /// Human-facing adapter metadata.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AdapterInfo {
+    /// Stable identifier used in logs, diagnostics, and configuration inspection.
     pub id: &'static str,
+    /// Broad model family implemented by the adapter.
     pub family: ModelFamily,
+    /// Human-readable version range the adapter accepts.
     pub version_range: String,
+    /// Features implemented by this adapter's current loader.
     pub capabilities: Capabilities,
+    /// Short human-readable description of the implementation and its limits.
     pub notes: &'static str,
 }
 
 /// Uniform model-family routing and loading interface.
 pub trait ModelAdapter: Send + Sync {
+    /// Return the adapter's stable identifier.
     fn id(&self) -> &'static str;
+    /// Return the broad model family implemented by this adapter.
     fn family(&self) -> ModelFamily;
+    /// Return metadata describing the adapter's supported range and capabilities.
     fn describe(&self) -> AdapterInfo;
+    /// Score this adapter for a detected checkpoint.
+    ///
+    /// Higher scores are preferred; equal scores preserve registry order.
+    /// Returning `None` means the adapter cannot handle the checkpoint.
     fn match_score(&self, model: &DetectedModel) -> Option<u32>;
+    /// Construct a model from the already-detected configuration and checkpoint directory.
+    ///
+    /// Implementations must consume `DetectedModel::raw` or `resolved_config()`
+    /// rather than reopening `config.json`, and return a descriptive error when
+    /// the config or weights are incompatible.
     fn load(&self, model: &DetectedModel) -> Result<AnyModel, ModelError>;
 }
 
@@ -293,22 +336,6 @@ static DEEPSEEK_V2: BuiltinAdapter = BuiltinAdapter {
     kind: LoadKind::DeepSeekV2,
 };
 
-static ADAPTERS: [&'static dyn ModelAdapter; 13] = [
-    &BONSAI_Q1,
-    &QWEN35_MOE,
-    &QWEN35_DENSE,
-    &QWEN3_NEXT,
-    &QWEN3_MOE,
-    &GEMMA4,
-    &GEMMA3,
-    &GEMMA2,
-    &PHI3,
-    &STARCODER2,
-    &LLAVA_QWEN2,
-    &DEEPSEEK_V2,
-    &TRANSFORMER_DENSE,
-];
-
 static BUILTINS: [&BuiltinAdapter; 13] = [
     &BONSAI_Q1,
     &QWEN35_MOE,
@@ -378,8 +405,12 @@ impl BuiltinAdapter {
             .any(|model_type| self.is_exact(model_type))
     }
 
+    fn has_exact_resolved_config(&self, model: &DetectedModel) -> bool {
+        self.is_exact(&model.model_type)
+    }
+
     fn validate_tolerant(&self, model: &DetectedModel) -> Result<(), ModelError> {
-        if self.has_exact_candidate(model) {
+        if self.has_exact_resolved_config(model) {
             return Ok(());
         }
         let config = model.resolved_config();
@@ -559,11 +590,17 @@ fn qwen35_args(model: &DetectedModel) -> Result<crate::qwen3_next::Qwen3NextMode
     }
 }
 
+fn as_model_adapter(adapter: &'static BuiltinAdapter) -> &'static dyn ModelAdapter {
+    adapter
+}
+
 /// The process-wide ordered adapter registry.
 #[must_use]
 pub fn registry() -> &'static [&'static dyn ModelAdapter] {
-    static REGISTRY: OnceLock<&'static [&'static dyn ModelAdapter]> = OnceLock::new();
-    REGISTRY.get_or_init(|| &ADAPTERS)
+    static REGISTRY: OnceLock<Vec<&'static dyn ModelAdapter>> = OnceLock::new();
+    REGISTRY
+        .get_or_init(|| BUILTINS.iter().copied().map(as_model_adapter).collect())
+        .as_slice()
 }
 
 /// Parse and classify a checkpoint's `config.json` once.
@@ -616,7 +653,7 @@ pub fn detect(dir: &Path) -> Result<DetectedModel, ModelError> {
 /// Exact matches on either the nested or wrapper candidate take precedence over
 /// every version-tolerant match. Tolerant selections retain structural checks.
 pub fn resolve(model: &DetectedModel) -> Result<&'static dyn ModelAdapter, ModelError> {
-    let selected = registry()
+    let selected = BUILTINS
         .iter()
         .enumerate()
         .filter_map(|(index, adapter)| {
@@ -631,16 +668,7 @@ pub fn resolve(model: &DetectedModel) -> Result<&'static dyn ModelAdapter, Model
     };
     // Keep validation in resolve so callers that only inspect a checkpoint
     // still receive structural errors before attempting to load weights.
-    let Some(concrete) = BUILTINS
-        .iter()
-        .find(|candidate| candidate.id == adapter.id())
-    else {
-        return Err(ModelError::UnsupportedModel(format!(
-            "internal adapter registry mismatch for '{}'",
-            adapter.id()
-        )));
-    };
-    concrete.validate_tolerant(model)?;
+    adapter.validate_tolerant(model)?;
     Ok(adapter)
 }
 

--- a/crates/higgs-models/src/adapter.rs
+++ b/crates/higgs-models/src/adapter.rs
@@ -1,0 +1,738 @@
+//! Model-family detection and loading adapters.
+//!
+//! Resolution chooses the adapter with the highest score. Equal scores are
+//! resolved by registry order, which is stable and therefore deterministic.
+
+use std::{
+    fmt,
+    path::{Path, PathBuf},
+    sync::OnceLock,
+};
+
+use serde_json::Value;
+
+use crate::{AnyModel, error::ModelError};
+
+/// Maximum accepted `config.json` size (10 MiB).
+pub const MAX_CONFIG_SIZE: u64 = 10 * 1024 * 1024;
+
+/// A broad model family, independent of checkpoint naming revisions.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ModelFamily {
+    Qwen,
+    Gemma,
+    Llama,
+    Mistral,
+    Phi,
+    Starcoder,
+    DeepSeek,
+    Llava,
+    Other(String),
+}
+
+impl fmt::Display for ModelFamily {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Qwen => f.write_str("Qwen"),
+            Self::Gemma => f.write_str("Gemma"),
+            Self::Llama => f.write_str("Llama"),
+            Self::Mistral => f.write_str("Mistral"),
+            Self::Phi => f.write_str("Phi"),
+            Self::Starcoder => f.write_str("Starcoder"),
+            Self::DeepSeek => f.write_str("DeepSeek"),
+            Self::Llava => f.write_str("Llava"),
+            Self::Other(name) => f.write_str(name),
+        }
+    }
+}
+
+/// Numeric family version parsed from a checkpoint's effective model type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ModelVersion {
+    pub major: u32,
+    pub minor: u32,
+}
+
+impl fmt::Display for ModelVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}", self.major, self.minor)
+    }
+}
+
+/// A config parsed once for adapter resolution and loading.
+#[derive(Debug, Clone)]
+pub struct DetectedModel {
+    /// Effective text model type.
+    pub model_type: String,
+    /// Top-level wrapper model type when `text_config` was selected.
+    pub wrapper_model_type: Option<String>,
+    pub architectures: Vec<String>,
+    pub family: ModelFamily,
+    pub version: Option<ModelVersion>,
+    /// Original, unmodified top-level configuration.
+    pub raw: Value,
+    pub dir: PathBuf,
+}
+
+impl DetectedModel {
+    /// The config object consumed by the effective text loader.
+    #[must_use]
+    pub fn resolved_config(&self) -> &Value {
+        if self.wrapper_model_type.is_some() {
+            self.raw.get("text_config").unwrap_or(&self.raw)
+        } else {
+            &self.raw
+        }
+    }
+}
+
+/// Statically knowable capabilities of an adapter's current implementation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct Capabilities {
+    pub vision: bool,
+    pub mtp: bool,
+    pub moe: bool,
+    pub mla_latent_cache: bool,
+    pub batch_engine: bool,
+}
+
+/// Human-facing adapter metadata.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AdapterInfo {
+    pub id: &'static str,
+    pub family: ModelFamily,
+    pub version_range: String,
+    pub capabilities: Capabilities,
+    pub notes: &'static str,
+}
+
+/// Uniform model-family routing and loading interface.
+pub trait ModelAdapter: Send + Sync {
+    fn id(&self) -> &'static str;
+    fn family(&self) -> ModelFamily;
+    fn describe(&self) -> AdapterInfo;
+    fn match_score(&self, model: &DetectedModel) -> Option<u32>;
+    fn load(&self, model: &DetectedModel) -> Result<AnyModel, ModelError>;
+}
+
+#[derive(Clone, Copy)]
+enum LoadKind {
+    Transformer,
+    Bonsai,
+    Qwen3Next,
+    Qwen35Dense,
+    Qwen35Moe,
+    Qwen3Moe,
+    Gemma2,
+    Gemma3,
+    Gemma4,
+    Phi3,
+    Starcoder2,
+    LlavaQwen2,
+    DeepSeekV2,
+}
+
+struct BuiltinAdapter {
+    id: &'static str,
+    family: fn() -> ModelFamily,
+    version_range: &'static str,
+    capabilities: Capabilities,
+    notes: &'static str,
+    kind: LoadKind,
+}
+
+#[allow(clippy::fn_params_excessive_bools)]
+const fn caps(
+    vision: bool,
+    mtp: bool,
+    moe: bool,
+    mla_latent_cache: bool,
+    batch_engine: bool,
+) -> Capabilities {
+    Capabilities {
+        vision,
+        mtp,
+        moe,
+        mla_latent_cache,
+        batch_engine,
+    }
+}
+
+const fn qwen() -> ModelFamily {
+    ModelFamily::Qwen
+}
+const fn gemma() -> ModelFamily {
+    ModelFamily::Gemma
+}
+const fn phi() -> ModelFamily {
+    ModelFamily::Phi
+}
+const fn starcoder() -> ModelFamily {
+    ModelFamily::Starcoder
+}
+const fn deepseek() -> ModelFamily {
+    ModelFamily::DeepSeek
+}
+const fn llava() -> ModelFamily {
+    ModelFamily::Llava
+}
+
+static TRANSFORMER_DENSE: BuiltinAdapter = BuiltinAdapter {
+    id: "transformer-dense",
+    family: qwen,
+    version_range: "Qwen 2-3; Llama; Mistral",
+    capabilities: caps(false, false, false, false, true),
+    notes: "Dense transformer engine for Qwen2/Qwen3, Llama, and Mistral",
+    kind: LoadKind::Transformer,
+};
+static BONSAI_Q1: BuiltinAdapter = BuiltinAdapter {
+    id: "bonsai-q1-packed",
+    family: qwen,
+    version_range: "Qwen 3.0 (Bonsai 1-bit)",
+    capabilities: caps(false, false, false, false, false),
+    notes: "Packed 1.25-bpw Bonsai-Q1 checkpoints",
+    kind: LoadKind::Bonsai,
+};
+static QWEN3_NEXT: BuiltinAdapter = BuiltinAdapter {
+    id: "qwen3-next",
+    family: qwen,
+    version_range: "Qwen 3 Next",
+    capabilities: caps(false, true, true, false, false),
+    notes: "Hybrid attention/GDN Qwen3-Next",
+    kind: LoadKind::Qwen3Next,
+};
+static QWEN35_DENSE: BuiltinAdapter = BuiltinAdapter {
+    id: "qwen3.5-dense",
+    family: qwen,
+    version_range: "Qwen 3.5+ dense",
+    capabilities: caps(false, true, false, false, false),
+    notes: "Qwen3.5 text backbone, including structurally compatible newer revisions",
+    kind: LoadKind::Qwen35Dense,
+};
+static QWEN35_MOE: BuiltinAdapter = BuiltinAdapter {
+    id: "qwen3.5-moe",
+    family: qwen,
+    version_range: "Qwen 3.5+ MoE",
+    capabilities: caps(false, true, true, false, false),
+    notes: "Qwen3.5 MoE text backbone, including structurally compatible newer revisions",
+    kind: LoadKind::Qwen35Moe,
+};
+static QWEN3_MOE: BuiltinAdapter = BuiltinAdapter {
+    id: "qwen3-moe",
+    family: qwen,
+    version_range: "Qwen 3.0 MoE",
+    capabilities: caps(false, false, true, false, false),
+    notes: "Qwen3 sparse MoE",
+    kind: LoadKind::Qwen3Moe,
+};
+static GEMMA2: BuiltinAdapter = BuiltinAdapter {
+    id: "gemma2",
+    family: gemma,
+    version_range: "Gemma 2.x",
+    capabilities: caps(false, false, false, false, false),
+    notes: "Gemma 2 text model",
+    kind: LoadKind::Gemma2,
+};
+static GEMMA3: BuiltinAdapter = BuiltinAdapter {
+    id: "gemma3-text",
+    family: gemma,
+    version_range: "Gemma 3+ text",
+    capabilities: caps(false, false, false, false, false),
+    notes: "Gemma 3 text backbone",
+    kind: LoadKind::Gemma3,
+};
+static GEMMA4: BuiltinAdapter = BuiltinAdapter {
+    id: "gemma4-text",
+    family: gemma,
+    version_range: "Gemma 4+ text/unified",
+    capabilities: caps(false, false, true, false, false),
+    notes: "Gemma 4 text backbone with optional MoE",
+    kind: LoadKind::Gemma4,
+};
+static PHI3: BuiltinAdapter = BuiltinAdapter {
+    id: "phi3",
+    family: phi,
+    version_range: "Phi 3.x",
+    capabilities: caps(false, false, false, false, false),
+    notes: "Phi-3",
+    kind: LoadKind::Phi3,
+};
+static STARCODER2: BuiltinAdapter = BuiltinAdapter {
+    id: "starcoder2",
+    family: starcoder,
+    version_range: "Starcoder 2.x",
+    capabilities: caps(false, false, false, false, false),
+    notes: "Starcoder2",
+    kind: LoadKind::Starcoder2,
+};
+static LLAVA_QWEN2: BuiltinAdapter = BuiltinAdapter {
+    id: "llava-qwen2",
+    family: llava,
+    version_range: "LLaVA-Qwen2",
+    capabilities: caps(true, false, false, false, false),
+    notes: "LLaVA vision-language model with Qwen2 text",
+    kind: LoadKind::LlavaQwen2,
+};
+static DEEPSEEK_V2: BuiltinAdapter = BuiltinAdapter {
+    id: "deepseek-v2",
+    family: deepseek,
+    version_range: "DeepSeek 2.x",
+    capabilities: caps(false, false, true, true, false),
+    notes: "DeepSeek-V2 MLA/MoE",
+    kind: LoadKind::DeepSeekV2,
+};
+
+static ADAPTERS: [&'static dyn ModelAdapter; 13] = [
+    &BONSAI_Q1,
+    &QWEN35_MOE,
+    &QWEN35_DENSE,
+    &QWEN3_NEXT,
+    &QWEN3_MOE,
+    &GEMMA4,
+    &GEMMA3,
+    &GEMMA2,
+    &PHI3,
+    &STARCODER2,
+    &LLAVA_QWEN2,
+    &DEEPSEEK_V2,
+    &TRANSFORMER_DENSE,
+];
+
+static BUILTINS: [&BuiltinAdapter; 13] = [
+    &BONSAI_Q1,
+    &QWEN35_MOE,
+    &QWEN35_DENSE,
+    &QWEN3_NEXT,
+    &QWEN3_MOE,
+    &GEMMA4,
+    &GEMMA3,
+    &GEMMA2,
+    &PHI3,
+    &STARCODER2,
+    &LLAVA_QWEN2,
+    &DEEPSEEK_V2,
+    &TRANSFORMER_DENSE,
+];
+
+impl BuiltinAdapter {
+    fn is_exact(&self, model_type: &str) -> bool {
+        match self.kind {
+            LoadKind::Transformer => matches!(model_type, "qwen2" | "qwen3" | "llama" | "mistral"),
+            LoadKind::Bonsai => model_type == "qwen3",
+            LoadKind::Qwen3Next => model_type == "qwen3_next",
+            LoadKind::Qwen35Dense => model_type == "qwen3_5",
+            LoadKind::Qwen35Moe => model_type == "qwen3_5_moe",
+            LoadKind::Qwen3Moe => model_type == "qwen3_moe",
+            LoadKind::Gemma2 => model_type == "gemma2",
+            LoadKind::Gemma3 => matches!(model_type, "gemma3" | "gemma3_text"),
+            LoadKind::Gemma4 => matches!(model_type, "gemma4" | "gemma4_text" | "gemma4_unified"),
+            LoadKind::Phi3 => model_type == "phi3",
+            LoadKind::Starcoder2 => model_type == "starcoder2",
+            LoadKind::LlavaQwen2 => model_type == "llava-qwen2",
+            LoadKind::DeepSeekV2 => model_type == "deepseek_v2",
+        }
+    }
+
+    fn tolerant_match(&self, model: &DetectedModel) -> bool {
+        match self.kind {
+            LoadKind::Qwen35Dense => {
+                qwen_revision(&model.model_type).is_some_and(|(minor, moe)| minor >= 5 && !moe)
+            }
+            LoadKind::Qwen35Moe => {
+                qwen_revision(&model.model_type).is_some_and(|(minor, moe)| minor >= 5 && moe)
+            }
+            LoadKind::Gemma3 => gemma_revision(&model.model_type).is_some_and(|major| major >= 3),
+            LoadKind::Gemma4 => gemma_revision(&model.model_type).is_some_and(|major| major >= 4),
+            LoadKind::Transformer
+            | LoadKind::Bonsai
+            | LoadKind::Qwen3Next
+            | LoadKind::Qwen3Moe
+            | LoadKind::Gemma2
+            | LoadKind::Phi3
+            | LoadKind::Starcoder2
+            | LoadKind::LlavaQwen2
+            | LoadKind::DeepSeekV2 => false,
+        }
+    }
+
+    fn validate_tolerant(&self, model: &DetectedModel) -> Result<(), ModelError> {
+        if self.is_exact(&model.model_type) {
+            return Ok(());
+        }
+        let config = model.resolved_config();
+        let common_integer_fields = [
+            "hidden_size",
+            "num_hidden_layers",
+            "num_attention_heads",
+            "num_key_value_heads",
+            "vocab_size",
+        ];
+        let qwen_integer_fields = [
+            "intermediate_size",
+            "head_dim",
+            "max_position_embeddings",
+            "linear_num_value_heads",
+            "linear_num_key_heads",
+            "linear_key_head_dim",
+            "linear_value_head_dim",
+            "linear_conv_kernel_dim",
+        ];
+        let moe_integer_fields = [
+            "num_experts",
+            "num_experts_per_tok",
+            "shared_expert_intermediate_size",
+            "moe_intermediate_size",
+        ];
+        let required_integers = common_integer_fields
+            .iter()
+            .chain(
+                matches!(self.kind, LoadKind::Qwen35Dense | LoadKind::Qwen35Moe)
+                    .then_some(qwen_integer_fields.iter())
+                    .into_iter()
+                    .flatten(),
+            )
+            .chain(
+                matches!(self.kind, LoadKind::Qwen35Moe)
+                    .then_some(moe_integer_fields.iter())
+                    .into_iter()
+                    .flatten(),
+            );
+        let mut invalid = required_integers
+            .into_iter()
+            .filter(|field| {
+                config
+                    .get(*field)
+                    .and_then(Value::as_i64)
+                    .is_none_or(|value| value <= 0)
+            })
+            .copied()
+            .collect::<Vec<_>>();
+        if matches!(self.kind, LoadKind::Qwen35Dense | LoadKind::Qwen35Moe)
+            && config
+                .get("rms_norm_eps")
+                .and_then(Value::as_f64)
+                .is_none_or(|value| !value.is_finite() || value <= 0.0)
+        {
+            invalid.push("rms_norm_eps");
+        }
+        if invalid.is_empty() {
+            Ok(())
+        } else {
+            Err(ModelError::UnsupportedModel(format!(
+                "untested model type '{}' is not structurally compatible with adapter '{}': missing or invalid field(s): {}",
+                model.model_type,
+                self.id,
+                invalid.join(", ")
+            )))
+        }
+    }
+}
+
+impl ModelAdapter for BuiltinAdapter {
+    fn id(&self) -> &'static str {
+        self.id
+    }
+    fn family(&self) -> ModelFamily {
+        (self.family)()
+    }
+    fn describe(&self) -> AdapterInfo {
+        AdapterInfo {
+            id: self.id,
+            family: self.family(),
+            version_range: self.version_range.to_owned(),
+            capabilities: self.capabilities,
+            notes: self.notes,
+        }
+    }
+    fn match_score(&self, model: &DetectedModel) -> Option<u32> {
+        if matches!(self.kind, LoadKind::Bonsai) {
+            let group_size = u64::try_from(crate::bonsai_q1::GROUP_SIZE).ok()?;
+            let quantization = model.raw.get("quantization")?;
+            return (model.model_type == "qwen3"
+                && quantization.get("bits").and_then(Value::as_u64) == Some(1)
+                && quantization.get("group_size").and_then(Value::as_u64) == Some(group_size))
+            .then_some(2_000);
+        }
+        if self.is_exact(&model.model_type) {
+            Some(1_000)
+        } else if self.tolerant_match(model) {
+            Some(if matches!(self.kind, LoadKind::Gemma4) {
+                120
+            } else {
+                100
+            })
+        } else {
+            None
+        }
+    }
+    fn load(&self, model: &DetectedModel) -> Result<AnyModel, ModelError> {
+        self.validate_tolerant(model)?;
+        if !self.is_exact(&model.model_type) {
+            tracing::warn!(model_type = %model.model_type, adapter = self.id, "loading an untested model version through a structurally compatible adapter");
+        }
+        let dir = &model.dir;
+        match self.kind {
+            LoadKind::Transformer => {
+                crate::transformer::model_args_from_value(model.resolved_config())
+                    .and_then(|args| crate::transformer::load_model_with_args(dir, args))
+                    .map(AnyModel::Transformer)
+            }
+            LoadKind::Bonsai => crate::bonsai_q1::load_bonsai_q1_with_config(dir, &model.raw)
+                .map(AnyModel::BonsaiQ1),
+            LoadKind::Qwen3Next => {
+                crate::qwen3_next::load_qwen3_next_args_from_value(model.resolved_config().clone())
+                    .and_then(|args| crate::qwen3_next::load_qwen3_next_model_with_args(dir, args))
+                    .map(AnyModel::Qwen3Next)
+            }
+            LoadKind::Qwen35Dense => qwen35_args(model)
+                .and_then(|args| crate::qwen3_next::load_qwen3_5_model_with_args(dir, args))
+                .map(AnyModel::Qwen3Next),
+            LoadKind::Qwen35Moe => qwen35_args(model)
+                .and_then(|args| crate::qwen3_next::load_qwen3_5_moe_model_with_args(dir, args))
+                .map(AnyModel::Qwen3Next),
+            LoadKind::Qwen3Moe => serde_json::from_value(model.resolved_config().clone())
+                .map_err(ModelError::Json)
+                .and_then(|args| crate::qwen3_moe::load_qwen3_moe_model_with_args(dir, args))
+                .map(AnyModel::Qwen3Moe),
+            LoadKind::Gemma2 => serde_json::from_value(model.resolved_config().clone())
+                .map_err(ModelError::Json)
+                .and_then(|args| crate::gemma2::load_gemma2_model_with_args(dir, args))
+                .map(AnyModel::Gemma2),
+            LoadKind::Gemma3 => crate::gemma3::gemma3_model_args_from_value(model.raw.clone())
+                .and_then(|args| crate::gemma3::load_gemma3_model_with_args(dir, args))
+                .map(AnyModel::Gemma3),
+            LoadKind::Gemma4 => crate::gemma4::gemma4_model_args_from_value(model.raw.clone())
+                .and_then(|args| crate::gemma4::load_gemma4_model_with_args(dir, args))
+                .map(AnyModel::Gemma4),
+            LoadKind::Phi3 => serde_json::from_value(model.resolved_config().clone())
+                .map_err(ModelError::Json)
+                .and_then(|args| crate::phi3::load_phi3_model_with_args(dir, args))
+                .map(AnyModel::Phi3),
+            LoadKind::Starcoder2 => serde_json::from_value(model.resolved_config().clone())
+                .map_err(ModelError::Json)
+                .and_then(|args| crate::starcoder2::load_starcoder2_model_with_args(dir, args))
+                .map(AnyModel::Starcoder2),
+            LoadKind::LlavaQwen2 => {
+                crate::llava_qwen2::load_llava_qwen2_model_from_value(dir, &model.raw)
+                    .map(AnyModel::LlavaQwen2)
+            }
+            LoadKind::DeepSeekV2 => serde_json::from_value(model.resolved_config().clone())
+                .map_err(ModelError::Json)
+                .and_then(|args| crate::deepseek_v2::load_deepseek_v2_model_with_args(dir, args))
+                .map(AnyModel::DeepSeekV2),
+        }
+    }
+}
+
+fn qwen35_args(model: &DetectedModel) -> Result<crate::qwen3_next::Qwen3NextModelArgs, ModelError> {
+    if model.raw.get("text_config").is_some() {
+        crate::qwen3_next::load_qwen3_5_text_config_args_from_value(&model.raw)
+    } else {
+        let wrapped = serde_json::json!({ "text_config": model.raw.clone() });
+        crate::qwen3_next::load_qwen3_5_text_config_args_from_value(&wrapped)
+    }
+}
+
+/// The process-wide ordered adapter registry.
+#[must_use]
+pub fn registry() -> &'static [&'static dyn ModelAdapter] {
+    static REGISTRY: OnceLock<&'static [&'static dyn ModelAdapter]> = OnceLock::new();
+    REGISTRY.get_or_init(|| &ADAPTERS)
+}
+
+/// Parse and classify a checkpoint's `config.json` once.
+pub fn detect(dir: &Path) -> Result<DetectedModel, ModelError> {
+    let path = dir.join("config.json");
+    let file = std::fs::File::open(path)?;
+    let size = file.metadata()?.len();
+    if size > MAX_CONFIG_SIZE {
+        return Err(ModelError::UnsupportedModel(format!(
+            "config.json too large ({size} bytes, max {MAX_CONFIG_SIZE})"
+        )));
+    }
+    let raw: Value = serde_json::from_reader(file)?;
+    let top_model_type = raw
+        .get("model_type")
+        .and_then(Value::as_str)
+        .ok_or_else(|| ModelError::UnsupportedModel("missing model_type in config.json".into()))?;
+    let architectures = raw
+        .get("architectures")
+        .and_then(Value::as_array)
+        .map_or_else(Vec::new, |values| {
+            values
+                .iter()
+                .filter_map(Value::as_str)
+                .map(ToOwned::to_owned)
+                .collect()
+        });
+    let is_wrapper = architectures
+        .iter()
+        .any(|name| name.ends_with("ForConditionalGeneration"));
+    let nested_type = raw
+        .get("text_config")
+        .and_then(|value| value.get("model_type"))
+        .and_then(Value::as_str);
+    let (model_type, wrapper_model_type) = if is_wrapper {
+        nested_type.map_or_else(
+            || (top_model_type.to_owned(), None),
+            |nested| (nested.to_owned(), Some(top_model_type.to_owned())),
+        )
+    } else {
+        (top_model_type.to_owned(), None)
+    };
+    let (family, version) = classify(&model_type);
+    Ok(DetectedModel {
+        model_type,
+        wrapper_model_type,
+        architectures,
+        family,
+        version,
+        raw,
+        dir: dir.to_path_buf(),
+    })
+}
+
+/// Resolve the most-specific adapter, validating structural compatibility for
+/// version-tolerant matches.
+pub fn resolve(model: &DetectedModel) -> Result<&'static dyn ModelAdapter, ModelError> {
+    let selected = registry()
+        .iter()
+        .enumerate()
+        .filter_map(|(index, adapter)| {
+            adapter
+                .match_score(model)
+                .map(|score| (score, std::cmp::Reverse(index), *adapter))
+        })
+        .max_by_key(|(score, index, _)| (*score, *index))
+        .map(|(_, _, adapter)| adapter);
+    let Some(adapter) = selected else {
+        return Err(unsupported_error(&model.model_type));
+    };
+    // Keep validation in resolve so callers that only inspect a checkpoint
+    // still receive structural errors before attempting to load weights.
+    let Some(concrete) = BUILTINS
+        .iter()
+        .find(|candidate| candidate.id == adapter.id())
+    else {
+        return Err(ModelError::UnsupportedModel(format!(
+            "internal adapter registry mismatch for '{}'",
+            adapter.id()
+        )));
+    };
+    concrete.validate_tolerant(model)?;
+    Ok(adapter)
+}
+
+/// Metadata for every registered adapter, in deterministic resolution order.
+#[must_use]
+pub fn supported() -> Vec<AdapterInfo> {
+    registry()
+        .iter()
+        .map(|adapter| adapter.describe())
+        .collect()
+}
+
+/// Whether resolution selected a structurally gated, not-exactly-known version.
+#[must_use]
+pub fn is_untested_version(adapter: &dyn ModelAdapter, model: &DetectedModel) -> bool {
+    !is_exact_supported_by(adapter.id(), &model.model_type)
+}
+
+/// Exact-string compatibility used by the legacy registry facade.
+#[must_use]
+pub fn is_exact_supported(model_type: &str) -> bool {
+    BUILTINS.iter().any(|adapter| adapter.is_exact(model_type))
+}
+
+fn is_exact_supported_by(adapter_id: &str, model_type: &str) -> bool {
+    BUILTINS
+        .iter()
+        .any(|adapter| adapter.id == adapter_id && adapter.is_exact(model_type))
+}
+
+fn unsupported_error(model_type: &str) -> ModelError {
+    let ranges = supported()
+        .into_iter()
+        .map(|info| format!("{} ({})", info.family, info.version_range))
+        .collect::<Vec<_>>()
+        .join(", ");
+    ModelError::UnsupportedModel(format!(
+        "{model_type}; supported families/version ranges: {ranges}"
+    ))
+}
+
+fn qwen_revision(model_type: &str) -> Option<(u32, bool)> {
+    let rest = model_type.strip_prefix("qwen3_")?;
+    let (minor_text, suffix) = rest
+        .split_once('_')
+        .map_or((rest, None), |(minor, suffix)| (minor, Some(suffix)));
+    let minor = minor_text.parse().ok()?;
+    match suffix {
+        None => Some((minor, false)),
+        Some("moe") => Some((minor, true)),
+        Some(_) => None,
+    }
+}
+
+fn gemma_revision(model_type: &str) -> Option<u32> {
+    let rest = model_type.strip_prefix("gemma")?;
+    let (major, suffix) = rest
+        .split_once('_')
+        .map_or((rest, None), |(major, suffix)| (major, Some(suffix)));
+    if suffix.is_some_and(|value| !matches!(value, "text" | "unified")) {
+        return None;
+    }
+    major.parse().ok()
+}
+
+fn classify(model_type: &str) -> (ModelFamily, Option<ModelVersion>) {
+    if model_type.starts_with("llava") {
+        return (ModelFamily::Llava, number_after(model_type, "llava-qwen"));
+    }
+    if model_type.starts_with("qwen") {
+        return (ModelFamily::Qwen, number_after(model_type, "qwen"));
+    }
+    if model_type.starts_with("gemma") {
+        return (ModelFamily::Gemma, number_after(model_type, "gemma"));
+    }
+    if model_type.starts_with("llama") {
+        return (ModelFamily::Llama, number_after(model_type, "llama"));
+    }
+    if model_type.starts_with("mistral") {
+        return (ModelFamily::Mistral, number_after(model_type, "mistral"));
+    }
+    if model_type.starts_with("phi") {
+        return (ModelFamily::Phi, number_after(model_type, "phi"));
+    }
+    if model_type.starts_with("starcoder") {
+        return (
+            ModelFamily::Starcoder,
+            number_after(model_type, "starcoder"),
+        );
+    }
+    if model_type.starts_with("deepseek") {
+        return (
+            ModelFamily::DeepSeek,
+            number_after(model_type, "deepseek_v"),
+        );
+    }
+    (
+        ModelFamily::Other(
+            model_type
+                .split(['_', '-'])
+                .next()
+                .unwrap_or(model_type)
+                .to_owned(),
+        ),
+        None,
+    )
+}
+
+fn number_after(model_type: &str, prefix: &str) -> Option<ModelVersion> {
+    let rest = model_type.strip_prefix(prefix)?;
+    let mut parts = rest.trim_start_matches(['_', '-']).split(['_', '-']);
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next().and_then(|part| part.parse().ok()).unwrap_or(0);
+    Some(ModelVersion { major, minor })
+}

--- a/crates/higgs-models/src/bonsai_q1.rs
+++ b/crates/higgs-models/src/bonsai_q1.rs
@@ -65,6 +65,15 @@ pub fn load_bonsai_q1<P: AsRef<Path>>(model_dir: P) -> Result<BonsaiQ1Gpu, Model
     engine.to_gpu().map_err(ModelError::Mlx)
 }
 
+pub(crate) fn load_bonsai_q1_with_config(
+    model_dir: &Path,
+    config: &serde_json::Value,
+) -> Result<BonsaiQ1Gpu, ModelError> {
+    let engine =
+        BonsaiQ1Engine::load_with_config(model_dir, config).map_err(ModelError::ShapeMismatch)?;
+    engine.to_gpu().map_err(ModelError::Mlx)
+}
+
 pub const GROUP_SIZE: usize = 128;
 const GROUP_SIZE_I32: i32 = GROUP_SIZE as i32;
 
@@ -192,12 +201,14 @@ impl BonsaiQ1Engine {
     #[allow(clippy::too_many_lines)]
     pub fn load<P: AsRef<Path>>(model_dir: P) -> Result<Self, String> {
         let dir = model_dir.as_ref();
-
         let cfg_txt = std::fs::read_to_string(dir.join("config.json"))
             .map_err(|e| format!("config.json: {e}"))?;
         let cfg: serde_json::Value =
             serde_json::from_str(&cfg_txt).map_err(|e| format!("config.json parse: {e}"))?;
+        Self::load_with_config(dir, &cfg)
+    }
 
+    fn load_with_config(dir: &Path, cfg: &serde_json::Value) -> Result<Self, String> {
         let u64_of = |k: &str| -> Result<u64, String> {
             cfg[k]
                 .as_u64()

--- a/crates/higgs-models/src/deepseek_v2.rs
+++ b/crates/higgs-models/src/deepseek_v2.rs
@@ -1230,7 +1230,13 @@ pub fn load_deepseek_v2_model<P: AsRef<Path>>(
 ) -> Result<DeepSeekV2CausalLM, ModelError> {
     let model_path = model_dir.as_ref();
     let args = load_model_args(model_path)?;
+    load_deepseek_v2_model_with_args(model_path, args)
+}
 
+pub(crate) fn load_deepseek_v2_model_with_args(
+    model_path: &Path,
+    args: DeepSeekV2ModelArgs,
+) -> Result<DeepSeekV2CausalLM, ModelError> {
     tracing::info!(
         model_type = %args.model_type,
         hidden_size = args.hidden_size,
@@ -1244,9 +1250,15 @@ pub fn load_deepseek_v2_model<P: AsRef<Path>>(
         "Loading deepseek_v2 model"
     );
 
+    let quantization = args.quantization.clone();
     let mut model = DeepSeekV2CausalLM::new(args)?;
 
-    crate::load_safetensors_weights(&mut model, model_path)?;
+    crate::load_quantized_safetensors_weights_with_settings(
+        &mut model,
+        model_path,
+        false,
+        quantization.as_ref(),
+    )?;
 
     tracing::info!("DeepSeek-V2 model loaded successfully");
     Ok(model)

--- a/crates/higgs-models/src/gemma2.rs
+++ b/crates/higgs-models/src/gemma2.rs
@@ -912,7 +912,13 @@ pub fn load_gemma2_model_args<P: AsRef<Path>>(model_dir: P) -> Result<Gemma2Mode
 pub fn load_gemma2_model<P: AsRef<Path>>(model_dir: P) -> Result<Gemma2CausalLM, ModelError> {
     let model_path = model_dir.as_ref();
     let args = load_gemma2_model_args(model_path)?;
+    load_gemma2_model_with_args(model_path, args)
+}
 
+pub(crate) fn load_gemma2_model_with_args(
+    model_path: &Path,
+    args: Gemma2ModelArgs,
+) -> Result<Gemma2CausalLM, ModelError> {
     tracing::info!(
         model_type = %args.model_type,
         hidden_size = args.hidden_size,
@@ -945,7 +951,12 @@ pub fn load_gemma2_model<P: AsRef<Path>>(model_dir: P) -> Result<Gemma2CausalLM,
         raw_model
     };
 
-    crate::load_quantized_safetensors_weights(&mut model, model_path, quantization.is_some())?;
+    crate::load_quantized_safetensors_weights_with_settings(
+        &mut model,
+        model_path,
+        quantization.is_some(),
+        quantization.as_ref(),
+    )?;
 
     // Apply RMSNorm +1 convention: add 1.0 to all norm weights
     apply_rmsnorm_plus_one(&mut model)

--- a/crates/higgs-models/src/gemma3.rs
+++ b/crates/higgs-models/src/gemma3.rs
@@ -766,12 +766,17 @@ struct Gemma3TopLevel {
 /// `text_config`-wrapped layouts.
 pub fn load_gemma3_model_args<P: AsRef<Path>>(model_dir: P) -> Result<Gemma3ModelArgs, ModelError> {
     let config_path = model_dir.as_ref().join("config.json");
-    let text = std::fs::read_to_string(config_path)?;
-    let raw: serde_json::Value = serde_json::from_str(&text)?;
+    let file = std::fs::File::open(config_path)?;
+    let raw: serde_json::Value = serde_json::from_reader(file)?;
+    gemma3_model_args_from_value(raw)
+}
 
+pub(crate) fn gemma3_model_args_from_value(
+    raw: serde_json::Value,
+) -> Result<Gemma3ModelArgs, ModelError> {
     // Detect wrapping: if a `text_config` object exists, deserialize from it
     // and take `model_type` from the top level when absent.
-    let top: Gemma3TopLevel = serde_json::from_str(&text)?;
+    let top: Gemma3TopLevel = serde_json::from_value(raw.clone())?;
 
     let mut args: Gemma3ModelArgs = if let Some(inner) = top.text_config {
         let mut a: Gemma3ModelArgs = serde_json::from_value(inner)?;
@@ -804,8 +809,14 @@ pub fn load_gemma3_model_args<P: AsRef<Path>>(model_dir: P) -> Result<Gemma3Mode
 /// path contains "norm" after the safetensors weights are loaded.
 pub fn load_gemma3_model<P: AsRef<Path>>(model_dir: P) -> Result<Gemma3CausalLM, ModelError> {
     let model_path = model_dir.as_ref();
-    let mut args = load_gemma3_model_args(model_path)?;
+    let args = load_gemma3_model_args(model_path)?;
+    load_gemma3_model_with_args(model_path, args)
+}
 
+pub(crate) fn load_gemma3_model_with_args(
+    model_path: &Path,
+    mut args: Gemma3ModelArgs,
+) -> Result<Gemma3CausalLM, ModelError> {
     // HF Gemma 3 text configs omit `tie_word_embeddings`; MLX checkpoints that ship
     // a separate (often separately-quantized) `lm_head` are untied. Honor the
     // checkpoint — reusing the tied embedding as the output projection corrupts
@@ -849,11 +860,12 @@ pub fn load_gemma3_model<P: AsRef<Path>>(model_dir: P) -> Result<Gemma3CausalLM,
     // Multimodal `gemma3` checkpoints nest the text model under `language_model.`
     // (alongside a vision tower); text-only `gemma3_text` checkpoints start at
     // `model.`. Strip the prefix when present so both load, skipping vision weights.
-    crate::load_quantized_safetensors_weights_optional_prefix(
+    crate::load_quantized_safetensors_weights_optional_prefix_with_settings(
         &mut model,
         model_path,
         quantization.is_some(),
         "language_model.",
+        quantization.as_ref(),
     )?;
 
     // Apply RMSNorm +1 convention — Gemma 3 uses the same shifted-weight storage

--- a/crates/higgs-models/src/gemma4.rs
+++ b/crates/higgs-models/src/gemma4.rs
@@ -1542,9 +1542,15 @@ struct Gemma4TopLevel {
 /// Supports both flat and `text_config`-wrapped HF config formats.
 pub fn load_gemma4_model_args<P: AsRef<Path>>(model_dir: P) -> Result<Gemma4ModelArgs, ModelError> {
     let config_path = model_dir.as_ref().join("config.json");
-    let text = std::fs::read_to_string(config_path)?;
-    let raw: serde_json::Value = serde_json::from_str(&text)?;
-    let top: Gemma4TopLevel = serde_json::from_str(&text)?;
+    let file = std::fs::File::open(config_path)?;
+    let raw: serde_json::Value = serde_json::from_reader(file)?;
+    gemma4_model_args_from_value(raw)
+}
+
+pub(crate) fn gemma4_model_args_from_value(
+    raw: serde_json::Value,
+) -> Result<Gemma4ModelArgs, ModelError> {
+    let top: Gemma4TopLevel = serde_json::from_value(raw.clone())?;
 
     let mut args: Gemma4ModelArgs = if let Some(inner) = top.text_config {
         let mut a: Gemma4ModelArgs = serde_json::from_value(inner)?;
@@ -1574,7 +1580,13 @@ pub fn load_gemma4_model_args<P: AsRef<Path>>(model_dir: P) -> Result<Gemma4Mode
 pub fn load_gemma4_model<P: AsRef<Path>>(model_dir: P) -> Result<Gemma4CausalLM, ModelError> {
     let model_path = model_dir.as_ref();
     let args = load_gemma4_model_args(model_path)?;
+    load_gemma4_model_with_args(model_path, args)
+}
 
+pub(crate) fn load_gemma4_model_with_args(
+    model_path: &Path,
+    args: Gemma4ModelArgs,
+) -> Result<Gemma4CausalLM, ModelError> {
     tracing::info!(
         model_type = %args.model_type,
         hidden_size = args.hidden_size,
@@ -1609,11 +1621,12 @@ pub fn load_gemma4_model<P: AsRef<Path>>(model_dir: P) -> Result<Gemma4CausalLM,
     // `gemma4` (multimodal wrapper) checkpoints nest the text model under
     // `language_model.`; `gemma4_text` checkpoints start at `model.`. Strip the
     // prefix when present so both load, and skip the vision/audio tower weights.
-    crate::load_quantized_safetensors_weights_optional_prefix(
+    crate::load_quantized_safetensors_weights_optional_prefix_with_settings(
         &mut model,
         model_path,
         quantization.is_some(),
         "language_model.",
+        quantization.as_ref(),
     )?;
 
     if enable_moe {

--- a/crates/higgs-models/src/lib.rs
+++ b/crates/higgs-models/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod adapter;
 pub mod bonsai_q1;
 pub mod cache;
 pub mod deepseek_v2;
@@ -1328,8 +1329,22 @@ pub fn load_quantized_safetensors_weights<M: ModuleParametersExt>(
     model_path: &Path,
     quantized: bool,
 ) -> Result<(), ModelError> {
-    let safetensors_files = collect_safetensors_files(model_path)?;
     let quantization = load_checkpoint_quantization_settings(model_path)?;
+    load_quantized_safetensors_weights_with_settings(
+        model,
+        model_path,
+        quantized,
+        quantization.as_ref(),
+    )
+}
+
+pub(crate) fn load_quantized_safetensors_weights_with_settings<M: ModuleParametersExt>(
+    model: &mut M,
+    model_path: &Path,
+    quantized: bool,
+    quantization: Option<&quant_config::QuantizationSettings>,
+) -> Result<(), ModelError> {
+    let safetensors_files = collect_safetensors_files(model_path)?;
 
     let mut params = model.parameters_mut().flatten();
 
@@ -1337,7 +1352,7 @@ pub fn load_quantized_safetensors_weights<M: ModuleParametersExt>(
         tracing::debug!(file = %file_path.display(), "Loading weights");
         let loaded = Array::load_safetensors(file_path)
             .map_err(|e| ModelError::Io(std::io::Error::other(e.to_string())))?;
-        validate_quantized_tensor_widths(&loaded, quantization.as_ref())?;
+        validate_quantized_tensor_widths(&loaded, quantization)?;
 
         for (key, value) in loaded {
             if let Some(param) = params.get_mut(&*key) {
@@ -1376,9 +1391,27 @@ pub fn load_quantized_safetensors_weights_with_prefix<M: ModuleParametersExt>(
     quantized: bool,
     prefix: &str,
 ) -> Result<(), ModelError> {
+    let quantization = load_checkpoint_quantization_settings(model_path)?;
+    load_quantized_safetensors_weights_with_prefix_and_settings(
+        model,
+        model_path,
+        quantized,
+        prefix,
+        quantization.as_ref(),
+    )
+}
+
+pub(crate) fn load_quantized_safetensors_weights_with_prefix_and_settings<
+    M: ModuleParametersExt,
+>(
+    model: &mut M,
+    model_path: &Path,
+    quantized: bool,
+    prefix: &str,
+    quantization: Option<&quant_config::QuantizationSettings>,
+) -> Result<(), ModelError> {
     const MAX_UNMATCHED_WARNS: usize = 5;
     let safetensors_files = collect_safetensors_files(model_path)?;
-    let quantization = load_checkpoint_quantization_settings(model_path)?;
 
     let mut params = model.parameters_mut().flatten();
 
@@ -1389,7 +1422,7 @@ pub fn load_quantized_safetensors_weights_with_prefix<M: ModuleParametersExt>(
         tracing::debug!(file = %file_path.display(), prefix, "Loading weights with prefix");
         let loaded = Array::load_safetensors(file_path)
             .map_err(|e| ModelError::Io(std::io::Error::other(e.to_string())))?;
-        validate_quantized_tensor_widths(&loaded, quantization.as_ref())?;
+        validate_quantized_tensor_widths(&loaded, quantization)?;
 
         let mut matched = 0usize;
         let mut unmatched = 0usize;
@@ -1456,9 +1489,27 @@ pub fn load_quantized_safetensors_weights_optional_prefix<M: ModuleParametersExt
     quantized: bool,
     optional_prefix: &str,
 ) -> Result<(), ModelError> {
+    let quantization = load_checkpoint_quantization_settings(model_path)?;
+    load_quantized_safetensors_weights_optional_prefix_with_settings(
+        model,
+        model_path,
+        quantized,
+        optional_prefix,
+        quantization.as_ref(),
+    )
+}
+
+pub(crate) fn load_quantized_safetensors_weights_optional_prefix_with_settings<
+    M: ModuleParametersExt,
+>(
+    model: &mut M,
+    model_path: &Path,
+    quantized: bool,
+    optional_prefix: &str,
+    quantization: Option<&quant_config::QuantizationSettings>,
+) -> Result<(), ModelError> {
     const MAX_UNMATCHED_WARNS: usize = 5;
     let safetensors_files = collect_safetensors_files(model_path)?;
-    let quantization = load_checkpoint_quantization_settings(model_path)?;
 
     let mut params = model.parameters_mut().flatten();
     let mut total_matched = 0usize;
@@ -1468,7 +1519,7 @@ pub fn load_quantized_safetensors_weights_optional_prefix<M: ModuleParametersExt
     for file_path in &safetensors_files {
         let loaded = Array::load_safetensors(file_path)
             .map_err(|e| ModelError::Io(std::io::Error::other(e.to_string())))?;
-        validate_quantized_tensor_widths(&loaded, quantization.as_ref())?;
+        validate_quantized_tensor_widths(&loaded, quantization)?;
 
         for (key, value) in loaded {
             let stripped = key.strip_prefix(optional_prefix).unwrap_or(&key);

--- a/crates/higgs-models/src/llava_qwen2.rs
+++ b/crates/higgs-models/src/llava_qwen2.rs
@@ -266,8 +266,23 @@ fn merge_embeddings(
 pub fn load_llava_qwen2_model(model_dir: &Path) -> Result<LlavaQwen2Model, ModelError> {
     let config_path = model_dir.join("config.json");
     let config_str = std::fs::read_to_string(&config_path)?;
-    let config: LlavaQwen2Config = serde_json::from_str(&config_str)?;
+    let raw: serde_json::Value = serde_json::from_str(&config_str)?;
+    load_llava_qwen2_model_from_value(model_dir, &raw)
+}
 
+pub(crate) fn load_llava_qwen2_model_from_value(
+    model_dir: &Path,
+    raw: &serde_json::Value,
+) -> Result<LlavaQwen2Model, ModelError> {
+    let config: LlavaQwen2Config = serde_json::from_value(raw.clone())?;
+    load_llava_qwen2_model_with_config(model_dir, &config, raw)
+}
+
+fn load_llava_qwen2_model_with_config(
+    model_dir: &Path,
+    config: &LlavaQwen2Config,
+    raw: &serde_json::Value,
+) -> Result<LlavaQwen2Model, ModelError> {
     tracing::info!(
         image_size = config.vision_config.image_size,
         vision_layers = config.vision_config.num_hidden_layers,
@@ -285,7 +300,8 @@ pub fn load_llava_qwen2_model(model_dir: &Path) -> Result<LlavaQwen2Model, Model
     let mut mm_projector = MmProjector::new(config.mm_hidden_size, config.hidden_size)?;
 
     // Build language model (reads text_config, strips language_model. prefix)
-    let language_model = transformer::load_vlm_language_model(model_dir)?;
+    let language_args = transformer::text_model_args_from_value(raw)?;
+    let language_model = transformer::load_vlm_language_model_with_args(model_dir, language_args)?;
 
     // Load all safetensor weights for vision and projector
     let weights = load_safetensor_weights(model_dir)?;

--- a/crates/higgs-models/src/phi3.rs
+++ b/crates/higgs-models/src/phi3.rs
@@ -559,7 +559,13 @@ pub fn load_phi3_model_args<P: AsRef<Path>>(model_dir: P) -> Result<Phi3ModelArg
 pub fn load_phi3_model<P: AsRef<Path>>(model_dir: P) -> Result<Phi3CausalLM, ModelError> {
     let model_path = model_dir.as_ref();
     let args = load_phi3_model_args(model_path)?;
+    load_phi3_model_with_args(model_path, args)
+}
 
+pub(crate) fn load_phi3_model_with_args(
+    model_path: &Path,
+    args: Phi3ModelArgs,
+) -> Result<Phi3CausalLM, ModelError> {
     let quantization = args.quantization.clone();
     if let Some(settings) = quantization.as_ref() {
         crate::validate_per_tensor_quantization_support(settings, &[])?;
@@ -590,7 +596,12 @@ pub fn load_phi3_model<P: AsRef<Path>>(model_dir: P) -> Result<Phi3CausalLM, Mod
         raw_model
     };
 
-    crate::load_quantized_safetensors_weights(&mut model, model_path, quantization.is_some())?;
+    crate::load_quantized_safetensors_weights_with_settings(
+        &mut model,
+        model_path,
+        quantization.is_some(),
+        quantization.as_ref(),
+    )?;
 
     tracing::info!("Phi-3 model loaded successfully");
     Ok(model)

--- a/crates/higgs-models/src/qwen3_moe.rs
+++ b/crates/higgs-models/src/qwen3_moe.rs
@@ -587,7 +587,13 @@ pub fn load_model_args<P: AsRef<Path>>(model_dir: P) -> Result<Qwen3MoeModelArgs
 pub fn load_qwen3_moe_model<P: AsRef<Path>>(model_dir: P) -> Result<Qwen3MoeCausalLM, ModelError> {
     let model_path = model_dir.as_ref();
     let args = load_model_args(model_path)?;
+    load_qwen3_moe_model_with_args(model_path, args)
+}
 
+pub(crate) fn load_qwen3_moe_model_with_args(
+    model_path: &Path,
+    args: Qwen3MoeModelArgs,
+) -> Result<Qwen3MoeCausalLM, ModelError> {
     tracing::info!(
         model_type = %args.model_type,
         hidden_size = args.hidden_size,
@@ -608,9 +614,15 @@ pub fn load_qwen3_moe_model<P: AsRef<Path>>(model_dir: P) -> Result<Qwen3MoeCaus
         crate::validate_per_tensor_quantization_support(settings, &[])?;
     }
 
+    let quantization = args.quantization.clone();
     let mut model = Qwen3MoeCausalLM::new(args)?;
 
-    crate::load_safetensors_weights(&mut model, model_path)?;
+    crate::load_quantized_safetensors_weights_with_settings(
+        &mut model,
+        model_path,
+        false,
+        quantization.as_ref(),
+    )?;
 
     tracing::info!("Qwen3MoE model loaded successfully");
     Ok(model)

--- a/crates/higgs-models/src/qwen3_next.rs
+++ b/crates/higgs-models/src/qwen3_next.rs
@@ -4424,7 +4424,7 @@ fn gate_quantization_override(config: &serde_json::Value) -> Option<serde_json::
     None
 }
 
-fn load_qwen3_next_args_from_value(
+pub(crate) fn load_qwen3_next_args_from_value(
     mut config: serde_json::Value,
 ) -> Result<Qwen3NextModelArgs, ModelError> {
     let gate_override = gate_quantization_override(&config);
@@ -4631,7 +4631,14 @@ pub fn load_qwen3_next_model<P: AsRef<Path>>(
     model_dir: P,
 ) -> Result<Qwen3NextCausalLM, ModelError> {
     let model_path = model_dir.as_ref();
-    let mut args = load_model_args(model_path)?;
+    let args = load_model_args(model_path)?;
+    load_qwen3_next_model_with_args(model_path, args)
+}
+
+pub(crate) fn load_qwen3_next_model_with_args(
+    model_path: &Path,
+    mut args: Qwen3NextModelArgs,
+) -> Result<Qwen3NextCausalLM, ModelError> {
     maybe_disable_mtp_without_checkpoint_weights(&mut args, model_path)?;
 
     tracing::info!(
@@ -4645,6 +4652,7 @@ pub fn load_qwen3_next_model<P: AsRef<Path>>(
         "Loading qwen3_next model"
     );
 
+    let quantization = args.quantization.clone();
     let mut model = Qwen3NextCausalLM::new(args)?;
 
     // Backbone keys match model params directly, but the MTP sidecar may need
@@ -4652,7 +4660,7 @@ pub fn load_qwen3_next_model<P: AsRef<Path>>(
     // dense or MoE head (params `dense_mtp.*` / `moe_mtp.*`) while the checkpoint
     // still ships the head under the `mtp.*` namespace. The plain loader can't
     // bridge that, so it would silently leave the draft head uninitialized.
-    load_qwen3_next_weights(&mut model, model_path)?;
+    load_qwen3_next_weights(&mut model, model_path, quantization.as_ref())?;
 
     tracing::info!("Qwen3Next model loaded successfully");
     Ok(model)
@@ -4674,7 +4682,12 @@ fn load_qwen3_5_moe_text_config_args<P: AsRef<Path>>(
     let config_path = model_dir.as_ref().join("config.json");
     let file = std::fs::File::open(config_path)?;
     let config: serde_json::Value = serde_json::from_reader(file)?;
+    load_qwen3_5_text_config_args_from_value(&config)
+}
 
+pub(crate) fn load_qwen3_5_text_config_args_from_value(
+    config: &serde_json::Value,
+) -> Result<Qwen3NextModelArgs, ModelError> {
     let text_config = config
         .get("text_config")
         .ok_or_else(|| ModelError::UnsupportedModel("missing text_config in config.json".into()))?;
@@ -4730,7 +4743,7 @@ fn load_qwen3_5_moe_text_config_args<P: AsRef<Path>>(
     // in Unsloth dynamic quants), construct the model with separate GDN
     // projection fields so the direct weight loader can match them. Otherwise,
     // construct with fused fields (weights are rearranged at load time).
-    let mixed_ba_layers = qwen3_5_mixed_ba_quantization_layers(&config, text_config);
+    let mixed_ba_layers = qwen3_5_mixed_ba_quantization_layers(config, text_config);
     let config_requests_separate = map
         .get("use_separate_gdn_projections")
         .and_then(serde_json::Value::as_bool)
@@ -4750,7 +4763,7 @@ fn load_qwen3_5_moe_text_config_args<P: AsRef<Path>>(
     }
 
     // Detect per-layer gate quantization override from top-level quantization config
-    if let Some(gate_q) = gate_quantization_override(&config) {
+    if let Some(gate_q) = gate_quantization_override(config) {
         map.insert("gate_quantization".to_owned(), gate_q);
     }
 
@@ -4827,7 +4840,14 @@ fn qwen3_5_mixed_ba_quantization_layers(
 /// `decoder_sparse_step=1` or attempt `MoE` gate fusion.
 pub fn load_qwen3_5_model<P: AsRef<Path>>(model_dir: P) -> Result<Qwen3NextCausalLM, ModelError> {
     let model_path = model_dir.as_ref();
-    let mut args = load_qwen3_5_moe_text_config_args(model_path)?;
+    let args = load_qwen3_5_moe_text_config_args(model_path)?;
+    load_qwen3_5_model_with_args(model_path, args)
+}
+
+pub(crate) fn load_qwen3_5_model_with_args(
+    model_path: &Path,
+    mut args: Qwen3NextModelArgs,
+) -> Result<Qwen3NextCausalLM, ModelError> {
     maybe_disable_mtp_without_checkpoint_weights(&mut args, model_path)?;
 
     tracing::info!(
@@ -4861,7 +4881,14 @@ pub fn load_qwen3_5_moe_model<P: AsRef<Path>>(
     model_dir: P,
 ) -> Result<Qwen3NextCausalLM, ModelError> {
     let model_path = model_dir.as_ref();
-    let mut args = load_qwen3_5_moe_text_config_args(model_path)?;
+    let args = load_qwen3_5_moe_text_config_args(model_path)?;
+    load_qwen3_5_moe_model_with_args(model_path, args)
+}
+
+pub(crate) fn load_qwen3_5_moe_model_with_args(
+    model_path: &Path,
+    mut args: Qwen3NextModelArgs,
+) -> Result<Qwen3NextCausalLM, ModelError> {
     maybe_disable_mtp_without_checkpoint_weights(&mut args, model_path)?;
 
     tracing::info!(
@@ -4905,18 +4932,24 @@ fn load_qwen3_5_model_with_gdn_fallback(
     mut args: Qwen3NextModelArgs,
     gdn_dims: &GdnDims,
 ) -> Result<Qwen3NextCausalLM, ModelError> {
+    let quantization = args.quantization.clone();
     let force_separate =
         args.use_separate_gdn_projections || std::env::var("HIGGS_SEPARATE_GDN_PROJ").is_ok();
     if force_separate {
         args.use_separate_gdn_projections = true;
         let mut model = Qwen3NextCausalLM::new(args)?;
-        load_qwen3_5_moe_weights_direct(&mut model, model_path)?;
+        load_qwen3_5_moe_weights_direct(&mut model, model_path, quantization.as_ref())?;
         tracing::info!("Using SEPARATE GDN projections (4 dispatches per layer)");
         return Ok(model);
     }
 
     let mut fused_model = Qwen3NextCausalLM::new(args.clone())?;
-    match load_qwen3_5_moe_weights_fused(&mut fused_model, model_path, gdn_dims) {
+    match load_qwen3_5_moe_weights_fused(
+        &mut fused_model,
+        model_path,
+        gdn_dims,
+        quantization.as_ref(),
+    ) {
         Ok(()) => {
             tracing::info!("Using FUSED GDN projections (2 dispatches per layer)");
             Ok(fused_model)
@@ -4928,7 +4961,11 @@ fn load_qwen3_5_model_with_gdn_fallback(
             );
             args.use_separate_gdn_projections = true;
             let mut separate_model = Qwen3NextCausalLM::new(args)?;
-            load_qwen3_5_moe_weights_direct(&mut separate_model, model_path)?;
+            load_qwen3_5_moe_weights_direct(
+                &mut separate_model,
+                model_path,
+                quantization.as_ref(),
+            )?;
             tracing::info!(
                 "Using SEPARATE GDN projections (4 dispatches per layer, mixed-bit fallback)"
             );
@@ -5158,15 +5195,15 @@ fn qwen35_loaded_value(
 fn load_qwen3_next_weights<M: mlx_rs::module::ModuleParametersExt>(
     model: &mut M,
     model_path: &Path,
+    quantization: Option<&QuantizationConfig>,
 ) -> Result<(), crate::error::ModelError> {
     let safetensors_files = crate::collect_safetensors_files(model_path)?;
-    let quantization = crate::load_checkpoint_quantization_settings(model_path)?;
     let mut params = model.parameters_mut().flatten();
 
     for file_path in &safetensors_files {
         let loaded = Array::load_safetensors(file_path)
             .map_err(|e| crate::error::ModelError::Io(std::io::Error::other(e.to_string())))?;
-        crate::validate_quantized_tensor_widths(&loaded, quantization.as_ref())?;
+        crate::validate_quantized_tensor_widths(&loaded, quantization)?;
 
         for (key, value) in loaded {
             let key = normalize_sidecar_mtp_key(file_path, key);
@@ -5195,9 +5232,9 @@ fn load_qwen3_next_weights<M: mlx_rs::module::ModuleParametersExt>(
 fn load_qwen3_5_moe_weights_direct<M: mlx_rs::module::ModuleParametersExt>(
     model: &mut M,
     model_path: &Path,
+    quantization: Option<&QuantizationConfig>,
 ) -> Result<(), crate::error::ModelError> {
     let safetensors_files = crate::collect_safetensors_files(model_path)?;
-    let quantization = crate::load_checkpoint_quantization_settings(model_path)?;
     let mut params = model.parameters_mut().flatten();
     let mut matched = 0usize;
     let mut unmatched = Vec::new();
@@ -5205,7 +5242,7 @@ fn load_qwen3_5_moe_weights_direct<M: mlx_rs::module::ModuleParametersExt>(
     for file_path in &safetensors_files {
         let loaded = Array::load_safetensors(file_path)
             .map_err(|e| crate::error::ModelError::Io(std::io::Error::other(e.to_string())))?;
-        crate::validate_quantized_tensor_widths(&loaded, quantization.as_ref())?;
+        crate::validate_quantized_tensor_widths(&loaded, quantization)?;
 
         for (key, value) in loaded {
             let key = normalize_sidecar_mtp_key(file_path, key);
@@ -5271,11 +5308,11 @@ fn load_qwen3_5_moe_weights_fused<M: mlx_rs::module::ModuleParametersExt>(
     model: &mut M,
     model_path: &Path,
     gdn_dims: &GdnDims,
+    quantization: Option<&QuantizationConfig>,
 ) -> Result<(), crate::error::ModelError> {
     use std::collections::HashMap;
 
     let safetensors_files = crate::collect_safetensors_files(model_path)?;
-    let quantization = crate::load_checkpoint_quantization_settings(model_path)?;
     let mut params = model.parameters_mut().flatten();
 
     let qkvz_perm = build_qkvz_permutation(gdn_dims)
@@ -5294,7 +5331,7 @@ fn load_qwen3_5_moe_weights_fused<M: mlx_rs::module::ModuleParametersExt>(
     for file_path in &safetensors_files {
         let loaded = Array::load_safetensors(file_path)
             .map_err(|e| crate::error::ModelError::Io(std::io::Error::other(e.to_string())))?;
-        crate::validate_quantized_tensor_widths(&loaded, quantization.as_ref())?;
+        crate::validate_quantized_tensor_widths(&loaded, quantization)?;
 
         for (key, value) in loaded {
             let key = normalize_sidecar_mtp_key(file_path, key);
@@ -6235,7 +6272,9 @@ mod tests {
         .unwrap();
 
         let mut model = Qwen3NextCausalLM::new(valid_causal_lm_args()).unwrap();
-        let err = load_qwen3_next_weights(&mut model, dir.path()).unwrap_err();
+        let quantization: QuantizationConfig =
+            serde_json::from_str(r#"{"group_size": 64, "bits": 4}"#).unwrap();
+        let err = load_qwen3_next_weights(&mut model, dir.path(), Some(&quantization)).unwrap_err();
         assert!(
             err.to_string().contains("model.layers.0.self_attn.q_proj"),
             "unexpected error: {err}"

--- a/crates/higgs-models/src/registry.rs
+++ b/crates/higgs-models/src/registry.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use crate::error::ModelError;
 
 /// Maximum config.json size (10 MiB) — prevents `DoS` from symlinked large files.
-const MAX_CONFIG_SIZE: u64 = 10 * 1024 * 1024;
+const MAX_CONFIG_SIZE: u64 = crate::adapter::MAX_CONFIG_SIZE;
 
 /// Detect the model architecture from config.json's `model_type` field.
 pub fn detect_model_type<P: AsRef<Path>>(model_dir: P) -> Result<String, ModelError> {
@@ -26,27 +26,7 @@ pub fn detect_model_type<P: AsRef<Path>>(model_dir: P) -> Result<String, ModelEr
 
 /// Supported model architectures.
 pub fn is_supported(model_type: &str) -> bool {
-    matches!(
-        model_type,
-        "qwen2"
-            | "qwen3"
-            | "llama"
-            | "mistral"
-            | "qwen3_next"
-            | "qwen3_moe"
-            | "qwen3_5"
-            | "qwen3_5_moe"
-            | "gemma2"
-            | "gemma3"
-            | "gemma3_text"
-            | "gemma4"
-            | "gemma4_text"
-            | "gemma4_unified"
-            | "phi3"
-            | "starcoder2"
-            | "llava-qwen2"
-            | "deepseek_v2"
-    )
+    crate::adapter::is_exact_supported(model_type)
 }
 
 #[allow(clippy::panic, clippy::unwrap_used)]

--- a/crates/higgs-models/src/starcoder2.rs
+++ b/crates/higgs-models/src/starcoder2.rs
@@ -627,7 +627,13 @@ pub fn load_starcoder2_model<P: AsRef<Path>>(
 ) -> Result<Starcoder2CausalLM, ModelError> {
     let model_path = model_dir.as_ref();
     let args = load_starcoder2_model_args(model_path)?;
+    load_starcoder2_model_with_args(model_path, args)
+}
 
+pub(crate) fn load_starcoder2_model_with_args(
+    model_path: &Path,
+    args: Starcoder2ModelArgs,
+) -> Result<Starcoder2CausalLM, ModelError> {
     tracing::info!(
         model_type = %args.model_type,
         hidden_size = args.hidden_size,
@@ -660,7 +666,12 @@ pub fn load_starcoder2_model<P: AsRef<Path>>(
         raw_model
     };
 
-    crate::load_quantized_safetensors_weights(&mut model, model_path, quantization.is_some())?;
+    crate::load_quantized_safetensors_weights_with_settings(
+        &mut model,
+        model_path,
+        quantization.is_some(),
+        quantization.as_ref(),
+    )?;
 
     tracing::info!("Starcoder2 model loaded successfully");
     Ok(model)

--- a/crates/higgs-models/src/transformer.rs
+++ b/crates/higgs-models/src/transformer.rs
@@ -893,12 +893,21 @@ pub fn load_model_args<P: AsRef<Path>>(model_dir: P) -> Result<ModelArgs, ModelE
     Ok(serde_json::from_reader(file)?)
 }
 
+pub(crate) fn model_args_from_value(config: &serde_json::Value) -> Result<ModelArgs, ModelError> {
+    Ok(serde_json::from_value(config.clone())?)
+}
+
 /// Load model args from the `text_config` section of config.json (used by VLMs).
 pub fn load_text_config_args<P: AsRef<Path>>(model_dir: P) -> Result<ModelArgs, ModelError> {
     let config_path = model_dir.as_ref().join("config.json");
     let file = std::fs::File::open(config_path)?;
     let config: serde_json::Value = serde_json::from_reader(file)?;
+    text_model_args_from_value(&config)
+}
 
+pub(crate) fn text_model_args_from_value(
+    config: &serde_json::Value,
+) -> Result<ModelArgs, ModelError> {
     let text_config = config
         .get("text_config")
         .ok_or_else(|| ModelError::UnsupportedModel("missing text_config in config.json".into()))?;
@@ -919,7 +928,7 @@ pub fn load_text_config_args<P: AsRef<Path>>(model_dir: P) -> Result<ModelArgs, 
         }
     }
 
-    Ok(serde_json::from_value(text_obj)?)
+    model_args_from_value(&text_obj)
 }
 
 /// Load a language model for a VLM.
@@ -929,7 +938,13 @@ pub fn load_text_config_args<P: AsRef<Path>>(model_dir: P) -> Result<ModelArgs, 
 pub fn load_vlm_language_model<P: AsRef<Path>>(model_dir: P) -> Result<Model, ModelError> {
     let model_path = model_dir.as_ref();
     let args = load_text_config_args(model_path)?;
+    load_vlm_language_model_with_args(model_path, args)
+}
 
+pub(crate) fn load_vlm_language_model_with_args(
+    model_path: &Path,
+    args: ModelArgs,
+) -> Result<Model, ModelError> {
     tracing::info!(
         model_type = %args.model_type,
         hidden_size = args.hidden_size,
@@ -959,11 +974,12 @@ pub fn load_vlm_language_model<P: AsRef<Path>>(model_dir: P) -> Result<Model, Mo
         raw_model
     };
 
-    crate::load_quantized_safetensors_weights_with_prefix(
+    crate::load_quantized_safetensors_weights_with_prefix_and_settings(
         &mut model,
         model_path,
         quantization.is_some(),
         "language_model.",
+        quantization.as_ref(),
     )?;
 
     tracing::info!("VLM language model loaded successfully");
@@ -973,8 +989,14 @@ pub fn load_vlm_language_model<P: AsRef<Path>>(model_dir: P) -> Result<Model, Mo
 /// Load a model from a directory containing safetensors + config.json.
 pub fn load_model<P: AsRef<Path>>(model_dir: P) -> Result<Model, ModelError> {
     let model_path = model_dir.as_ref();
-
     let args = load_model_args(model_path)?;
+    load_model_with_args(model_path, args)
+}
+
+pub(crate) fn load_model_with_args(
+    model_path: &Path,
+    args: ModelArgs,
+) -> Result<Model, ModelError> {
     tracing::info!(
         model_type = %args.model_type,
         hidden_size = args.hidden_size,
@@ -1011,7 +1033,12 @@ pub fn load_model<P: AsRef<Path>>(model_dir: P) -> Result<Model, ModelError> {
         raw_model
     };
 
-    crate::load_quantized_safetensors_weights(&mut model, model_path, quantization.is_some())?;
+    crate::load_quantized_safetensors_weights_with_settings(
+        &mut model,
+        model_path,
+        quantization.is_some(),
+        quantization.as_ref(),
+    )?;
 
     tracing::info!("Model loaded successfully");
     Ok(model)

--- a/crates/higgs-models/tests/adapter_registry.rs
+++ b/crates/higgs-models/tests/adapter_registry.rs
@@ -1,0 +1,205 @@
+#![allow(clippy::panic, clippy::tests_outside_test_module, clippy::unwrap_used)]
+
+use std::io::Write;
+
+use higgs_models::adapter::{self, ModelFamily, ModelVersion};
+
+fn write_config(value: &serde_json::Value) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("config.json"),
+        serde_json::to_vec(value).unwrap(),
+    )
+    .unwrap();
+    dir
+}
+
+fn complete_config(model_type: &str) -> serde_json::Value {
+    serde_json::json!({
+        "model_type": model_type,
+        "hidden_size": 4096,
+        "num_hidden_layers": 32,
+        "num_attention_heads": 32,
+        "num_key_value_heads": 8,
+        "vocab_size": 152_064,
+        "intermediate_size": 11_008,
+        "head_dim": 128,
+        "max_position_embeddings": 131_072,
+        "linear_num_value_heads": 32,
+        "linear_num_key_heads": 16,
+        "linear_key_head_dim": 128,
+        "linear_value_head_dim": 128,
+        "linear_conv_kernel_dim": 4,
+        "rms_norm_eps": 0.000_001
+    })
+}
+
+#[test]
+fn detects_plain_config() {
+    let dir = write_config(&serde_json::json!({
+        "model_type": "qwen3_5",
+        "architectures": ["Qwen3_5Model"]
+    }));
+    let detected = adapter::detect(dir.path()).unwrap();
+
+    assert_eq!(detected.model_type, "qwen3_5");
+    assert_eq!(detected.wrapper_model_type, None);
+    assert_eq!(detected.family, ModelFamily::Qwen);
+    assert_eq!(detected.version, Some(ModelVersion { major: 3, minor: 5 }));
+}
+
+#[test]
+fn parses_family_versions_from_known_type_shapes() {
+    for (model_type, family, version) in [
+        (
+            "gemma4_text",
+            ModelFamily::Gemma,
+            ModelVersion { major: 4, minor: 0 },
+        ),
+        (
+            "deepseek_v2",
+            ModelFamily::DeepSeek,
+            ModelVersion { major: 2, minor: 0 },
+        ),
+    ] {
+        let dir = write_config(&serde_json::json!({"model_type": model_type}));
+        let detected = adapter::detect(dir.path()).unwrap();
+        assert_eq!(detected.family, family);
+        assert_eq!(detected.version, Some(version));
+    }
+}
+
+#[test]
+fn detects_nested_text_config_for_conditional_generation_wrapper() {
+    let dir = write_config(&serde_json::json!({
+        "model_type": "qwen3_5",
+        "architectures": ["Qwen3_5ForConditionalGeneration"],
+        "text_config": { "model_type": "qwen3_9" }
+    }));
+    let detected = adapter::detect(dir.path()).unwrap();
+
+    assert_eq!(detected.wrapper_model_type.as_deref(), Some("qwen3_5"));
+    assert_eq!(detected.model_type, "qwen3_9");
+    assert_eq!(detected.version, Some(ModelVersion { major: 3, minor: 9 }));
+}
+
+#[test]
+fn missing_model_type_is_an_error() {
+    let dir = write_config(&serde_json::json!({"vocab_size": 32000}));
+    let error = adapter::detect(dir.path()).unwrap_err();
+    assert!(error.to_string().contains("missing model_type"));
+}
+
+#[test]
+fn oversized_config_is_an_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut file = std::fs::File::create(dir.path().join("config.json")).unwrap();
+    file.set_len(adapter::MAX_CONFIG_SIZE + 1).unwrap();
+    file.flush().unwrap();
+
+    let error = adapter::detect(dir.path()).unwrap_err();
+    assert!(error.to_string().contains("config.json too large"));
+}
+
+#[test]
+fn bonsai_is_more_specific_than_transformer_dense() {
+    let dir = write_config(&serde_json::json!({
+        "model_type": "qwen3",
+        "quantization": {"bits": 1, "group_size": 128}
+    }));
+    let detected = adapter::detect(dir.path()).unwrap();
+    assert_eq!(
+        adapter::resolve(&detected).unwrap().id(),
+        "bonsai-q1-packed"
+    );
+}
+
+#[test]
+fn qwen_moe_does_not_resolve_to_dense() {
+    let dir = write_config(&complete_config("qwen3_5_moe"));
+    let detected = adapter::detect(dir.path()).unwrap();
+    assert_eq!(adapter::resolve(&detected).unwrap().id(), "qwen3.5-moe");
+}
+
+#[test]
+fn exact_match_beats_version_tolerant_match() {
+    let dir = write_config(&complete_config("gemma4_text"));
+    let detected = adapter::detect(dir.path()).unwrap();
+    let resolved = adapter::resolve(&detected).unwrap();
+    assert_eq!(resolved.id(), "gemma4-text");
+    assert!(!adapter::is_untested_version(resolved, &detected));
+}
+
+#[test]
+fn future_qwen_dense_resolves_after_structural_check() {
+    let dir = write_config(&complete_config("qwen3_9"));
+    let detected = adapter::detect(dir.path()).unwrap();
+    let resolved = adapter::resolve(&detected).unwrap();
+
+    assert_eq!(resolved.id(), "qwen3.5-dense");
+    assert!(adapter::is_untested_version(resolved, &detected));
+}
+
+#[test]
+fn future_qwen_missing_required_field_is_rejected() {
+    let mut config = complete_config("qwen3_9");
+    config.as_object_mut().unwrap().remove("hidden_size");
+    let dir = write_config(&config);
+    let detected = adapter::detect(dir.path()).unwrap();
+    let error = match adapter::resolve(&detected) {
+        Err(error) => error,
+        Ok(adapter) => panic!("unexpected adapter: {}", adapter.id()),
+    };
+
+    assert!(error.to_string().contains("hidden_size"));
+}
+
+#[test]
+fn unknown_family_error_lists_supported_ranges() {
+    let dir = write_config(&complete_config("mamba"));
+    let detected = adapter::detect(dir.path()).unwrap();
+    let error = match adapter::resolve(&detected) {
+        Err(error) => error,
+        Ok(adapter) => panic!("unexpected adapter: {}", adapter.id()),
+    };
+
+    assert!(error.to_string().contains("mamba"));
+    assert!(error.to_string().contains("Qwen"));
+    assert!(error.to_string().contains("Gemma"));
+}
+
+#[test]
+fn supported_adapter_ids_are_unique() {
+    let supported = adapter::supported();
+    assert!(!supported.is_empty());
+    let mut ids = supported.iter().map(|info| info.id).collect::<Vec<_>>();
+    ids.sort_unstable();
+    ids.dedup();
+    assert_eq!(ids.len(), supported.len());
+}
+
+#[test]
+fn adapter_load_uses_the_already_parsed_config() {
+    let dir = write_config(&serde_json::json!({
+        "model_type": "qwen3",
+        "hidden_size": 64,
+        "num_hidden_layers": 1,
+        "intermediate_size": 128,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "rms_norm_eps": 0.000_001,
+        "vocab_size": 256,
+        "max_position_embeddings": 1024
+    }));
+    let detected = adapter::detect(dir.path()).unwrap();
+    let resolved = adapter::resolve(&detected).unwrap();
+    std::fs::remove_file(dir.path().join("config.json")).unwrap();
+
+    let Err(error) = resolved.load(&detected) else {
+        panic!("config-only checkpoint unexpectedly loaded");
+    };
+    assert!(
+        !matches!(error, higgs_models::error::ModelError::Io(ref io) if io.kind() == std::io::ErrorKind::NotFound),
+        "adapter reopened config.json instead of using DetectedModel::raw"
+    );
+}

--- a/crates/higgs-models/tests/adapter_registry.rs
+++ b/crates/higgs-models/tests/adapter_registry.rs
@@ -34,6 +34,14 @@ fn complete_config(model_type: &str) -> serde_json::Value {
     })
 }
 
+fn wrapped_config(top_model_type: &str, nested_model_type: &str) -> serde_json::Value {
+    serde_json::json!({
+        "model_type": top_model_type,
+        "architectures": ["Qwen3_5ForConditionalGeneration"],
+        "text_config": complete_config(nested_model_type)
+    })
+}
+
 #[test]
 fn detects_plain_config() {
     let dir = write_config(&serde_json::json!({
@@ -81,6 +89,71 @@ fn detects_nested_text_config_for_conditional_generation_wrapper() {
     assert_eq!(detected.wrapper_model_type.as_deref(), Some("qwen3_5"));
     assert_eq!(detected.model_type, "qwen3_9");
     assert_eq!(detected.version, Some(ModelVersion { major: 3, minor: 9 }));
+}
+
+#[test]
+fn nested_text_config_is_always_a_resolution_candidate() {
+    let dir = write_config(&serde_json::json!({
+        "model_type": "qwen3_5",
+        "architectures": ["NonstandardWrapperModel"],
+        "text_config": { "model_type": "unknown_text_backbone" }
+    }));
+    let detected = adapter::detect(dir.path()).unwrap();
+
+    assert_eq!(detected.model_type, "unknown_text_backbone");
+    assert_eq!(detected.wrapper_model_type.as_deref(), Some("qwen3_5"));
+    assert_eq!(adapter::resolve(&detected).unwrap().id(), "qwen3.5-dense");
+}
+
+#[test]
+fn qwen38_wrapper_text_alias_resolves_to_dense_adapter() {
+    let dir = write_config(&wrapped_config("qwen3_5", "qwen3_5_text"));
+    let detected = adapter::detect(dir.path()).unwrap();
+    let resolved = adapter::resolve(&detected).unwrap();
+
+    assert_eq!(detected.model_type, "qwen3_5_text");
+    assert_eq!(detected.wrapper_model_type.as_deref(), Some("qwen3_5"));
+    assert_eq!(resolved.id(), "qwen3.5-dense");
+    assert!(!adapter::is_untested_version(resolved, &detected));
+}
+
+#[test]
+fn exact_wrapper_candidate_beats_tolerant_nested_candidate() {
+    let dir = write_config(&wrapped_config("qwen3_5", "qwen3_9_text"));
+    let detected = adapter::detect(dir.path()).unwrap();
+    let resolved = adapter::resolve(&detected).unwrap();
+
+    assert_eq!(resolved.id(), "qwen3.5-dense");
+    assert!(!adapter::is_untested_version(resolved, &detected));
+}
+
+#[test]
+fn future_qwen_wrapper_text_alias_resolves_tolerantly() {
+    let dir = write_config(&wrapped_config("qwen3_9", "qwen3_9_text"));
+    let detected = adapter::detect(dir.path()).unwrap();
+    let resolved = adapter::resolve(&detected).unwrap();
+
+    assert_eq!(resolved.id(), "qwen3.5-dense");
+    assert!(adapter::is_untested_version(resolved, &detected));
+}
+
+#[test]
+fn future_qwen_text_moe_alias_resolves_tolerantly() {
+    let mut config = wrapped_config("qwen3_9_text_moe", "qwen3_9_text_moe");
+    let text_config = config
+        .get_mut("text_config")
+        .and_then(serde_json::Value::as_object_mut)
+        .unwrap();
+    text_config.insert("num_experts".into(), 128.into());
+    text_config.insert("num_experts_per_tok".into(), 8.into());
+    text_config.insert("shared_expert_intermediate_size".into(), 1_024.into());
+    text_config.insert("moe_intermediate_size".into(), 768.into());
+    let dir = write_config(&config);
+    let detected = adapter::detect(dir.path()).unwrap();
+    let resolved = adapter::resolve(&detected).unwrap();
+
+    assert_eq!(resolved.id(), "qwen3.5-moe");
+    assert!(adapter::is_untested_version(resolved, &detected));
 }
 
 #[test]

--- a/crates/higgs-models/tests/adapter_registry.rs
+++ b/crates/higgs-models/tests/adapter_registry.rs
@@ -96,13 +96,31 @@ fn nested_text_config_is_always_a_resolution_candidate() {
     let dir = write_config(&serde_json::json!({
         "model_type": "qwen3_5",
         "architectures": ["NonstandardWrapperModel"],
-        "text_config": { "model_type": "unknown_text_backbone" }
+        "text_config": complete_config("unknown_text_backbone")
     }));
     let detected = adapter::detect(dir.path()).unwrap();
 
     assert_eq!(detected.model_type, "unknown_text_backbone");
     assert_eq!(detected.wrapper_model_type.as_deref(), Some("qwen3_5"));
     assert_eq!(adapter::resolve(&detected).unwrap().id(), "qwen3.5-dense");
+}
+
+#[test]
+fn exact_wrapper_fallback_validates_unknown_nested_config() {
+    let mut text_config = complete_config("unknown_text_backbone");
+    text_config.as_object_mut().unwrap().remove("hidden_size");
+    let dir = write_config(&serde_json::json!({
+        "model_type": "qwen3_5",
+        "architectures": ["NonstandardWrapperModel"],
+        "text_config": text_config
+    }));
+    let detected = adapter::detect(dir.path()).unwrap();
+    let error = match adapter::resolve(&detected) {
+        Err(error) => error,
+        Ok(adapter) => panic!("unexpected adapter: {}", adapter.id()),
+    };
+
+    assert!(error.to_string().contains("hidden_size"));
 }
 
 #[test]

--- a/crates/higgs/src/config.rs
+++ b/crates/higgs/src/config.rs
@@ -904,10 +904,6 @@ fn validate_config(config: &HiggsConfig, simple_mode: bool) -> Result<(), String
     Ok(())
 }
 
-fn supports_batch_model_type(model_type: &str) -> bool {
-    matches!(model_type, "qwen2" | "qwen3" | "llama" | "mistral")
-}
-
 fn batch_support_for_model_path(model_path: &str) -> Result<Option<bool>, String> {
     match crate::model_resolver::resolve(model_path) {
         Ok(resolved) => resolved_model_supports_batch(&resolved).map(Some),
@@ -929,7 +925,7 @@ fn batch_support_check_can_be_deferred(model_path: &str, err: &str) -> bool {
 pub fn resolved_model_supports_batch(model_dir: &Path) -> Result<bool, String> {
     let inspected = model_loader::ModelConfig::from_dir(model_dir)
         .map_err(|e| format!("failed to inspect {}: {e}", model_dir.display()))?;
-    Ok(supports_batch_model_type(&inspected.model_type))
+    Ok(inspected.capabilities.batch_engine)
 }
 
 /// If `auto_router` is enabled, ensure its model is present in `config.models`

--- a/crates/higgs/src/doctor.rs
+++ b/crates/higgs/src/doctor.rs
@@ -407,20 +407,17 @@ fn check_models(config: &HiggsConfig, result: &mut DoctorResult) {
                         continue;
                     }
                 };
-                if model.batch {
-                    if !inspected.capabilities.batch_engine {
-                        fail(
-                            &format!(
-                                "model {label} enables unsupported batch=true; adapter '{}' does not support true batched decode",
-                                inspected.adapter_id
-                            ),
-                            result,
-                        );
-                        continue;
-                    }
+                if model.batch && !inspected.capabilities.batch_engine {
+                    fail(
+                        &format!(
+                            "model {label} enables unsupported batch=true; adapter '{}' does not support true batched decode",
+                            inspected.adapter_id
+                        ),
+                        result,
+                    );
+                    continue;
                 }
-                if higgs_models::cache::resolve_mla_latent_cache(model.kv_cache_config().mla_latent)
-                {
+                if higgs_models::cache::resolve_mla_latent_cache(kv_cache_config.mla_latent) {
                     check_mla_latent_cache_adapter(&label, &inspected, result);
                 }
                 let requested_profile = model.requested_mlx_profile(&config.local);

--- a/crates/higgs/src/doctor.rs
+++ b/crates/higgs/src/doctor.rs
@@ -286,11 +286,9 @@ fn check_prefill_yield_tokens(
     true
 }
 
-/// Warn (not fail) when the *resolved* MLA decision is enabled for a model
-/// whose architecture isn't `deepseek_v2`. The flag is a no-op for other
-/// architectures at runtime -- `KvCacheConfig::mla_latent` is only consulted
-/// by `DeepSeekV2::make_cache_with_config` -- so this is advisory, not a
-/// hard failure.
+/// Warn (not fail) when the *resolved* MLA decision is enabled for an adapter
+/// that does not advertise MLA latent-cache support. The flag is a no-op for
+/// those adapters at runtime, so this is advisory rather than a hard failure.
 ///
 /// Uses [`higgs_models::cache::resolve_mla_latent_cache`] rather than the raw
 /// `model.mla_latent_cache` field, so this matches runtime behavior: e.g.
@@ -298,6 +296,7 @@ fn check_prefill_yield_tokens(
 /// warns (the flag is effectively on), and `HIGGS_MLA_LATENT_CACHE=0` with
 /// `mla_latent_cache=true` in config does not warn (the flag is effectively
 /// off).
+#[cfg(test)]
 fn check_mla_latent_cache_architecture(
     label: &str,
     model: &crate::config::ModelConfig,
@@ -308,21 +307,7 @@ fn check_mla_latent_cache_architecture(
         return;
     }
     match model_loader::ModelConfig::from_dir(resolved) {
-        Ok(inspected) if inspected.model_type == "deepseek_v2" => {
-            pass(
-                &format!("model {label} mla_latent_cache=true (deepseek_v2)"),
-                result,
-            );
-        }
-        Ok(inspected) => {
-            warn(
-                &format!(
-                    "model {label} enables mla_latent_cache=true but architecture '{}' is not deepseek_v2; the flag is a no-op at runtime",
-                    inspected.model_type
-                ),
-                result,
-            );
-        }
+        Ok(inspected) => check_mla_latent_cache_adapter(label, &inspected, result),
         Err(err) => {
             warn(
                 &format!(
@@ -334,6 +319,31 @@ fn check_mla_latent_cache_architecture(
     }
 }
 
+fn check_mla_latent_cache_adapter(
+    label: &str,
+    inspected: &model_loader::ModelConfig,
+    result: &mut DoctorResult,
+) {
+    if inspected.capabilities.mla_latent_cache {
+        pass(
+            &format!(
+                "model {label} mla_latent_cache=true (adapter {})",
+                inspected.adapter_id
+            ),
+            result,
+        );
+    } else {
+        warn(
+            &format!(
+                "model {label} enables mla_latent_cache=true but adapter '{}' does not support MLA latent cache; the flag is a no-op at runtime",
+                inspected.adapter_id
+            ),
+            result,
+        );
+    }
+}
+
+#[allow(clippy::too_many_lines)]
 fn check_models(config: &HiggsConfig, result: &mut DoctorResult) {
     for model in &config.models {
         let label = model_label(model);
@@ -387,28 +397,32 @@ fn check_models(config: &HiggsConfig, result: &mut DoctorResult) {
         }
         match model_resolver::resolve(&model.path) {
             Ok(resolved) => {
+                let inspected = match model_loader::ModelConfig::from_dir(&resolved) {
+                    Ok(inspected) => inspected,
+                    Err(err) => {
+                        fail(
+                            &format!("model {label} architecture validation failed: {err}"),
+                            result,
+                        );
+                        continue;
+                    }
+                };
                 if model.batch {
-                    match crate::config::resolved_model_supports_batch(&resolved) {
-                        Ok(true) => {}
-                        Ok(false) => {
-                            fail(
-                                &format!(
-                                    "model {label} enables unsupported batch=true; only transformer models (llama, mistral, qwen2, qwen3) support true batched decode"
-                                ),
-                                result,
-                            );
-                            continue;
-                        }
-                        Err(err) => {
-                            fail(
-                                &format!("model {label} batch validation failed: {err}"),
-                                result,
-                            );
-                            continue;
-                        }
+                    if !inspected.capabilities.batch_engine {
+                        fail(
+                            &format!(
+                                "model {label} enables unsupported batch=true; adapter '{}' does not support true batched decode",
+                                inspected.adapter_id
+                            ),
+                            result,
+                        );
+                        continue;
                     }
                 }
-                check_mla_latent_cache_architecture(&label, model, &resolved, result);
+                if higgs_models::cache::resolve_mla_latent_cache(model.kv_cache_config().mla_latent)
+                {
+                    check_mla_latent_cache_adapter(&label, &inspected, result);
+                }
                 let requested_profile = model.requested_mlx_profile(&config.local);
                 let profile_msg = if model.batch {
                     "batch=true; batched decode supported".to_owned()
@@ -425,7 +439,16 @@ fn check_models(config: &HiggsConfig, result: &mut DoctorResult) {
                         )
                     }
                 };
-                pass(&format!("model {label} resolvable ({profile_msg})"), result);
+                let version = inspected
+                    .version
+                    .map_or_else(|| "unknown".to_owned(), |version| version.to_string());
+                pass(
+                    &format!(
+                        "model {label} resolvable (adapter={}, family={}, version={version}; {profile_msg})",
+                        inspected.adapter_id, inspected.family
+                    ),
+                    result,
+                );
             }
             Err(err) => fail(&format!("model {label} not found: {err}"), result),
         }

--- a/docs/models.md
+++ b/docs/models.md
@@ -10,8 +10,8 @@ Higgs detects local model support from `config.json` `model_type`. The tables be
 | Mistral | `mistral` | Mistral 7B |
 | Qwen2 | `qwen2` | Qwen2 and Qwen2.5 |
 | Qwen3 | `qwen3` | Qwen3 |
-| Qwen3.5 (dense) | `qwen3_5` | Qwen3.5 dense MLX checkpoints |
-| Qwen3.5 / Qwen3.6 MoE | `qwen3_5_moe` | Qwen3.5-35B-A3B, Qwen3.6-35B-A3B |
+| Qwen3.5+ (dense) | `qwen3_5`, `qwen3_5_text` | Qwen3.5 dense checkpoints; Qwen3.8-27B |
+| Qwen3.5+ (MoE) | `qwen3_5_moe`, `qwen3_5_text_moe` | Qwen3.5-35B-A3B, Qwen3.6-35B-A3B |
 | Qwen3-Next | `qwen3_next` | Qwen3-Coder hybrid checkpoints |
 | Qwen3-MoE | `qwen3_moe` | Qwen3-30B-A3B |
 | Gemma 2 | `gemma2` | Gemma 2 2B, 9B, and 27B |
@@ -56,11 +56,15 @@ Other supported architectures still serve normally in simple mode, but Higgs now
 | Qwen3.5 dense | `mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit` |
 | Qwen3.5 MoE | `NexVeridian/Qwen3.5-35B-A3B-3bit` |
 | Qwen3.6 MoE | `mlx-community/Qwen3.6-35B-A3B-4bit` |
+| Qwen3.8 dense | `mlx-community/Qwen3.8-27B-4bit` |
 | DeepSeek-V2 | `mlx-community/DeepSeek-Coder-V2-Lite-Instruct-4bit-mlx` |
 
-## Qwen 3.6 Notes
+## Qwen 3.5+ Adapter and Version Notes
 
-- `Qwen3.6` support currently uses the `qwen3_5_moe` loader path.
+- Qwen 3.5, 3.6, and 3.8 dense and MoE checkpoints use the Qwen 3.5 adapters. This includes `*ForConditionalGeneration` wrapper configs: Higgs detects the top-level wrapper and consumes the nested `text_config` used by the text loader.
+- `_text` aliases such as `qwen3_5_text` and `qwen3_5_text_moe` resolve to the corresponding dense or MoE adapter.
+- Unknown newer versions within a supported family can use the nearest adapter only after the resolved config passes structural validation. Higgs logs an untested-version warning when it takes this tolerant path. A missing or invalid required field is rejected by name; an unknown family is rejected with the supported family/version list.
+- `mlx-community/Qwen3.8-27B-4bit` (27B dense, 4-bit) is verified working through its top-level `qwen3_5` wrapper and nested `qwen3_5_text` config.
 - The cached-model smoke matrix covered `mlx-community/Qwen3.6-35B-A3B-4bit` plus `mlx-community/Llama-3.2-1B-Instruct-4bit`, `mlx-community/Qwen2.5-3B-Instruct-4bit`, `mlx-community/Qwen3-1.7B-4bit`, and `mlx-community/Qwen3-Coder-Next-4bit`.
 - OpenAI-style chat requests use non-thinking mode by default for `Qwen3.6` unless the request explicitly opts into reasoning.
 

--- a/validation/model-adapters/report.md
+++ b/validation/model-adapters/report.md
@@ -1,0 +1,47 @@
+# Validation report: model adapter registry
+
+- chip: Apple M4 Max, 128 GB, macOS 26.5.1
+- branch: claude/model-adapters (off main f599e95)
+
+## Why
+Model support was keyed on exact `model_type` strings in two disconnected places
+(`registry.rs::is_supported` and `model_loader.rs::load_model`). mlx-community/Qwen3.8-27B-4bit only
+works today by accident: it declares `model_type: "qwen3_5"` (wrapper arch
+`Qwen3_5ForConditionalGeneration`, nested `text_config.model_type: "qwen3_5_text"`). Any genuinely new
+version string would hard-fail with no path forward short of editing two files.
+
+## Verification (all run on hardware against real cached checkpoints)
+
+### Behavioral equivalence vs main — PASS
+Qwen3.8-27B-4bit, identical greedy request (temp 0, max_tokens 600):
+| Build | content | reasoning chars | usage |
+| --- | --- | ---: | --- |
+| main f599e95 | '391' | 137 | prompt 67 / completion 52 |
+| adapter branch | '391' | 137 | prompt 67 / completion 52 |
+Byte-identical. Codex also verified Qwen3-1.7B-4bit (transformer path) and
+DeepSeek-Coder-V2-Lite-4bit (deepseek_v2 path) generate normally.
+
+### Version tolerance — PASS
+Synthetic future checkpoint (/tmp fixture: `model_type: qwen3_9` top-level AND nested, weights
+symlinked from Qwen3.8) loads through the `qwen3.5-dense` adapter and generates the correct answer
+('391'), with an explicit log line:
+  WARN higgs_models::adapter: loading an untested model version through a structurally compatible
+  adapter model_type=qwen3_9 adapter="qwen3.5-dense"
+Acceptance is gated on a structural check of the fields the loader actually reads; missing/ill-typed
+fields error by name rather than loading garbage.
+
+### Unknown family — PASS (still a hard error, now actionable)
+`model_type: "mamba"` =>
+  UnsupportedModel("mamba; supported families/version ranges: Qwen (Qwen 3.0 (Bonsai 1-bit)),
+  Qwen (Qwen 3.5+ MoE), Qwen (Qwen 3.5+ dense), Qwen (Qwen 3 Next), ...")
+
+### Regression caught during review (recorded honestly)
+The first implementation preferred the nested `text_config.model_type` unconditionally, making
+Qwen3.8's effective type `qwen3_5_text` — which matched no adapter, so a model that works on main
+failed to load entirely. Fixed by treating nested + top-level types as CANDIDATES (exact match on any
+candidate wins) and normalizing `_text` aliases family-wide, with regression tests using the real
+Qwen3.8 config shape. The equivalence table above was re-measured after the fix.
+
+### Gates
+clippy -Dwarnings (higgs-models, higgs-engine) clean; fmt clean; tests: higgs-models 470+18,
+higgs-engine 298, higgs 488+2+99 — all green.

--- a/validation/model-adapters/report.md
+++ b/validation/model-adapters/report.md
@@ -14,10 +14,12 @@ version string would hard-fail with no path forward short of editing two files.
 
 ### Behavioral equivalence vs main — PASS
 Qwen3.8-27B-4bit, identical greedy request (temp 0, max_tokens 600):
+
 | Build | content | reasoning chars | usage |
 | --- | --- | ---: | --- |
 | main f599e95 | '391' | 137 | prompt 67 / completion 52 |
 | adapter branch | '391' | 137 | prompt 67 / completion 52 |
+
 Byte-identical. Codex also verified Qwen3-1.7B-4bit (transformer path) and
 DeepSeek-Coder-V2-Lite-4bit (deepseek_v2 path) generate normally.
 


### PR DESCRIPTION
Makes model support adapter-shaped — families with versions and per-model nuance behind one uniform interface — instead of exact `model_type` string matching duplicated in two places.

## The problem this fixes (verified, not theoretical)
`mlx-community/Qwen3.8-27B-4bit` works on main **only by accident**: it declares `model_type: "qwen3_5"` (wrapper arch `Qwen3_5ForConditionalGeneration`, nested `text_config.model_type: "qwen3_5_text"`). Support was a flat `matches!` in `registry.rs` plus a flat `match` in `model_loader.rs`, with nuance smeared around the loader (Bonsai-Q1 config peeking, `gemma3`/`gemma3_text` alias groups, a second config.json read). Any genuinely new version string = edit two files or fail.

## What this adds
- `higgs-models::adapter`: `ModelAdapter` trait (`id` / `family` / `describe` / `match_score` / `load`), `DetectedModel` (config parsed **once**, wrapper + nested type both retained), `ModelFamily`/`ModelVersion`, `Capabilities`, and a registry with `detect` → `resolve` (highest specificity) → `load`.
- One adapter per existing loader path, behavior preserved exactly. Bonsai-Q1 is now a higher-specificity adapter rather than an `if` inside the loader — the canonical example of nuance living in an adapter.
- **Version tolerance**: family adapters accept unknown newer versions (Qwen 3.5+, Gemma 3+/4+, incl. `_text` aliases), gated on a structural check of the fields the loader actually reads, and logged as untested. Unknown families still hard-error, now listing supported families/ranges.
- `model_loader::load_model` keeps its signature (`detect → resolve → adapter.load`); `registry::is_supported` retained; doctor sources batch/MLA capability checks from the registry and reports adapter id/family/version.

## Evidence (validation/model-adapters/report.md)
- **Equivalence vs main**: Qwen3.8-27B-4bit greedy request byte-identical (`391`, 137 reasoning chars, prompt 67 / completion 52 both builds); Qwen3-1.7B and DeepSeek-V2-Lite also verified generating.
- **Future version**: synthetic `qwen3_9` checkpoint loads via the `qwen3.5-dense` adapter and answers correctly, with `WARN ... loading an untested model version ... adapter="qwen3.5-dense"`.
- **Unknown family**: `mamba` errors with the supported-family list.
- Gates: clippy `-Dwarnings` clean, fmt clean, tests green (higgs-models 470+18, higgs-engine 298, higgs 488+2+99).

## Review note
The first implementation regressed Qwen3.8 to a hard load failure (it preferred the nested `qwen3_5_text` type, which matched no adapter). Caught by running the real model rather than trusting unit tests, and fixed with candidate-based resolution + family-wide `_text` normalization and regression tests built from the real Qwen3.8 config shape.

Implemented by Codex CLI (gpt-5.6-sol, medium); reviewed and hardware-verified by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic model-family and version detection with support for nested configurations and multiple architectures.
  - Added adapter-based loading for Qwen, Gemma, Phi, Starcoder, LLaVA, DeepSeek, Bonsai, and generic transformer models.
  - Added support for dense and MoE MTP checkpoint layouts.
  - Added Qwen 3.8 support, including 4-bit model handling.

- **Bug Fixes**
  - Improved quantized model loading by preserving configuration settings.
  - Enhanced diagnostics with adapter, family, version, and capability details.
  - Improved handling of future versions and unsupported model families.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->