### PR TITLE
fix(deps): migrate to sha2 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,6 +360,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -650,6 +659,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -816,6 +831,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1064,8 +1088,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1665,7 +1700,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "sysinfo",
  "tempfile",
  "tokenizers 0.23.1",
@@ -1686,7 +1721,7 @@ dependencies = [
  "outlines-core",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "tempfile",
  "thiserror 2.0.20",
  "tokenizers 0.23.1",
@@ -1757,6 +1792,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2897,7 +2941,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3730,7 +3774,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4071,7 +4126,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "phf",
- "sha2",
+ "sha2 0.10.9",
  "signal-hook",
  "siphasher",
  "terminfo",
@@ -4951,7 +5006,7 @@ checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
 dependencies = [
  "getrandom 0.3.4",
  "mac_address",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "uuid",
 ]

--- a/crates/higgs-bench/Cargo.toml
+++ b/crates/higgs-bench/Cargo.toml
@@ -23,7 +23,7 @@ reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sysinfo = "0.38"
-sha2 = "0.10"
+sha2 = "0.11"
 tokio = { workspace = true }
 tokenizers.workspace = true
 toml = "1.0"

--- a/crates/higgs-bench/src/bin/quality_gate.rs
+++ b/crates/higgs-bench/src/bin/quality_gate.rs
@@ -364,7 +364,16 @@ fn model_basename(model_dir: &Path) -> Result<String> {
 fn config_hash(model_dir: &Path) -> Result<String> {
     let path = model_dir.join("config.json");
     let bytes = std::fs::read(&path).with_context(|| format!("read {}", path.display()))?;
-    Ok(format!("{:x}", Sha256::digest(bytes)))
+    Ok(hex_lower(&Sha256::digest(bytes)))
+}
+fn hex_lower(bytes: &[u8]) -> String {
+    const DIGITS: &[u8; 16] = b"0123456789abcdef";
+    let mut encoded = String::with_capacity(bytes.len().saturating_mul(2));
+    for &byte in bytes {
+        encoded.push(char::from(DIGITS[usize::from(byte >> 4)]));
+        encoded.push(char::from(DIGITS[usize::from(byte & 0x0f)]));
+    }
+    encoded
 }
 
 fn ensure_fixture_matches_model_config(
@@ -391,6 +400,14 @@ fn prompt_passed(token_exact: bool, max_abs_logprob_delta: f32, tolerance: f32) 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn sha256_lowercase_hex_is_stable() {
+        assert_eq!(
+            hex_lower(&Sha256::digest(b"higgs")),
+            "a93f7a91f88ee389a5147b54b22968c2521a59e41b1bf98ff0d22d7b5a704a42"
+        );
+    }
 
     #[test]
     fn perturbation_reduces_the_current_argmax_logit() {

--- a/crates/higgs-engine/Cargo.toml
+++ b/crates/higgs-engine/Cargo.toml
@@ -24,7 +24,7 @@ tracing.workspace = true
 tokio = { version = "1", features = ["sync"] }
 outlines-core = { version = "0.2.14", default-features = false }
 half = { version = "2.4", features = ["bytemuck"] }
-sha2 = "0.10"
+sha2 = "0.11"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/higgs-engine/src/disk_prefix_store.rs
+++ b/crates/higgs-engine/src/disk_prefix_store.rs
@@ -1099,10 +1099,16 @@ fn sha256(bytes: &[u8]) -> [u8; 32] {
 fn key(tokens: &[u32], block_size: usize) -> String {
     let n = tokens.len() / block_size * block_size;
     let bytes: Vec<u8> = tokens[..n].iter().flat_map(|t| t.to_le_bytes()).collect();
-    hex(&sha256(&bytes))
+    hex_lower(&sha256(&bytes))
 }
-fn hex(bytes: &[u8]) -> String {
-    bytes.iter().map(|b| format!("{b:02x}")).collect()
+fn hex_lower(bytes: &[u8]) -> String {
+    const DIGITS: &[u8; 16] = b"0123456789abcdef";
+    let mut encoded = String::with_capacity(bytes.len().saturating_mul(2));
+    for &byte in bytes {
+        encoded.push(char::from(DIGITS[usize::from(byte >> 4)]));
+        encoded.push(char::from(DIGITS[usize::from(byte & 0x0f)]));
+    }
+    encoded
 }
 /// Build a temp-file path that is unique per writer, so two processes (or two
 /// writers in the same process) sharing a store directory cannot clobber each
@@ -1176,6 +1182,13 @@ mod tests {
     use tempfile::tempdir;
     fn identity() -> StoreIdentity {
         StoreIdentity::for_tests()
+    }
+    #[test]
+    fn sha256_digest_bytes_and_lowercase_hex_are_stable() {
+        assert_eq!(
+            hex_lower(&sha256(b"higgs")),
+            "a93f7a91f88ee389a5147b54b22968c2521a59e41b1bf98ff0d22d7b5a704a42"
+        );
     }
     #[test]
     fn round_trip_preserves_dense_payload() {


### PR DESCRIPTION
Supersedes #269. Renovate proposed sha2 0.10 → 0.11 as a lockfile/manifest bump, but 0.11 is a **breaking API change** that does not compile as-is:

```
error[E0277]: the trait bound `Array<u8, UInt<...>>: LowerHex` is not satisfied
   --> crates/higgs-bench/src/bin/quality_gate.rs:367
   Ok(format!("{:x}", Sha256::digest(bytes)))
```

sha2 0.11 returns `hybrid_array::Array` instead of `GenericArray`, which no longer implements `LowerHex`/`UpperHex`.

## What this does
Bumps sha2 to 0.11 in higgs-engine and higgs-bench and adapts every usage site (the disk prefix store's key/identity/payload-checksum hashing, and quality_gate's config hashing) to the new API with explicit lowercase-hex encoding — no new dependency added.

## Why the digests are safe
The disk KV store embeds sha256 digests in its on-disk format (file keys, store identity, payload checksum), so a hashing change would silently invalidate or corrupt every stored prefix. Verified they are unchanged:
- Digest-stability tests added in **both** crates hard-coding `sha256("higgs") = a93f7a91f88ee389a5147b54b22968c2521a59e41b1bf98ff0d22d7b5a704a42` — independently confirmed against Python's `hashlib`.
- Hash inputs and the `[u8; 32]` digest bytes are untouched; no store format version needed bumping (and none changed).
- The disk-store tests for identity mismatch, payload-checksum rejection and longest-prefix lookup still pass.

## End-to-end proof the feature still works
Restart-resume on a 7,000-token prompt with `kv_disk_dir` set: cold **9.84s** → after restart **0.55s** (~17.9×), with `Disk prefix hit token_count=6976 total_len=7000` in the log.

Gates: clippy `-Dwarnings` clean, fmt clean, higgs-engine 299 / higgs-bench / higgs 485+2+104 tests green.

Implemented by Codex CLI (gpt-5.6-sol, medium); reviewed and verified by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)