### PR TITLE
feat(models): add Escha trellis support

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ curl http://localhost:8000/v1/chat/completions \
 
 - Serve MLX models from Hugging Face IDs or local paths.
 - Support current model families including Qwen 3.8, Qwen 3.x, Llama, Mistral, Gemma 2, Phi-3, Starcoder2, DeepSeek-V2, and LLaVA-Qwen2. Qwen 3.5+ checkpoints (3.5, 3.6, and 3.8; dense and MoE) use the Qwen 3.5 adapters, including `*ForConditionalGeneration` wrappers whose text-model config lives in `text_config`. Unknown newer versions in a supported family use the nearest structurally compatible adapter and log an untested-version warning; unknown families are rejected with the supported family/version list.
+- Load EschaLabs `eschamoe` trellis-quantized checkpoints (for example `EschaLabs/Qwen3.6-35B-A3B-Escha-W2`) with automatic detection and no config field needed. Experts remain in trellis form and decode on the GPU; the 35B release holds about 11 GB and loads in seconds. See [docs/models.md](docs/models.md#eschalabs-eschamoe-checkpoints).
 - Expose local serving through OpenAI and Anthropic-compatible endpoints.
 
 ### Use one endpoint for local and remote models
@@ -133,6 +134,7 @@ curl http://localhost:8000/v1/chat/completions \
 - `[local].raise_wired_limit` defaults to `false`. Enable it only when you explicitly want MLX to raise the process wired-memory limit.
 - `batch=true` is only supported for transformer families with true batched decode support.
 - For batch models, `prefill_yield_tokens` can interleave long prompt prefills with decode; use `0` or omit it for the synchronous default.
+- EschaLabs `eschamoe` checkpoints keep their experts in the trellis form by default: 12.3 GB on disk becomes ~11 GB resident for the 35B release, and the load takes seconds. Set `HIGGS_ESCHA_NATIVE=0` to decode every expert to affine 4-bit instead, which raises the same model to ~22 GB resident and ~140 s of CPU-bound conversion at start. `higgs doctor` estimates the resident size for the active mode and warns when it crowds system RAM.
 
 ## Performance
 

--- a/crates/higgs-models/src/bonsai_q1.rs
+++ b/crates/higgs-models/src/bonsai_q1.rs
@@ -1219,8 +1219,10 @@ fn load_packed(
     }
 
     let w_packed: Vec<u32> = w_bytes
-        .chunks_exact(4)
-        .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .map(|c| u32::from_le_bytes(*c))
         .collect();
     let scales = bytes_to_f16_vec(s_bytes);
     let biases = bytes_to_f16_vec(b_bytes);
@@ -1240,8 +1242,10 @@ fn load_f16(tensors: &SafeTensors<'_>, name: &str) -> Result<Vec<f16>, String> {
 }
 
 fn bytes_to_f16_vec(b: &[u8]) -> Vec<f16> {
-    b.chunks_exact(2)
-        .map(|c| f16::from_bits(u16::from_le_bytes([c[0], c[1]])))
+    b.as_chunks::<2>()
+        .0
+        .iter()
+        .map(|c| f16::from_bits(u16::from_le_bytes(*c)))
         .collect()
 }
 

--- a/crates/higgs-models/src/eschamoe.rs
+++ b/crates/higgs-models/src/eschamoe.rs
@@ -1,0 +1,2728 @@
+//! `EschaLabs` `eschamoe` weights. The format uses a trellis code.
+//!
+//! `eschamoe` is the EXL3 format of exllamav3. EXL3 is a variant of QTIP.
+//! `eschamoe` applies EXL3 to each expert. The checkpoint holds these tensors
+//! for each expert projection:
+//!
+//! | tensor        | dtype | shape                    |
+//! |---------------|-------|--------------------------|
+//! | `escha_code`  | I16   | `[E, in/16, out/16, 16K]` |
+//! | `escha_rin`   | F16   | `[E, in]`                |
+//! | `escha_rout`  | F16   | `[E, out]`               |
+//! | `escha_s_in`  | F32   | `[E, in]`                |
+//! | `escha_s_out` | F32   | `[E, out]`               |
+//! | `escha_config`| I32   | `[9]`                    |
+//!
+//! A dense checkpoint stores the same tensors without the `E` axis. The code
+//! tensor then has rank 3, and each scale vector has rank 1. Refer to
+//! [`ExpertAxis`].
+//!
+//! This equation gives the weight:
+//!
+//! ```text
+//! W[out, in] = (H128 . Ŵ . H128 * rin[:, None] * rout[None, :]).T
+//! ```
+//!
+//! `Ŵ` is the `[in, out]` matrix from the trellis code. The two scale vectors
+//! apply outside the Hadamard blocks. The tool `tools/escha_ref.py` shows the
+//! test data for this equation.
+//!
+//! This module gives correct results, but it is not the fast path. The CPU
+//! decodes the bits and the codebook. MLX does the Hadamard and the scale
+//! operations. The Metal kernel in [`crate::metal_kernel`] uses this module as
+//! its reference. The bit format and the tile order come from these MIT files
+//! of exllamav3: `exllamav3_ext/quant/pack.cu` and `exl3_lib/quantize.py`.
+
+// This module copies the reference kernels bit for bit. The mask operations
+// and the short casts are part of the algorithm. Tile indexes stay in range
+// because of the tile size. The tests `tile_perm_is_a_permutation` and
+// `decode_expert_codes_*` show this. The modules `turboquant` and `bonsai_q1`
+// use the same permission for the same reason.
+#![allow(
+    clippy::as_conversions,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::indexing_slicing
+)]
+
+use half::f16;
+use mlx_rs::ops::indexing::IndexOp;
+use mlx_rs::{Array, Dtype, ops};
+
+use crate::error::ModelError;
+
+/// The tile edge as an `i32` for the shape checks.
+const TILE_I32: i32 = 16;
+/// The number of elements on each edge of a tile.
+const TILE: usize = TILE_I32 as usize;
+/// The number of elements in one tile.
+const TILE_ELEMS: usize = TILE * TILE;
+/// The width of one Hadamard block. This is the only supported size. The
+/// function [`had_size`] selects the size for each axis.
+pub const HAD_BLOCK: i32 = 128;
+/// The Hadamard block sizes that this module supports.
+const HAD_SIZES: [i32; 1] = [HAD_BLOCK];
+/// The permitted distance of the `|rout|` mean from 1.0.
+const ROUT_MEAN_TOL: f32 = 0.05;
+/// The multiply constant of codebook 1 (`decode_3inst<1>`).
+const MCG_MULT: u32 = 0xCBAC_1FED;
+/// The instruction `lop3.b32 ..., 0x8fff8fff, 0x3b603b60, 0x6a` is equal to
+/// `(x & AND) ^ XOR`.
+const LOP3_AND: u32 = 0x8FFF_8FFF;
+const LOP3_XOR: u32 = 0x3B60_3B60;
+
+// ---------------------------------------------------------------------------
+// Codebooks
+// ---------------------------------------------------------------------------
+
+/// The reduce step of a codebook. It changes the 32 hash bits into one value.
+///
+/// A new codebook can add a variant here. The decode loop reads the variant
+/// from one `Codebook` value. Thus the loop stays branch-free.
+#[derive(Debug, Clone, Copy)]
+enum Reducer {
+    /// Add the two `f16` halves of the hash word.
+    SumF16Halves,
+}
+
+/// The data of one trellis codebook.
+///
+/// The decode equation is:
+/// `v = reduce(((code * mul + add) & mask) ^ xor) * scale + bias`.
+#[derive(Debug, Clone, Copy)]
+struct Codebook {
+    mul: u32,
+    add: u32,
+    mask: u32,
+    xor: u32,
+    reducer: Reducer,
+    scale: f32,
+    bias: f32,
+}
+
+/// Codebook 1 (`decode_3inst<1>`). The tests compare it with the released
+/// checkpoint. Do not change these values.
+const CODEBOOK_MCG: Codebook = Codebook {
+    mul: MCG_MULT,
+    add: 0,
+    mask: LOP3_AND,
+    xor: LOP3_XOR,
+    reducer: Reducer::SumF16Halves,
+    scale: 1.0,
+    bias: 0.0,
+};
+
+/// The codebook slot for each value of the `escha_config[3]` flag.
+///
+/// The slots 0 and 2 exist in exllamav3. Their decode steps have no
+/// verification here. Thus the slots hold no data, and the loader rejects
+/// them. To fill a slot, get reference codes and values from exllamav3.
+/// Then add a test like `unpack_tile_matches_reference`.
+const CODEBOOK_SLOTS: [Option<Codebook>; 3] = [None, Some(CODEBOOK_MCG), None];
+
+/// Give the codebook for one config flag, or an error.
+fn codebook_for_flag(flag: i32) -> Result<Codebook, ModelError> {
+    let index = usize::try_from(flag).ok();
+    match index.and_then(|i| CODEBOOK_SLOTS.get(i)) {
+        Some(&Some(codebook)) => Ok(codebook),
+        Some(&None) => Err(ModelError::UnsupportedModel(format!(
+            "eschamoe codebook flag {flag} is unverified: this module has no reference decode \
+             data for it; supply exllamav3 codes and values to enable it"
+        ))),
+        None => Err(ModelError::UnsupportedModel(format!(
+            "eschamoe codebook flag {flag} unknown: known flags are 0..=2, verified flag is 1"
+        ))),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Spec
+// ---------------------------------------------------------------------------
+
+/// The layout of one quantized projection. The data comes from the
+/// `escha_config` tensor.
+///
+/// The tensor holds nine values in this sequence: the tile edge, the value K
+/// (the number of bits for each weight), the number of bits, the MCG codebook
+/// flag, the number of experts, the input size, the output size, the padded
+/// input size, and the padded output size.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EschaSpec {
+    pub k: usize,
+    pub mcg: bool,
+    pub num_experts: i32,
+    pub in_features: i32,
+    pub out_features: i32,
+}
+
+impl EschaSpec {
+    /// Read the layout from the `escha_config` tensor of nine values.
+    ///
+    /// # Pad note
+    ///
+    /// This function rejects a checkpoint with `in_p > in` or `out_p > out`.
+    /// The pad layout is unverified, not impossible. The working hypothesis:
+    /// the quantizer adds zero rows and columns at the end, before the
+    /// trellis step. The safe strip would then be: decode the full matrix,
+    /// apply the Hadamard, apply the scales, transpose, and slice
+    /// `[..out, ..in]`. The blockwise Hadamard mixes pad rows into real
+    /// rows. Thus a slice before the Hadamard is wrong. To settle it,
+    /// quantize a small padded matrix with exllamav3. Then compare the two
+    /// strip orders against the source matrix.
+    pub fn from_config(config: &[i32]) -> Result<Self, ModelError> {
+        let [
+            tile,
+            k,
+            _bits,
+            mcg,
+            num_experts,
+            in_features,
+            out_features,
+            in_p,
+            out_p,
+        ] = *<&[i32; 9]>::try_from(config).map_err(|_| {
+            ModelError::ShapeMismatch(format!(
+                "escha_config must have 9 elements, got {}",
+                config.len()
+            ))
+        })?;
+
+        if tile != TILE_I32 {
+            return Err(ModelError::UnsupportedModel(format!(
+                "eschamoe tile size {tile} unsupported (only {TILE})"
+            )));
+        }
+        codebook_for_flag(mcg)?;
+        if !(1..=8).contains(&k) {
+            return Err(ModelError::UnsupportedModel(format!(
+                "eschamoe K={k} out of range 1..=8"
+            )));
+        }
+        for (name, dim, padded) in [("in", in_features, in_p), ("out", out_features, out_p)] {
+            if padded < dim {
+                return Err(ModelError::ShapeMismatch(format!(
+                    "eschamoe {name} padded size {padded} is less than {name}_features {dim}"
+                )));
+            }
+            if padded % TILE_I32 != 0 {
+                return Err(ModelError::ShapeMismatch(format!(
+                    "eschamoe {name} padded size {padded} is not a multiple of the tile edge \
+                     {TILE}"
+                )));
+            }
+            had_size(padded, name)?;
+        }
+        // Refer to the pad note above. The pad layout is unverified. A decode
+        // with a guessed layout could give wrong weights. Thus the function
+        // rejects it.
+        if in_p != in_features || out_p != out_features {
+            return Err(ModelError::UnsupportedModel(format!(
+                "eschamoe padded dims {in_features}->{in_p}, {out_features}->{out_p}: the pad \
+                 layout is unverified (see the pad note on EschaSpec::from_config)"
+            )));
+        }
+
+        Ok(Self {
+            k: usize::try_from(k).unwrap_or(0),
+            // Only flag 1 passes the codebook gate above. Thus `mcg` is true.
+            mcg: true,
+            num_experts,
+            in_features,
+            out_features,
+        })
+    }
+
+    /// Give the number of tiles on the input axis and the output axis.
+    pub const fn tiles(&self) -> (usize, usize) {
+        (
+            self.in_features as usize / TILE,
+            self.out_features as usize / TILE,
+        )
+    }
+
+    /// Give the number of `u16` words in one packed tile.
+    pub const fn words_per_tile(&self) -> usize {
+        TILE * self.k
+    }
+}
+
+/// The expert axis of one trellis projection.
+///
+/// An expert checkpoint stores each projection with a leading expert axis.
+/// A dense checkpoint stores one matrix and has no expert axis.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExpertAxis {
+    /// No expert axis. The code tensor has rank 3, and each scale vector
+    /// has rank 1.
+    Dense,
+    /// A leading expert axis with this number of experts. The code tensor
+    /// has rank 4, and each scale vector has rank 2.
+    Experts(i32),
+}
+
+impl ExpertAxis {
+    /// Derive the axis from `escha_config[4]` and the code tensor rank.
+    ///
+    /// The two sources must agree. A dense code tensor needs a config value
+    /// of zero or one. An expert code tensor needs a config value of one or
+    /// more. On disagreement, the error names both values.
+    pub fn derive(config_experts: i32, code_rank: usize) -> Result<Self, ModelError> {
+        match (code_rank, config_experts) {
+            (3, 0 | 1) => Ok(Self::Dense),
+            (4, experts) if experts >= 1 => Ok(Self::Experts(experts)),
+            (3, experts) => Err(ModelError::ShapeMismatch(format!(
+                "escha_config[4] gives {experts} experts, but escha_code has rank 3 (the dense \
+                 layout permits 0 or 1)"
+            ))),
+            (4, experts) => Err(ModelError::ShapeMismatch(format!(
+                "escha_config[4] gives {experts} experts, but escha_code has rank 4 (the expert \
+                 layout needs 1 or more)"
+            ))),
+            (rank, experts) => Err(ModelError::ShapeMismatch(format!(
+                "escha_code has rank {rank} with {experts} experts in escha_config[4]; the rank \
+                 must be 3 (dense) or 4 (experts)"
+            ))),
+        }
+    }
+
+    /// Give the number of matrices to decode.
+    pub const fn count(self) -> i32 {
+        match self {
+            Self::Dense => 1,
+            Self::Experts(experts) => experts,
+        }
+    }
+}
+
+/// The length convention of one scale vector.
+///
+/// A checkpoint can store each scale vector with the logical length or with
+/// the padded length. The loader records the convention here. The record
+/// matters for a future pad strip. Refer to the pad note on
+/// [`EschaSpec::from_config`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScaleLen {
+    /// The vector length equals the feature count.
+    Logical,
+    /// The vector length equals the padded feature count.
+    Padded,
+}
+
+/// The validated layout of one trellis projection.
+#[derive(Debug, Clone, Copy)]
+pub struct TrellisLayout {
+    /// The parsed config values.
+    pub spec: EschaSpec,
+    /// The expert axis of the six tensors.
+    pub expert_axis: ExpertAxis,
+    /// The length convention of `rin` and `s_in`.
+    pub scale_len_in: ScaleLen,
+    /// The length convention of `rout` and `s_out`.
+    pub scale_len_out: ScaleLen,
+}
+
+// ---------------------------------------------------------------------------
+// Trellis decode
+// ---------------------------------------------------------------------------
+
+/// Give the element order in a tile of 16 by 16. EXL3 writes the elements in
+/// this order (`exl3_lib::tensor_core_perm`).
+///
+/// Item `i` of the result is the row-major position of stored element `i`.
+fn tile_perm() -> [u8; TILE_ELEMS] {
+    let mut perm = [0u8; TILE_ELEMS];
+    for t in 0..32 {
+        let r0 = (t % 4) * 2;
+        let c0 = t / 4;
+        let rows = [r0, r0 + 1, r0 + 8, r0 + 9];
+        for (j, c) in [c0, c0 + 8].into_iter().enumerate() {
+            for (i, r) in rows.into_iter().enumerate() {
+                // r, c < 16 so r * 16 + c < 256 and the cast cannot truncate.
+                perm[t * 8 + j * 4 + i] = (r * TILE + c) as u8;
+            }
+        }
+    }
+    perm
+}
+
+/// Change a trellis code of 16 bits into its codebook value.
+///
+/// The hash step multiplies the code, adds a constant, and applies a mask
+/// and an XOR. The reduce step changes the hash word into one value. Last,
+/// the scale and the bias apply. For codebook 1, the values have an
+/// approximate Gaussian distribution.
+#[inline]
+fn decode_code(code: u16, cb: &Codebook) -> f32 {
+    let x = (u32::from(code).wrapping_mul(cb.mul).wrapping_add(cb.add) & cb.mask) ^ cb.xor;
+    let reduced = match cb.reducer {
+        Reducer::SumF16Halves => {
+            f32::from(f16::from_bits(x as u16)) + f32::from(f16::from_bits((x >> 16) as u16))
+        }
+    };
+    reduced.mul_add(cb.scale, cb.bias)
+}
+
+/// Give the four hash constants of the codebook for the GPU decode.
+///
+/// The result holds the multiply, the add, the mask, and the XOR values.
+/// The Metal kernel supports only the verified codebook 1. That codebook
+/// adds the two `f16` halves and has a neutral scale and bias. For any
+/// other configuration, the function gives `None`. The kernel must then
+/// refuse the decode.
+// Phase 3 connects the kernel to the forward path. Until then, only the
+// tests use this chain. The allow keeps the lib target quiet.
+#[allow(dead_code)]
+pub(crate) fn gpu_codebook(spec: &EschaSpec) -> Option<[u32; 4]> {
+    if !spec.mcg {
+        return None;
+    }
+    let cb = CODEBOOK_MCG;
+    let neutral = cb.scale.to_bits() == 1.0f32.to_bits() && cb.bias.to_bits() == 0.0f32.to_bits();
+    (matches!(cb.reducer, Reducer::SumF16Halves) && neutral)
+        .then_some([cb.mul, cb.add, cb.mask, cb.xor])
+}
+
+/// Change a trellis code with codebook 1. The name comes from the CUDA
+/// function `decode_3inst<1>`. The tests use this helper.
+#[cfg(test)]
+fn decode_3inst(code: u16) -> f32 {
+    decode_code(code, &CODEBOOK_MCG)
+}
+
+/// Get the 256 trellis codes from one packed tile.
+///
+/// Each code is a window of 16 bits into a circular bit stream. The stream has
+/// `256 * K` bits. The step between two codes is `K` bits. Thus two adjacent
+/// codes have `16 - K` bits in common.
+///
+/// This function is a copy of `unpack_trellis_kernel`. In that kernel, thread
+/// `t` gives code `2t` and code `2t + 1`.
+fn unpack_tile(packed: &[u16], k: usize, codes: &mut [u16; TILE_ELEMS]) {
+    let n_words = k * TILE_ELEMS / 32;
+    // Read two little-endian `u16` values as one `u32`. The CUDA kernel does
+    // the same.
+    let word = |index: usize| -> u32 {
+        let lo = (index % n_words) * 2;
+        u32::from(packed[lo]) | (u32::from(packed[lo + 1]) << 16)
+    };
+
+    for t in 0..TILE_ELEMS / 2 {
+        // The term `+ TILE_ELEMS * k` is the wrap of the circular stream. It
+        // comes before `- 16`. Thus the unsigned result stays 0 or more when
+        // `t` is 0.
+        let b0 = t * 2 * k + k + TILE_ELEMS * k - 16;
+        let b2 = b0 + k + 16;
+        let i0 = b0 / 32;
+        let i1 = (b2 - 1) / 32;
+        let s1 = (i1 + 1) * 32 - b2;
+
+        let pair = (u64::from(word(i0)) << 32) | u64::from(word(i1));
+        let w1 = (pair >> s1) as u32;
+        codes[2 * t] = ((w1 >> k) & 0xFFFF) as u16;
+        codes[2 * t + 1] = (w1 & 0xFFFF) as u16;
+    }
+}
+
+/// Decode the packed codes of one expert into an `[in, out]` f16 matrix.
+///
+/// The result is `Ŵ`. The function [`dequant_expert`] applies the Hadamard and
+/// the channel scales after this step. Those operations are small, and the GPU
+/// does them.
+fn decode_expert_codes(packed: &[u16], spec: &EschaSpec) -> Vec<f16> {
+    let (tiles_k, tiles_n) = spec.tiles();
+    let words = spec.words_per_tile();
+    let perm = tile_perm();
+    let row_len = spec.out_features as usize;
+
+    // Only codebook 1 passes `EschaSpec::from_config`. Refer to
+    // `CODEBOOK_SLOTS`. The loop reads the codebook data, not a flag.
+    let cb = CODEBOOK_MCG;
+    let mut out = vec![f16::ZERO; tiles_k * TILE * row_len];
+    let mut codes = [0u16; TILE_ELEMS];
+
+    for tk in 0..tiles_k {
+        for tn in 0..tiles_n {
+            let base = (tk * tiles_n + tn) * words;
+            unpack_tile(&packed[base..base + words], spec.k, &mut codes);
+            for (i, &code) in codes.iter().enumerate() {
+                // Move each element from the stored order to its row-major
+                // position in the tile.
+                let slot = usize::from(perm[i]);
+                let (r, c) = (slot / TILE, slot % TILE);
+                out[(tk * TILE + r) * row_len + tn * TILE + c] =
+                    f16::from_f32(decode_code(code, &cb));
+            }
+        }
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Dequantization
+// ---------------------------------------------------------------------------
+
+/// Give the Hadamard block size for one axis length.
+///
+/// The module supports one size today. The value is per axis. Thus a future
+/// checkpoint can use a different size on each axis. The function gives an
+/// error when no supported size divides the length. Do not derive the size
+/// from the `rin` values: `|rin|` is not a scaled sign vector.
+fn had_size(dim: i32, name: &str) -> Result<i32, ModelError> {
+    HAD_SIZES
+        .into_iter()
+        .find(|&block| dim > 0 && dim % block == 0)
+        .ok_or_else(|| {
+            ModelError::UnsupportedModel(format!(
+                "eschamoe {name} size {dim}: no supported Hadamard block {HAD_SIZES:?} divides it"
+            ))
+        })
+}
+
+/// Apply an orthonormal Hadamard on `axis`. The block size comes from the
+/// axis length. Refer to [`had_size`].
+fn had_blockwise(x: &Array, axis: i32) -> Result<Array, ModelError> {
+    let moved = ops::swap_axes(x, axis, -1)?;
+    let shape = moved.shape().to_vec();
+    let last = *shape.last().unwrap_or(&0);
+    let block = had_size(last, "Hadamard axis")?;
+    let blocked = moved.reshape(&[-1, last / block, block])?;
+    let transformed = blocked.hadamard_transform(None)?;
+    Ok(ops::swap_axes(&transformed.reshape(&shape)?, axis, -1)?)
+}
+
+/// Build the weight of one expert as an `[out, in]` matrix.
+///
+/// The parameter `code` is the `[in/16, out/16, 16K]` slice of that expert.
+/// The four scale vectors are its `[in]` and `[out]` slices.
+///
+/// In the released checkpoint, all values of `s_in` and `s_out` are 1.0. This
+/// function applies them because a different checkpoint can have other
+/// values.
+pub fn dequant_expert(
+    code: &Array,
+    rin: &Array,
+    rout: &Array,
+    s_in: &Array,
+    s_out: &Array,
+    spec: &EschaSpec,
+) -> Result<Array, ModelError> {
+    let (tiles_k, tiles_n) = spec.tiles();
+    let expected = [
+        i32::try_from(tiles_k).unwrap_or(i32::MAX),
+        i32::try_from(tiles_n).unwrap_or(i32::MAX),
+        i32::try_from(spec.words_per_tile()).unwrap_or(i32::MAX),
+    ];
+    if code.shape() != expected {
+        return Err(ModelError::ShapeMismatch(format!(
+            "escha_code expected {expected:?}, got {:?}",
+            code.shape()
+        )));
+    }
+
+    let packed: Vec<u16> = code.as_dtype(Dtype::Uint16)?.as_slice::<u16>().to_vec();
+    let decoded = decode_expert_codes(&packed, spec);
+    let w = Array::from_slice(&decoded, &[spec.in_features, spec.out_features]);
+
+    // The scales apply outside the Hadamard on the two axes. Refer to the
+    // module documentation.
+    let scale_in = rin.multiply(s_in)?.reshape(&[spec.in_features, 1])?;
+    let scale_out = rout.multiply(s_out)?.reshape(&[1, spec.out_features])?;
+    let rotated = had_blockwise(&had_blockwise(&w, 0)?, 1)?;
+    let scaled = rotated.multiply(&scale_in)?.multiply(&scale_out)?;
+    Ok(ops::swap_axes(&scaled, 0, 1)?)
+}
+
+// ---------------------------------------------------------------------------
+// Native expert forward
+// ---------------------------------------------------------------------------
+
+/// One expert projection in native trellis form.
+///
+/// The struct keeps the packed code words resident. It folds the four scale
+/// vectors into two at load time. Refer to `factored_matvec_matches_dequant_expert`
+/// for the proof of the factored form.
+#[derive(Debug, Clone)]
+pub struct EschaProj {
+    /// The trellis words. Shape `[E, in/16, out/16, 16K]`, dtype int16.
+    pub code: Array,
+    /// The folded input scale `rin * s_in`. Shape `[E, in]`, dtype f32.
+    pub su: Array,
+    /// The folded output scale `rout * s_out`. Shape `[E, out]`, dtype f32.
+    pub sv: Array,
+    /// The tile layout of `code`.
+    pub spec: EschaSpec,
+}
+
+/// The stacked expert projections of one `SwitchMLP` block.
+///
+/// The checkpoint stores gate and up as one fused tensor. Thus the block
+/// holds two projections, not three.
+#[derive(Debug, Clone)]
+pub struct EschaSwitchMlp {
+    /// The fused gate+up projection. Its output size is `2 * intermediate`.
+    pub gate_up: EschaProj,
+    /// The down projection.
+    pub down: EschaProj,
+}
+
+impl EschaProj {
+    /// The row limit for the matvec kernel path.
+    ///
+    /// The matvec kernel decodes the expert weight again for each row. The
+    /// scratch path decodes each selected expert once. At 32 rows the two
+    /// decode costs are equal in the worst case. Below the limit, the matvec
+    /// path also avoids one CPU sync and the scratch buffer.
+    const GATHER_QMV_MAX_ROWS: i32 = 32;
+
+    /// Fold the scale vectors and keep the code words.
+    pub fn new(
+        code: Array,
+        rin: &Array,
+        rout: &Array,
+        s_in: &Array,
+        s_out: &Array,
+        spec: EschaSpec,
+    ) -> Result<Self, ModelError> {
+        let su = rin
+            .as_dtype(Dtype::Float32)?
+            .multiply(s_in.as_dtype(Dtype::Float32)?)?;
+        let sv = rout
+            .as_dtype(Dtype::Float32)?
+            .multiply(s_out.as_dtype(Dtype::Float32)?)?;
+        Ok(Self { code, su, sv, spec })
+    }
+
+    /// Apply the projection to each row with its own expert.
+    ///
+    /// The input `x` has shape `[rows, in]` in a float dtype. The input
+    /// `eids` has shape `[rows]`, dtype uint32. Sorted ids give the best
+    /// speed on the scratch path. Unsorted ids stay correct on both paths.
+    /// The result has shape `[rows, out]`, dtype f32.
+    pub fn gather_forward(&self, x: &Array, eids: &Array) -> Result<Array, ModelError> {
+        let rows = *x.shape().first().ok_or_else(|| {
+            ModelError::ShapeMismatch("gather_forward input must be [rows, in]".to_owned())
+        })?;
+        let su_rows = self.su.take_axis(eids, 0)?;
+        let sv_rows = self.sv.take_axis(eids, 0)?;
+        let xh = had_blockwise(&x.as_dtype(Dtype::Float32)?.multiply(&su_rows)?, -1)?;
+        let y_pre = if rows <= Self::GATHER_QMV_MAX_ROWS {
+            crate::metal_kernel::eschamoe_gather_qmv(&xh, &self.code, eids, &self.spec)?
+        } else {
+            self.scratch_matmul(&xh, eids)?
+        };
+        Ok(had_blockwise(&y_pre, -1)?.multiply(&sv_rows)?)
+    }
+
+    /// Apply the projection through a decoded scratch weight.
+    ///
+    /// The function splits the rows into runs with one expert each. It
+    /// decodes the expert of each run once. Then one matmul serves the whole
+    /// run.
+    // ponytail: the ceiling is the decode bandwidth. Each prefill call writes
+    // and reads up to E_used * in * out half words of scratch. A native
+    // trellis GEMM kernel would remove the scratch traffic. Build one when
+    // prefill throughput becomes the bottleneck.
+    fn scratch_matmul(&self, xh: &Array, eids: &Array) -> Result<Array, ModelError> {
+        let ids: Vec<u32> = eids.as_slice::<u32>().to_vec();
+        let mut run_experts: Vec<u32> = Vec::new();
+        let mut boundaries: Vec<i32> = Vec::new();
+        for (i, &id) in ids.iter().enumerate() {
+            if run_experts.last() == Some(&id) {
+                continue;
+            }
+            run_experts.push(id);
+            if i > 0 {
+                boundaries.push(
+                    i32::try_from(i).map_err(|_| {
+                        ModelError::ShapeMismatch("row count exceeds i32".to_owned())
+                    })?,
+                );
+            }
+        }
+        let parts = xh.split_axis(&boundaries, Some(0))?;
+        let mut segments: Vec<Array> = Vec::with_capacity(parts.len());
+        for (part, &expert) in parts.iter().zip(&run_experts) {
+            let sel = Array::from_slice(&[expert], &[1]);
+            let code_e = self.code.take_axis(&sel, 0)?.squeeze_axes(&[0])?;
+            let w_e = crate::metal_kernel::eschamoe_dequant_tiles(&code_e, &self.spec)?
+                .as_dtype(Dtype::Float32)?;
+            segments.push(ops::matmul(part, &w_e)?);
+        }
+        let refs: Vec<&Array> = segments.iter().collect();
+        Ok(ops::concatenate_axis(&refs, 0)?)
+    }
+}
+
+/// Dequantize a per-output-channel int8 tensor: `w[o, i] * scale[o]`.
+///
+/// Used for every non-expert projection in the checkpoint (`weight_int8` +
+/// `weight_scale`).
+pub fn dequant_int8(weight: &Array, scale: &Array) -> Result<Array, ModelError> {
+    let rows = *weight
+        .shape()
+        .first()
+        .ok_or_else(|| ModelError::ShapeMismatch("int8 weight must be at least 1-D".to_owned()))?;
+    if scale.shape() != [rows] {
+        return Err(ModelError::ShapeMismatch(format!(
+            "weight_scale expected [{rows}], got {:?}",
+            scale.shape()
+        )));
+    }
+    let per_row = scale.as_dtype(Dtype::Float32)?.reshape(&[rows, 1])?;
+    Ok(weight.as_dtype(Dtype::Float32)?.multiply(&per_row)?)
+}
+
+// ---------------------------------------------------------------------------
+// Checkpoint keys
+// ---------------------------------------------------------------------------
+
+/// The suffixes of the six tensors of one trellis projection.
+pub const CODE_SUFFIX: &str = ".escha_code";
+pub const CONFIG_SUFFIX: &str = ".escha_config";
+pub const ESCHA_SUFFIXES: [&str; 6] = [
+    ".escha_code",
+    ".escha_config",
+    ".escha_rin",
+    ".escha_rout",
+    ".escha_s_in",
+    ".escha_s_out",
+];
+/// The suffixes of an int8 projection. It has one scale for each output
+/// channel.
+pub const INT8_WEIGHT_SUFFIX: &str = ".weight_int8";
+pub const INT8_SCALE_SUFFIX: &str = ".weight_scale";
+
+/// Change an eschamoe key to the format that the Qwen3.5 loader accepts.
+///
+/// Escha uses the names of transformers v5, for example
+/// `model.language_model.layers.N...`. The loader in [`crate::qwen3_next`]
+/// accepts the mlx-community sequence, for example
+/// `language_model.model.layers.N...`. The loader then removes the first part
+/// to get the parameter path `model.layers.N...`.
+///
+/// This function moves the first two parts. Thus the loader can read an escha
+/// checkpoint with no other change.
+///
+/// The keys that start with `mtp.` are already correct. They do not change.
+pub fn normalize_key(key: &str) -> std::borrow::Cow<'_, str> {
+    use std::borrow::Cow;
+    key.strip_prefix("model.language_model.").map_or_else(
+        || {
+            if key.starts_with("lm_head.") {
+                Cow::Owned(format!("language_model.{key}"))
+            } else {
+                Cow::Borrowed(key)
+            }
+        },
+        |rest| Cow::Owned(format!("language_model.model.{rest}")),
+    )
+}
+
+/// The storage type of a checkpoint tensor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Storage {
+    /// One of the six trellis tensors. It has the projection prefix.
+    Trellis,
+    /// A `weight_int8` tensor or a `weight_scale` tensor.
+    Int8,
+    /// A bf16 tensor. Examples are the norms, the router gate, and the GDN
+    /// values.
+    Dense,
+}
+
+/// Give the storage type of a key and its projection prefix.
+///
+/// For a dense tensor, the prefix is the full key.
+pub fn classify(key: &str) -> (Storage, &str) {
+    for suffix in ESCHA_SUFFIXES {
+        if let Some(prefix) = key.strip_suffix(suffix) {
+            return (Storage::Trellis, prefix);
+        }
+    }
+    for suffix in [INT8_WEIGHT_SUFFIX, INT8_SCALE_SUFFIX] {
+        if let Some(prefix) = key.strip_suffix(suffix) {
+            return (Storage::Int8, prefix);
+        }
+    }
+    (Storage::Dense, key)
+}
+
+/// Whether a key holds an `RMSNorm` weight the checkpoint stores as `w - 1`.
+///
+/// Escha centres its norm weights on zero. Every `RMSNorm` follows that
+/// convention except the gated norm of the GDN block, which keeps the plain
+/// weight. Measured against `mlx-community/Qwen3.6-35B-A3B-4bit`, all 101
+/// offset tensors match at `|escha + 1 - base| <= 0.008`, the bf16 step, and
+/// the 30 `linear_attn.norm` tensors match exactly with no offset.
+///
+/// A norm is the only 1-D weight whose last name part holds `norm`, so the
+/// name gives the answer with no list of layers to maintain.
+fn is_offset_rmsnorm(key: &str) -> bool {
+    let Some(module) = key.strip_suffix(".weight") else {
+        return false;
+    };
+    !module.ends_with(".linear_attn.norm")
+        && module
+            .rsplit('.')
+            .next()
+            .is_some_and(|part| part.contains("norm"))
+}
+
+// ---------------------------------------------------------------------------
+// Checkpoint conversion
+// ---------------------------------------------------------------------------
+
+/// The affine quantization values for one projection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AffineTarget {
+    pub group_size: i32,
+    pub bits: i32,
+}
+
+/// The affine layout that the conversion code makes.
+///
+/// An eschamoe checkpoint has no MLX `quantization` block. Its
+/// `quantization_config` block gives the trellis bit rate, for example 2.0.
+/// That value is not an affine bit rate, and the model must not use it. Thus
+/// the loader sets this layout for the model and the conversion code. The
+/// values agree with `mlx-community/Qwen3.6-35B-A3B-4bit`.
+pub const CONVERSION_TARGET: AffineTarget = AffineTarget {
+    group_size: 64,
+    bits: 4,
+};
+
+impl Default for AffineTarget {
+    fn default() -> Self {
+        CONVERSION_TARGET
+    }
+}
+
+impl AffineTarget {
+    /// Read the values from the `quantization` block of `config.json`.
+    ///
+    /// The block has a `group_size` value and a `bits` value. It can also have
+    /// a different pair of values for each parameter path. The mlx-community
+    /// checkpoints use this layout. For example, they set 8 bits for
+    /// `mlp.gate`.
+    pub fn resolve(quantization: Option<&serde_json::Value>, path: &str) -> Self {
+        let Some(cfg) = quantization else {
+            return Self::default();
+        };
+        let field = |value: &serde_json::Value, key: &str| -> Option<i32> {
+            value.get(key)?.as_i64()?.try_into().ok()
+        };
+        let base = Self {
+            group_size: field(cfg, "group_size").unwrap_or(64),
+            bits: field(cfg, "bits").unwrap_or(4),
+        };
+        cfg.get(path).map_or(base, |over| Self {
+            group_size: field(over, "group_size").unwrap_or(base.group_size),
+            bits: field(over, "bits").unwrap_or(base.bits),
+        })
+    }
+}
+
+/// The two parts of the escha `gate_up_proj` tensor on the output axis.
+///
+/// The checkpoint `mlx-community/Qwen3.6-35B-A3B-4bit` holds the two parts as
+/// separate tensors. A test compared them with the escha tensor. The first
+/// part agrees with `gate_proj`, and the second part agrees with `up_proj`.
+/// The cosine value for each pair is 0.966. The cosine value for the two other
+/// pairs is near 0.00.
+pub const FUSED_GATE_UP: [&str; 2] = ["gate_proj", "up_proj"];
+
+/// An affine tensor. It has three parts: the packed weight, the scales, and
+/// the biases.
+type Triple = [Array; 3];
+
+/// Quantize an `[out, in]` matrix into the three affine tensors.
+///
+/// MLX gives a short message when this operation fails. Thus the function adds
+/// the tensor name, the shape, and the layout to the error. A person can then
+/// find the cause.
+fn quantize_affine_named(
+    name: &str,
+    dense: &Array,
+    target: AffineTarget,
+) -> Result<Triple, ModelError> {
+    let last = dense.shape().last().copied().unwrap_or(0);
+    if last % target.group_size != 0 {
+        return Err(ModelError::ShapeMismatch(format!(
+            "{name}: last dimension {last} is not a multiple of group_size {}",
+            target.group_size
+        )));
+    }
+    let (weight, scales, biases) =
+        ops::quantize(dense, target.group_size, target.bits).map_err(|e| {
+            ModelError::ShapeMismatch(format!(
+                "{name}: quantize shape {:?} group_size={} bits={} failed: {e}",
+                dense.shape(),
+                target.group_size,
+                target.bits
+            ))
+        })?;
+    Ok((weight, scales, biases).into())
+}
+
+fn quantize_affine(dense: &Array, target: AffineTarget) -> Result<Triple, ModelError> {
+    quantize_affine_named("tensor", dense, target)
+}
+
+/// Put the affine tensors of all experts into `[E, ...]` tensors.
+fn stack_triples(per_expert: &[Triple]) -> Result<Triple, ModelError> {
+    let mut stacked = Vec::with_capacity(3);
+    for axis in 0..3 {
+        let expanded: Vec<Array> = per_expert
+            .iter()
+            .map(|t| t[axis].expand_dims(0))
+            .collect::<Result<_, _>>()?;
+        let refs: Vec<&Array> = expanded.iter().collect();
+        stacked.push(ops::concatenate_axis(&refs, 0)?);
+    }
+    stacked
+        .try_into()
+        .map_err(|_| ModelError::ShapeMismatch("expected three stacked tensors".to_owned()))
+}
+
+/// Give the three parameter entries for one affine tensor.
+fn triple_entries(target: &str, [w, s, b]: Triple) -> [(String, Array); 3] {
+    [
+        (format!("{target}.weight"), w),
+        (format!("{target}.scales"), s),
+        (format!("{target}.biases"), b),
+    ]
+}
+
+/// The six tensors of one trellis projection.
+///
+/// The `prefix` field holds the checkpoint name of the projection, for example
+/// `model.layers.7.mlp.experts.gate_up_proj`. The checks name it in their
+/// messages, so a warning points at one tensor of the checkpoint.
+#[derive(Debug, Clone, Copy)]
+pub struct TrellisGroup<'a> {
+    pub prefix: &'a str,
+    pub code: &'a Array,
+    pub config: &'a Array,
+    pub rin: &'a Array,
+    pub rout: &'a Array,
+    pub s_in: &'a Array,
+    pub s_out: &'a Array,
+}
+
+impl TrellisGroup<'_> {
+    pub fn spec(&self) -> Result<EschaSpec, ModelError> {
+        let config: Vec<i32> = self.config.as_dtype(Dtype::Int32)?.as_slice().to_vec();
+        EschaSpec::from_config(&config)
+    }
+
+    /// Check the six tensors against the config and give the full layout.
+    ///
+    /// The checks are cheap and run before any decode:
+    ///
+    /// - the expert axis: the config value and the code rank must agree.
+    /// - the bit budget: the code bits must equal `experts * in_p * out_p * K`.
+    /// - the scale vectors: each shape must match the expert axis and one
+    ///   feature length.
+    /// - the `|rout|` mean: a value far from 1.0 gives a warning, not an
+    ///   error. The released checkpoint keeps the mean near 1.0.
+    pub fn validate(&self) -> Result<TrellisLayout, ModelError> {
+        let spec = self.spec()?;
+        let expert_axis = ExpertAxis::derive(spec.num_experts, self.code.ndim())?;
+        if let ExpertAxis::Experts(experts) = expert_axis {
+            let leading = self.code.shape().first().copied().unwrap_or(0);
+            if leading != experts {
+                return Err(ModelError::ShapeMismatch(format!(
+                    "escha_code leading dim {leading} does not equal the {experts} experts of \
+                     escha_config[4]"
+                )));
+            }
+        }
+        check_bit_budget(self.code, &spec, expert_axis)?;
+        // `from_config` rejects pads. Thus each padded length equals the
+        // logical length here, and the pair below carries the same value.
+        let scale_len_in = check_scale_pair(
+            ("escha_rin", self.rin),
+            ("escha_s_in", self.s_in),
+            expert_axis,
+            spec.in_features,
+            spec.in_features,
+        )?;
+        let scale_len_out = check_scale_pair(
+            ("escha_rout", self.rout),
+            ("escha_s_out", self.s_out),
+            expert_axis,
+            spec.out_features,
+            spec.out_features,
+        )?;
+        if let Some(mean) = rout_mean_if_off(self.rout)? {
+            tracing::warn!(
+                mean,
+                projection = self.prefix,
+                "eschamoe escha_rout |mean| is far from the expected 1.0; the checkpoint may \
+                 not follow the released convention"
+            );
+        }
+        Ok(TrellisLayout {
+            spec,
+            expert_axis,
+            scale_len_in,
+            scale_len_out,
+        })
+    }
+}
+
+/// Check the total bit budget of the code tensor.
+///
+/// Each stored word holds 16 bits. The trellis needs `K` bits for each
+/// weight. Thus the code bits must equal `experts * in_p * out_p * K`.
+fn check_bit_budget(code: &Array, spec: &EschaSpec, axis: ExpertAxis) -> Result<(), ModelError> {
+    let have = code.shape().iter().map(|&d| i64::from(d)).product::<i64>() * 16;
+    let need = i64::from(axis.count())
+        * i64::from(spec.in_features)
+        * i64::from(spec.out_features)
+        * i64::try_from(spec.k).unwrap_or(i64::MAX);
+    if have != need {
+        return Err(ModelError::ShapeMismatch(format!(
+            "escha_code holds {have} bits, expected {need} bits ({experts} experts x {in_f} x \
+             {out_f} x K={k})",
+            experts = axis.count(),
+            in_f = spec.in_features,
+            out_f = spec.out_features,
+            k = spec.k
+        )));
+    }
+    Ok(())
+}
+
+/// Check one pair of scale vectors on one axis. The two vectors must use the
+/// same length convention. Give that convention.
+fn check_scale_pair(
+    first: (&str, &Array),
+    second: (&str, &Array),
+    axis: ExpertAxis,
+    logical: i32,
+    padded: i32,
+) -> Result<ScaleLen, ModelError> {
+    let len_first = check_scale(first.0, first.1, axis, logical, padded)?;
+    let len_second = check_scale(second.0, second.1, axis, logical, padded)?;
+    if len_first == len_second {
+        Ok(len_first)
+    } else {
+        Err(ModelError::ShapeMismatch(format!(
+            "{} uses the {len_first:?} length but {} uses the {len_second:?} length",
+            first.0, second.0
+        )))
+    }
+}
+
+/// Check one scale vector against the expert axis and the feature lengths.
+fn check_scale(
+    name: &str,
+    vector: &Array,
+    axis: ExpertAxis,
+    logical: i32,
+    padded: i32,
+) -> Result<ScaleLen, ModelError> {
+    let shape = vector.shape();
+    let last = match (axis, shape) {
+        (ExpertAxis::Dense, [len]) => Some(*len),
+        (ExpertAxis::Experts(experts), [lead, len]) if *lead == experts => Some(*len),
+        (ExpertAxis::Dense | ExpertAxis::Experts(_), _) => None,
+    };
+    match last {
+        Some(len) if len == logical => Ok(ScaleLen::Logical),
+        Some(len) if len == padded => Ok(ScaleLen::Padded),
+        Some(_) | None => {
+            let expected = match axis {
+                ExpertAxis::Dense => format!("[{logical}]"),
+                ExpertAxis::Experts(experts) => format!("[{experts}, {logical}]"),
+            };
+            Err(ModelError::ShapeMismatch(format!(
+                "{name} expected {expected} (or the padded length {padded}), got {shape:?}"
+            )))
+        }
+    }
+}
+
+/// Give the mean of `|rout|` when it is far from 1.0.
+///
+/// The released checkpoint keeps the mean near 1.0. Six tensors gave values
+/// between 0.99971 and 1.00011. A future checkpoint can drop the convention.
+/// Thus the caller warns and does not fail.
+fn rout_mean_if_off(rout: &Array) -> Result<Option<f32>, ModelError> {
+    let mean = rout
+        .as_dtype(Dtype::Float32)?
+        .abs()?
+        .mean(None)?
+        .item::<f32>();
+    Ok(((mean - 1.0).abs() > ROUT_MEAN_TOL).then_some(mean))
+}
+
+/// Decode a trellis projection and quantize it to the affine format.
+///
+/// For an expert projection, the function decodes each expert and stacks the
+/// results on a leading `[E, ...]` axis. For a dense projection, the function
+/// decodes one matrix. Each dense result is then 2-D, with no expert axis.
+///
+/// The parameter `parts` divides the output axis into equal parts. Use 2 for
+/// the escha `gate_up_proj` tensor. Refer to [`FUSED_GATE_UP`]. Use 1 for the
+/// `down_proj` tensor. The function gives three affine tensors for each part.
+///
+/// The function decodes one expert at a time and keeps only the quantized
+/// result. The full set of experts in the f32 format is too large. For one
+/// projection, a `[256, 1024, 2048]` f32 tensor uses 2 GiB. One expert uses
+/// some MiB.
+pub fn convert_trellis(
+    group: TrellisGroup<'_>,
+    parts: i32,
+    target: AffineTarget,
+) -> Result<Vec<Triple>, ModelError> {
+    let layout = group.validate()?;
+    let spec = layout.spec;
+    if parts < 1 || spec.out_features % parts != 0 {
+        return Err(ModelError::ShapeMismatch(format!(
+            "cannot split {} output features into {parts} parts",
+            spec.out_features
+        )));
+    }
+    let rows = spec.out_features / parts;
+
+    match layout.expert_axis {
+        ExpertAxis::Dense => {
+            let dense = dequant_expert(
+                group.code,
+                group.rin,
+                group.rout,
+                group.s_in,
+                group.s_out,
+                &spec,
+            )?;
+            (0..parts)
+                .map(|part| {
+                    let lo = rows * part;
+                    quantize_affine(&dense.index((lo..lo + rows, ..)), target)
+                })
+                .collect()
+        }
+        ExpertAxis::Experts(experts) => {
+            let mut stacks: Vec<Vec<Triple>> =
+                vec![Vec::new(); usize::try_from(parts).unwrap_or(1)];
+            for expert in 0..experts {
+                let dense = dequant_expert(
+                    &group.code.index(expert),
+                    &group.rin.index(expert),
+                    &group.rout.index(expert),
+                    &group.s_in.index(expert),
+                    &group.s_out.index(expert),
+                    &spec,
+                )?;
+                for (part, stack) in stacks.iter_mut().enumerate() {
+                    let lo = rows * i32::try_from(part).unwrap_or(0);
+                    stack.push(quantize_affine(&dense.index((lo..lo + rows, ..)), target)?);
+                }
+            }
+            stacks.iter().map(|stack| stack_triples(stack)).collect()
+        }
+    }
+}
+
+/// Give the parameter names of one trellis projection.
+///
+/// An expert projection must sit under `mlp.experts`. It maps to the
+/// `switch_mlp` module of the model. The tensor `gate_up_proj` holds two
+/// projections. Thus it gives two names. Refer to [`FUSED_GATE_UP`].
+///
+/// A dense projection keeps its own prefix. A fused dense `gate_up_proj`
+/// tensor gives the two names next to it.
+fn projection_targets(prefix: &str, axis: ExpertAxis) -> Result<Vec<String>, ModelError> {
+    match (prefix.rsplit_once(".mlp.experts."), axis) {
+        (Some((stem, proj)), ExpertAxis::Experts(_)) => Ok(match proj {
+            "gate_up_proj" => FUSED_GATE_UP
+                .iter()
+                .map(|half| format!("{stem}.mlp.switch_mlp.{half}"))
+                .collect(),
+            other => vec![format!("{stem}.mlp.switch_mlp.{other}")],
+        }),
+        (Some(_), ExpertAxis::Dense) => Err(ModelError::UnsupportedModel(format!(
+            "dense trellis tensor under mlp.experts: {prefix}"
+        ))),
+        (None, ExpertAxis::Dense) => Ok(prefix.strip_suffix(".gate_up_proj").map_or_else(
+            || vec![prefix.to_owned()],
+            |stem| {
+                FUSED_GATE_UP
+                    .iter()
+                    .map(|half| format!("{stem}.{half}"))
+                    .collect()
+            },
+        )),
+        (None, ExpertAxis::Experts(_)) => Err(ModelError::UnsupportedModel(format!(
+            "expert trellis tensor outside mlp.experts: {prefix}"
+        ))),
+    }
+}
+
+/// Change a full eschamoe checkpoint into the affine tensors that the Qwen3.5
+/// loader accepts.
+///
+/// The result keys use the mlx-community format, for example
+/// `language_model.model.layers.N...`. Thus the caller can send them to the
+/// standard parameter code and the GDN fusion code.
+///
+/// The function operates on three storage types:
+///
+/// - the trellis tensors, dense or with experts. [`convert_trellis`] divides
+///   them and quantizes them.
+/// - the int8 tensors. The function decodes them and quantizes them.
+/// - the bf16 tensors. The function does not change them.
+///
+/// The sequence of the int8 step is important. The GDN fusion code looks for
+/// the names `.weight`, `.scales`, and `.biases`. Thus this function must make
+/// those three tensors before the fusion code starts.
+pub fn convert_checkpoint(
+    model_dir: &std::path::Path,
+    quantization: Option<&serde_json::Value>,
+) -> Result<Vec<(String, Array)>, ModelError> {
+    Ok(convert_checkpoint_impl(model_dir, quantization, false)?.0)
+}
+
+/// Whether the native expert path is on. Set `HIGGS_ESCHA_NATIVE=0` for the
+/// affine path.
+///
+/// The native path keeps each expert projection in its trellis form and reads
+/// it with the Metal kernel. The affine path decodes every expert and
+/// requantizes the result to 4 bits. For the 35B release the native path holds
+/// 11.2 GB and loads in about 6 s; the affine path holds 21.7 GB and takes
+/// about 140 s, which crowds a 32 GB machine. Thus the native path is the
+/// default, and the affine path stays available for comparison.
+pub fn native_mode() -> bool {
+    !std::env::var("HIGGS_ESCHA_NATIVE").is_ok_and(|v| v == "0")
+}
+
+/// The tensor list and the native expert weights of one conversion.
+pub type ConvertedCheckpoint = (Vec<(String, Array)>, Vec<(usize, EschaSwitchMlp)>);
+
+/// Convert a checkpoint and honor [`native_mode`].
+///
+/// In native mode, the expert projections do not decode. They stay in the
+/// trellis form as [`EschaSwitchMlp`] values. The second result gives one
+/// value for each layer. The first result then holds no expert affine
+/// tensors. All other tensors convert as in [`convert_checkpoint`].
+pub fn convert_checkpoint_auto(
+    model_dir: &std::path::Path,
+    quantization: Option<&serde_json::Value>,
+) -> Result<ConvertedCheckpoint, ModelError> {
+    convert_checkpoint_impl(model_dir, quantization, native_mode())
+}
+
+/// Give the layer index and the projection name of one expert prefix.
+///
+/// The prefix must sit in the main decoder stack. For example,
+/// `model.layers.7.mlp.experts.gate_up_proj` gives `(7, "gate_up_proj")`.
+/// Other prefixes give `None`, and the caller decodes them to affine.
+fn expert_layer_target(prefix: &str) -> Option<(usize, &str)> {
+    let (stem, rest) = prefix.split_once(".layers.")?;
+    if stem != "model" && stem != "language_model.model" {
+        return None;
+    }
+    let (index, tail) = rest.split_once('.')?;
+    let layer = index.parse::<usize>().ok()?;
+    let proj = tail.strip_prefix("mlp.experts.")?;
+    matches!(proj, "gate_up_proj" | "down_proj").then_some((layer, proj))
+}
+
+// The group loop must keep the take and eval sequence in one place. This
+// bounds the peak memory. Thus the function exceeds the line limit.
+#[allow(clippy::too_many_lines)]
+fn convert_checkpoint_impl(
+    model_dir: &std::path::Path,
+    quantization: Option<&serde_json::Value>,
+    native: bool,
+) -> Result<ConvertedCheckpoint, ModelError> {
+    use std::collections::HashMap;
+
+    let mut raw: HashMap<String, Array> = HashMap::new();
+    for file in crate::collect_safetensors_files(model_dir)? {
+        let loaded = Array::load_safetensors(file.to_str().unwrap_or_default())
+            .map_err(|e| ModelError::Io(std::io::Error::other(e.to_string())))?;
+        for (key, value) in loaded {
+            raw.insert(normalize_key(&key).into_owned(), value);
+        }
+    }
+
+    // Group by projection so the six trellis tensors (or the two int8 ones)
+    // are converted together.
+    let mut groups: HashMap<(Storage, String), Vec<String>> = HashMap::new();
+    for key in raw.keys() {
+        let (storage, prefix) = classify(key);
+        groups
+            .entry((storage, prefix.to_owned()))
+            .or_default()
+            .push(key.clone());
+    }
+
+    let mut out: Vec<(String, Array)> = Vec::with_capacity(raw.len());
+    // The native expert projections of each layer. The tuple holds the
+    // fused gate+up projection and then the down projection.
+    #[allow(clippy::type_complexity)]
+    let mut native_map: HashMap<usize, (Option<EschaProj>, Option<EschaProj>)> = HashMap::new();
+
+    // Each group makes its result and then frees its source tensors. A full
+    // checkpoint holds more than 11 GiB of packed data, and the affine result
+    // is larger again. If this loop kept both, the process would use too much
+    // memory. `take` removes each source tensor when the code reads it, and
+    // `eval` completes the MLX operations. MLX keeps the input of an
+    // incomplete operation, so the `eval` call is necessary to free it.
+    for ((storage, prefix), keys) in &groups {
+        let mut made: Vec<(String, Array)> = Vec::with_capacity(6);
+        let mut take = |key: &str| -> Result<Array, ModelError> {
+            raw.remove(key)
+                .ok_or_else(|| ModelError::MissingWeight(key.to_owned()))
+        };
+
+        match storage {
+            Storage::Dense => {
+                for key in keys {
+                    let value = take(key)?;
+                    // Escha keeps some projections in the bf16 format, for
+                    // example `mlp.gate` and the GDN `in_proj_a`. The model
+                    // makes a quantized layer for each of them, and that layer
+                    // needs a scales tensor and a biases tensor. Thus this code
+                    // quantizes each 2-D weight. The other dense tensors are
+                    // norms, the 3-D conv1d weight, or 1-D vectors. Only the
+                    // offset norms change; the rest go to the model as they
+                    // are.
+                    match key.strip_suffix(".weight").filter(|_| value.ndim() == 2) {
+                        Some(module) => {
+                            let target = AffineTarget::resolve(quantization, module);
+                            made.extend(triple_entries(
+                                module,
+                                quantize_affine_named(module, &value, target)?,
+                            ));
+                        }
+                        // Escha keeps the GDN conv1d weight in the PyTorch
+                        // sequence `[out, in/groups, kernel]`. MLX needs the
+                        // sequence `[out, kernel, in/groups]`. Thus this code
+                        // exchanges the last two axes.
+                        None if key.ends_with(".conv1d.weight") && value.ndim() == 3 => {
+                            made.push((key.clone(), ops::swap_axes(&value, 1, 2)?));
+                        }
+                        // An offset norm holds `w - 1`. Restore `w`, and keep
+                        // the checkpoint dtype so the model reads it as it
+                        // reads every other norm.
+                        None if is_offset_rmsnorm(key) => {
+                            let one = Array::from_f32(1.0).as_dtype(value.dtype())?;
+                            made.push((key.clone(), ops::add(&value, &one)?));
+                        }
+                        None => made.push((key.clone(), value)),
+                    }
+                }
+            }
+            Storage::Int8 => {
+                let weight = take(&format!("{prefix}{INT8_WEIGHT_SUFFIX}"))?;
+                let scale = take(&format!("{prefix}{INT8_SCALE_SUFFIX}"))?;
+                let dense = dequant_int8(&weight, &scale)?;
+                let target = AffineTarget::resolve(quantization, prefix);
+                made.extend(triple_entries(
+                    prefix,
+                    quantize_affine_named(prefix, &dense, target)?,
+                ));
+            }
+            Storage::Trellis => {
+                let code = take(&format!("{prefix}.escha_code"))?;
+                let config = take(&format!("{prefix}.escha_config"))?;
+                let rin = take(&format!("{prefix}.escha_rin"))?;
+                let rout = take(&format!("{prefix}.escha_rout"))?;
+                let s_in = take(&format!("{prefix}.escha_s_in"))?;
+                let s_out = take(&format!("{prefix}.escha_s_out"))?;
+                let group = TrellisGroup {
+                    prefix,
+                    code: &code,
+                    config: &config,
+                    rin: &rin,
+                    rout: &rout,
+                    s_in: &s_in,
+                    s_out: &s_out,
+                };
+                let axis = ExpertAxis::derive(group.spec()?.num_experts, code.ndim())?;
+                let native_target = (native && matches!(axis, ExpertAxis::Experts(_)))
+                    .then(|| expert_layer_target(prefix))
+                    .flatten();
+                if let Some((layer, proj)) = native_target {
+                    // Keep the expert projection in the trellis form. Do
+                    // not decode it. The eval call makes the folded scales
+                    // concrete and frees the source vectors.
+                    let spec = group.validate()?.spec;
+                    let built = EschaProj::new(code, &rin, &rout, &s_in, &s_out, spec)?;
+                    mlx_rs::transforms::eval([&built.code, &built.su, &built.sv])?;
+                    let slots = native_map.entry(layer).or_default();
+                    let slot = if proj == "gate_up_proj" {
+                        &mut slots.0
+                    } else {
+                        &mut slots.1
+                    };
+                    *slot = Some(built);
+                    continue;
+                }
+                let targets = projection_targets(prefix, axis)?;
+                let splits = i32::try_from(targets.len()).unwrap_or(1);
+                let affine = AffineTarget::resolve(quantization, prefix);
+                let converted = convert_trellis(group, splits, affine)?;
+                for (target, stacked) in targets.iter().zip(converted) {
+                    made.extend(triple_entries(target, stacked));
+                }
+            }
+        }
+
+        mlx_rs::transforms::eval(made.iter().map(|(_, a)| a))?;
+        out.extend(made);
+    }
+
+    let mut natives: Vec<(usize, EschaSwitchMlp)> = Vec::with_capacity(native_map.len());
+    for (layer, slots) in native_map {
+        match slots {
+            (Some(gate_up), Some(down)) => {
+                natives.push((layer, EschaSwitchMlp { gate_up, down }));
+            }
+            _ => {
+                return Err(ModelError::MissingWeight(format!(
+                    "layer {layer} misses one of its two native expert projections"
+                )));
+            }
+        }
+    }
+
+    tracing::info!(
+        tensors = out.len(),
+        groups = groups.len(),
+        native_layers = natives.len(),
+        "Converted eschamoe checkpoint to affine"
+    );
+    Ok((out, natives))
+}
+
+/// Whether `model_dir` holds an eschamoe checkpoint.
+///
+/// `quantize_config.json` is the authority; `config.json`'s
+/// `quantization_config.quant_method` is accepted as a fallback because the two
+/// duplicate the field.
+pub fn is_eschamoe_checkpoint(model_dir: &std::path::Path) -> Result<bool, ModelError> {
+    let method = |value: &serde_json::Value| -> Option<String> {
+        value
+            .get("quant_method")
+            .or_else(|| value.get("quantization_config")?.get("quant_method"))
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_owned)
+    };
+    for name in ["quantize_config.json", "config.json"] {
+        let path = model_dir.join(name);
+        if !path.exists() {
+            continue;
+        }
+        let text = std::fs::read_to_string(&path)?;
+        let value: serde_json::Value = serde_json::from_str(&text)?;
+        if let Some(found) = method(&value) {
+            return Ok(found == "eschamoe");
+        }
+    }
+    Ok(false)
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::print_stderr
+)]
+mod tests {
+    use mlx_rs::ops::indexing::IndexOp;
+
+    use super::*;
+
+    fn spec(k: usize, in_f: i32, out_f: i32) -> EschaSpec {
+        EschaSpec {
+            k,
+            mcg: true,
+            num_experts: 1,
+            in_features: in_f,
+            out_features: out_f,
+        }
+    }
+
+    /// Pack `codes` into the `[tiles_k, tiles_n, 16K]` i16 tensor the loader sees.
+    fn code_array(codes: &[u16], spec: &EschaSpec) -> Array {
+        let (tk, tn) = spec.tiles();
+        let signed: Vec<i16> = codes.iter().map(|&c| c.cast_signed()).collect();
+        let dims = [tk, tn, spec.words_per_tile()].map(|d| i32::try_from(d).unwrap());
+        Array::from_slice(&signed, &dims)
+    }
+
+    /// Give the directory of the test checkpoint.
+    fn test_model_dir() -> std::path::PathBuf {
+        std::env::var("HIGGS_ESCHA_TEST_MODEL")
+            .unwrap_or_else(|_| {
+                format!(
+                    "{}/AI-Models/escha-subset",
+                    std::env::var("HOME").unwrap_or_default()
+                )
+            })
+            .into()
+    }
+
+    fn pseudo_random(len: usize, seed: u64) -> Vec<u16> {
+        let mut state = seed;
+        (0..len)
+            .map(|_| {
+                state = state
+                    .wrapping_mul(6_364_136_223_846_793_005)
+                    .wrapping_add(1);
+                (state >> 33) as u16
+            })
+            .collect()
+    }
+
+    /// The owned tensors of one synthetic projection.
+    struct OwnedGroup {
+        code: Array,
+        config: Array,
+        rin: Array,
+        rout: Array,
+        s_in: Array,
+        s_out: Array,
+    }
+
+    impl OwnedGroup {
+        const fn as_group(&self) -> TrellisGroup<'_> {
+            TrellisGroup {
+                prefix: "synthetic",
+                code: &self.code,
+                config: &self.config,
+                rin: &self.rin,
+                rout: &self.rout,
+                s_in: &self.s_in,
+                s_out: &self.s_out,
+            }
+        }
+    }
+
+    /// Make one synthetic projection. `experts` selects the layout: `None`
+    /// gives the dense rank-3 layout, `Some(e)` gives the `[e, ...]` layout.
+    /// The scale values vary by channel with a zero-mean offset pattern.
+    fn synth_group(experts: Option<i32>, k: usize, in_f: i32, out_f: i32) -> OwnedGroup {
+        const OFFSETS: [f32; 5] = [-2.0, -1.0, 0.0, 1.0, 2.0];
+        let s = spec(k, in_f, out_f);
+        let (tk, tn) = s.tiles();
+        let words = s.words_per_tile();
+        let e = experts.unwrap_or(1);
+        let n = e as usize * tk * tn * words;
+        let signed: Vec<i16> = pseudo_random(n, 0xDA7A)
+            .iter()
+            .map(|&c| c.cast_signed())
+            .collect();
+        let mut dims = vec![
+            i32::try_from(tk).unwrap(),
+            i32::try_from(tn).unwrap(),
+            i32::try_from(words).unwrap(),
+        ];
+        if experts.is_some() {
+            dims.insert(0, e);
+        }
+        let channel = |len: i32, step: f32| -> Array {
+            let vals: Vec<f32> = (0..e * len)
+                .map(|i| OFFSETS[(i % 5) as usize].mul_add(step, 1.0))
+                .collect();
+            let shape = if experts.is_some() {
+                vec![e, len]
+            } else {
+                vec![len]
+            };
+            Array::from_slice(&vals, &shape)
+        };
+        let k_i32 = i32::try_from(k).unwrap();
+        OwnedGroup {
+            code: Array::from_slice(&signed, &dims),
+            config: Array::from_slice(
+                &[
+                    16,
+                    k_i32,
+                    k_i32,
+                    1,
+                    experts.unwrap_or(0),
+                    in_f,
+                    out_f,
+                    in_f,
+                    out_f,
+                ],
+                &[9],
+            ),
+            rin: channel(in_f, 0.125),
+            rout: channel(out_f, 0.0625),
+            s_in: channel(in_f, 0.25),
+            s_out: channel(out_f, 0.5),
+        }
+    }
+
+    /// Test the basic property of a circular window of bits.
+    ///
+    /// Two adjacent codes come from the same bit stream. The distance between
+    /// them is `K` bits. Thus the two codes must have the same `16 - K` bits
+    /// in common. This is true for all 256 codes, and the last code connects
+    /// to the first code.
+    ///
+    /// This property is true for all packed data. Thus the test does not need
+    /// a reference. An error of one bit in the offset breaks the property. The
+    /// test `unpack_tile_matches_reference` uses data from a checkpoint.
+    #[test]
+    fn unpack_tile_windows_overlap_circularly() {
+        for k in [2usize, 3, 4] {
+            let packed = pseudo_random(TILE * k, 0x5EED ^ k as u64);
+            let mut codes = [0u16; TILE_ELEMS];
+            unpack_tile(&packed, k, &mut codes);
+
+            let shared = (1u16 << (16 - k)) - 1;
+            for i in 0..TILE_ELEMS {
+                let next = codes[(i + 1) % TILE_ELEMS];
+                assert_eq!(
+                    codes[i] & shared,
+                    next >> k,
+                    "K={k}: codes {i} and {} do not share their {} overlapping bits",
+                    (i + 1) % TILE_ELEMS,
+                    16 - k
+                );
+            }
+            assert!(
+                codes.iter().any(|&c| c != codes[0]),
+                "K={k}: decode produced a constant stream"
+            );
+        }
+    }
+
+    /// Test the decode with known data from the released checkpoint.
+    ///
+    /// The data is tile [0, 0] of expert 0 of the tensor
+    /// `layers.0.mlp.experts.gate_up_proj`, with K equal to 2. The tool
+    /// `tools/escha_ref.py` gives the codes and the codebook values. A test
+    /// compared that tool with the unquantized model. The cosine value was
+    /// 0.97.
+    #[test]
+    fn unpack_tile_matches_reference() {
+        const PACKED: [u16; 32] = [
+            17306, 23673, 17721, 8298, 30284, 37780, 11190, 65313, 62638, 7569, 24420, 46439,
+            33879, 51555, 44741, 64370, 7988, 27160, 22813, 57471, 57599, 33229, 54809, 28588,
+            45070, 5627, 62389, 10510, 41066, 20219, 12929, 50458,
+        ];
+        const EXPECT_CODES: [u16; 8] = [51717, 10261, 41047, 33116, 1393, 5575, 22302, 23673];
+        const EXPECT_VALS: [f32; 8] = [
+            -0.998_169, -1.437_866, -0.343_384, -1.734_619, 0.371_948, 1.424_805, 0.638_672,
+            0.843_262,
+        ];
+
+        let mut codes = [0u16; TILE_ELEMS];
+        unpack_tile(&PACKED, 2, &mut codes);
+        assert_eq!(&codes[..8], &EXPECT_CODES, "trellis codes diverge");
+
+        for (i, (&code, &want)) in codes.iter().zip(EXPECT_VALS.iter()).enumerate() {
+            let got = decode_3inst(code);
+            assert!(
+                (got - want).abs() < 1e-5,
+                "codebook value {i}: got {got}, want {want}"
+            );
+        }
+    }
+
+    #[test]
+    fn tile_perm_is_a_permutation() {
+        let perm = tile_perm();
+        let mut seen = [false; TILE_ELEMS];
+        for &p in &perm {
+            assert!(!seen[usize::from(p)], "duplicate index {p}");
+            seen[usize::from(p)] = true;
+        }
+        assert!(seen.iter().all(|&s| s));
+    }
+
+    #[test]
+    fn decode_3inst_is_zero_mean_and_bounded() {
+        // The codebook values must have an approximate Gaussian distribution.
+        // The mean must be near zero, and the values must stay in a small
+        // range. If not, the trellis search cannot give good results.
+        let mut sum = 0.0f64;
+        let mut max = 0.0f32;
+        for code in 0..=u16::MAX {
+            let v = decode_3inst(code);
+            assert!(v.is_finite(), "code {code} decoded to {v}");
+            sum += f64::from(v);
+            max = max.max(v.abs());
+        }
+        let mean = sum / f64::from(u32::from(u16::MAX) + 1);
+        assert!(mean.abs() < 0.02, "codebook mean {mean} not centred");
+        assert!(
+            (1.0..8.0).contains(&max),
+            "codebook range {max} implausible"
+        );
+    }
+
+    #[test]
+    fn spec_rejects_padded_and_unaligned_shapes() {
+        assert!(EschaSpec::from_config(&[16, 2, 2, 1, 256, 2048, 1024, 2048, 1024]).is_ok());
+        // Padded dims are not handled.
+        assert!(EschaSpec::from_config(&[16, 2, 2, 1, 256, 2000, 1024, 2048, 1024]).is_err());
+        // in_features not a multiple of the Hadamard block.
+        assert!(EschaSpec::from_config(&[16, 2, 2, 1, 256, 2032, 1024, 2032, 1024]).is_err());
+        // Non-MCG codebook.
+        assert!(EschaSpec::from_config(&[16, 2, 2, 0, 256, 2048, 1024, 2048, 1024]).is_err());
+        // Wrong arity.
+        assert!(EschaSpec::from_config(&[16, 2, 2, 1]).is_err());
+    }
+
+    #[test]
+    fn spec_derives_tile_counts() {
+        let s = EschaSpec::from_config(&[16, 3, 3, 1, 256, 512, 2048, 512, 2048]).unwrap();
+        assert_eq!(s.k, 3);
+        assert_eq!(s.tiles(), (32, 128));
+        assert_eq!(s.words_per_tile(), 48);
+    }
+
+    /// Test the Hadamard operation on the two axes.
+    ///
+    /// An orthonormal Hadamard is its own inverse. Thus two calls to
+    /// `had_blockwise` on one axis must give the input again. The test finds
+    /// an error in the shape change, in the axis order, or in the scale.
+    #[test]
+    fn had_blockwise_is_an_involution_on_both_axes() {
+        let n = (HAD_BLOCK * 2) as usize;
+        let data: Vec<f32> = pseudo_random(n * n, 19)
+            .into_iter()
+            .map(|v| f32::from(v) / 32768.0 - 1.0)
+            .collect();
+        let x = Array::from_slice(&data, &[HAD_BLOCK * 2, HAD_BLOCK * 2]);
+
+        for axis in [0, 1] {
+            let back = had_blockwise(&had_blockwise(&x, axis).unwrap(), axis).unwrap();
+            let err = back
+                .subtract(&x)
+                .unwrap()
+                .abs()
+                .unwrap()
+                .max(None)
+                .unwrap()
+                .item::<f32>();
+            assert!(err < 1e-4, "axis {axis} round-trip error {err}");
+        }
+    }
+
+    /// Test the axis of each scale and the transpose step.
+    ///
+    /// The function `dequant_expert` gives an `[out, in]` matrix. The vectors
+    /// `rin` and `s_in` scale the input axis. The vectors `rout` and `s_out`
+    /// scale the output axis. The test sets one scale at a time. An incorrect
+    /// axis or an absent transpose gives an incorrect shape or an incorrect
+    /// column.
+    #[test]
+    fn dequant_expert_orients_scales_and_transpose() {
+        let (in_f, out_f) = (HAD_BLOCK * 2, HAD_BLOCK);
+        let s = spec(2, in_f, out_f);
+        let (tk, tn) = s.tiles();
+        let codes = pseudo_random(tk * tn * s.words_per_tile(), 23);
+        let code = code_array(&codes, &s);
+
+        let ones_in = Array::from_slice(&vec![1.0f32; in_f as usize], &[in_f]);
+        let ones_out = Array::from_slice(&vec![1.0f32; out_f as usize], &[out_f]);
+        let base = dequant_expert(&code, &ones_in, &ones_out, &ones_in, &ones_out, &s).unwrap();
+        assert_eq!(base.shape(), [out_f, in_f], "result must be [out, in]");
+
+        // If the scale of one input channel is 2.0, only that column must
+        // change by a factor of 2.0.
+        let mut rin = vec![1.0f32; in_f as usize];
+        rin[3] = 2.0;
+        let scaled = dequant_expert(
+            &code,
+            &Array::from_slice(&rin, &[in_f]),
+            &ones_out,
+            &ones_in,
+            &ones_out,
+            &s,
+        )
+        .unwrap();
+        let ratio = scaled.divide(&base).unwrap();
+        let col = ratio.index((.., 3)).mean(None).unwrap().item::<f32>();
+        let other = ratio.index((.., 4)).mean(None).unwrap().item::<f32>();
+        assert!((col - 2.0).abs() < 1e-3, "input scale hit column 3: {col}");
+        assert!((other - 1.0).abs() < 1e-3, "column 4 disturbed: {other}");
+
+        // The f32 scales must compose with the f16 ones, not be ignored.
+        let mut s_out = vec![1.0f32; out_f as usize];
+        s_out[5] = 3.0;
+        let scaled_out = dequant_expert(
+            &code,
+            &ones_in,
+            &ones_out,
+            &ones_in,
+            &Array::from_slice(&s_out, &[out_f]),
+            &s,
+        )
+        .unwrap();
+        let row = scaled_out
+            .divide(&base)
+            .unwrap()
+            .index((5, ..))
+            .mean(None)
+            .unwrap()
+            .item::<f32>();
+        assert!((row - 3.0).abs() < 1e-3, "s_out scale hit row 5: {row}");
+    }
+
+    /// Test all decode steps together against the `NumPy` reference. The test
+    /// uses data from a checkpoint.
+    ///
+    /// The steps are the bit decode, the codebook, the tile order, the two
+    /// Hadamard operations, the two scale pairs, and the transpose.
+    ///
+    /// To make the data file, use the command
+    /// `python3 tools/escha_ref.py fixture`. If the file is not available, the
+    /// test stops with no error. Thus a new copy of the repository passes.
+    #[test]
+    fn dequant_expert_matches_numpy_reference() {
+        const FIXTURE: &str = "/tmp/escha_fixture.safetensors";
+        if !std::path::Path::new(FIXTURE).exists() {
+            eprintln!("skipping: {FIXTURE} absent (python3 tools/escha_ref.py fixture)");
+            return;
+        }
+        let t = Array::load_safetensors(FIXTURE).unwrap();
+        let get = |k: &str| t.get(k).unwrap_or_else(|| panic!("fixture missing {k}"));
+
+        let expected = get("expected");
+        let (out_f, in_f) = (expected.shape()[0], expected.shape()[1]);
+        let s = EschaSpec {
+            k: get("code").shape()[2] as usize / TILE,
+            mcg: true,
+            num_experts: 1,
+            in_features: in_f,
+            out_features: out_f,
+        };
+
+        let got = dequant_expert(
+            get("code"),
+            get("rin"),
+            get("rout"),
+            get("s_in"),
+            get("s_out"),
+            &s,
+        )
+        .unwrap();
+        assert_eq!(got.shape(), expected.shape());
+
+        // The f16 format of the codebook values causes most of the error.
+        // Thus the test compares the error with the range of the reference.
+        let diff = got.subtract(expected).unwrap().abs().unwrap();
+        let max_err = diff.max(None).unwrap().item::<f32>();
+        let scale = expected.abs().unwrap().max(None).unwrap().item::<f32>();
+        assert!(
+            max_err < 1e-3 * scale,
+            "max |diff| {max_err} exceeds 1e-3 of reference range {scale}"
+        );
+    }
+
+    #[test]
+    fn dequant_expert_rejects_mismatched_code_shape() {
+        let s = spec(2, HAD_BLOCK, HAD_BLOCK);
+        let bad = Array::from_slice(&vec![0i16; 8 * 8 * 16], &[8, 8, 16]);
+        let ones = Array::from_slice(&vec![1.0f32; HAD_BLOCK as usize], &[HAD_BLOCK]);
+        assert!(dequant_expert(&bad, &ones, &ones, &ones, &ones, &s).is_err());
+    }
+
+    /// Test that the offset applies to every norm the checkpoint holds and to
+    /// nothing else. The `w - 1` convention was measured against
+    /// `mlx-community/Qwen3.6-35B-A3B-4bit`: 101 tensors match after the
+    /// offset, the 30 `linear_attn.norm` tensors match without it.
+    #[test]
+    fn is_offset_rmsnorm_splits_the_norms_from_everything_else() {
+        // Every norm key shape the checkpoint holds, in the normalized form.
+        // The GDN gated norm is the one norm that keeps the plain weight.
+        let offset = [
+            "language_model.model.layers.0.input_layernorm.weight",
+            "language_model.model.layers.39.post_attention_layernorm.weight",
+            "language_model.model.layers.3.self_attn.q_norm.weight",
+            "language_model.model.layers.3.self_attn.k_norm.weight",
+            "language_model.model.norm.weight",
+            "mtp.layers.0.input_layernorm.weight",
+            "mtp.layers.0.self_attn.k_norm.weight",
+            "mtp.norm.weight",
+            "mtp.pre_fc_norm_embedding.weight",
+            "mtp.pre_fc_norm_hidden.weight",
+        ];
+        let plain = [
+            "language_model.model.layers.0.linear_attn.norm.weight",
+            "language_model.model.layers.0.linear_attn.A_log",
+            "language_model.model.layers.0.linear_attn.dt_bias",
+            "language_model.model.layers.0.linear_attn.conv1d.weight",
+            "language_model.model.layers.0.mlp.gate.weight",
+            "language_model.model.layers.0.mlp.shared_expert_gate.weight",
+            "language_model.model.layers.3.self_attn.q_proj.weight_int8",
+            "language_model.model.embed_tokens.weight_int8",
+            "lm_head.weight_int8",
+        ];
+        for key in offset {
+            assert!(is_offset_rmsnorm(key), "{key} holds w - 1");
+        }
+        for key in plain {
+            assert!(!is_offset_rmsnorm(key), "{key} holds the plain value");
+        }
+    }
+
+    /// Test that each key format of the checkpoint gives a correct parameter
+    /// path. The key names come from `model.safetensors.index.json`.
+    #[test]
+    fn normalize_key_maps_every_checkpoint_shape() {
+        let cases = [
+            (
+                "model.language_model.layers.0.mlp.experts.gate_up_proj.escha_code",
+                "model.layers.0.mlp.experts.gate_up_proj.escha_code",
+            ),
+            (
+                "model.language_model.layers.3.self_attn.q_proj.weight_int8",
+                "model.layers.3.self_attn.q_proj.weight_int8",
+            ),
+            (
+                "model.language_model.layers.0.linear_attn.in_proj_qkv.weight_scale",
+                "model.layers.0.linear_attn.in_proj_qkv.weight_scale",
+            ),
+            (
+                "model.language_model.embed_tokens.weight_int8",
+                "model.embed_tokens.weight_int8",
+            ),
+            ("model.language_model.norm.weight", "model.norm.weight"),
+            ("lm_head.weight_int8", "lm_head.weight_int8"),
+            // MTP sidecar keys are already in the expected form.
+            ("mtp.fc.weight", "mtp.fc.weight"),
+            (
+                "mtp.pre_fc_norm_hidden.weight",
+                "mtp.pre_fc_norm_hidden.weight",
+            ),
+        ];
+        for (raw, want) in cases {
+            let normalized = normalize_key(raw);
+            let stripped = normalized
+                .strip_prefix("language_model.")
+                .unwrap_or(&normalized);
+            assert_eq!(stripped, want, "{raw}");
+        }
+    }
+
+    #[test]
+    fn classify_splits_storage_and_recovers_prefix() {
+        let proj = "model.layers.0.mlp.experts.down_proj";
+        for suffix in ESCHA_SUFFIXES {
+            assert_eq!(
+                classify(&format!("{proj}{suffix}")),
+                (Storage::Trellis, proj)
+            );
+        }
+        let attn = "model.layers.3.self_attn.q_proj";
+        for suffix in [INT8_WEIGHT_SUFFIX, INT8_SCALE_SUFFIX] {
+            assert_eq!(classify(&format!("{attn}{suffix}")), (Storage::Int8, attn));
+        }
+        // A plain tensor keeps its whole key, and `.weight` must not be
+        // mistaken for the int8 pair.
+        let norm = "model.layers.0.input_layernorm.weight";
+        assert_eq!(classify(norm), (Storage::Dense, norm));
+        let gate = "model.layers.0.mlp.gate.weight";
+        assert_eq!(classify(gate), (Storage::Dense, gate));
+    }
+
+    #[test]
+    fn is_eschamoe_checkpoint_reads_either_config() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(!is_eschamoe_checkpoint(dir.path()).unwrap());
+
+        let write = |name: &str, body: &str| {
+            std::fs::write(dir.path().join(name), body).unwrap();
+        };
+        write(
+            "config.json",
+            r#"{"quantization_config":{"quant_method":"eschamoe"}}"#,
+        );
+        assert!(is_eschamoe_checkpoint(dir.path()).unwrap());
+
+        // quantize_config.json wins when both are present.
+        write("quantize_config.json", r#"{"quant_method":"awq"}"#);
+        assert!(!is_eschamoe_checkpoint(dir.path()).unwrap());
+        write(
+            "quantize_config.json",
+            r#"{"quant_method":"eschamoe","bits":2.0}"#,
+        );
+        assert!(is_eschamoe_checkpoint(dir.path()).unwrap());
+
+        // Malformed config surfaces as an error rather than a silent false.
+        write("quantize_config.json", "not json");
+        assert!(is_eschamoe_checkpoint(dir.path()).is_err());
+    }
+
+    #[test]
+    fn affine_target_resolves_overrides() {
+        let cfg: serde_json::Value = serde_json::from_str(
+            r#"{"group_size": 64, "bits": 4, "mode": "affine",
+                "language_model.model.layers.0.mlp.gate": {"group_size": 64, "bits": 8}}"#,
+        )
+        .unwrap();
+        let base =
+            AffineTarget::resolve(Some(&cfg), "language_model.model.layers.0.self_attn.q_proj");
+        assert_eq!(
+            base,
+            AffineTarget {
+                group_size: 64,
+                bits: 4
+            }
+        );
+
+        let gate = AffineTarget::resolve(Some(&cfg), "language_model.model.layers.0.mlp.gate");
+        assert_eq!(
+            gate,
+            AffineTarget {
+                group_size: 64,
+                bits: 8
+            }
+        );
+
+        // No quantization block at all falls back to the MLX default.
+        assert_eq!(
+            AffineTarget::resolve(None, "anything"),
+            AffineTarget::default()
+        );
+    }
+
+    /// Test the conversion of a trellis projection from a checkpoint.
+    ///
+    /// The test decodes the affine result and compares it with the output of
+    /// `dequant_expert`. It does this for the two parts of the `gate_up`
+    /// tensor.
+    ///
+    /// To make the checkpoint, use the command
+    /// `python3 tools/escha_subset.py <dir> 4 32`. If the checkpoint is not
+    /// available, the test stops with no error.
+    #[test]
+    fn convert_trellis_round_trips_through_affine() {
+        let dir = std::env::var("HIGGS_ESCHA_TEST_MODEL").unwrap_or_else(|_| {
+            format!(
+                "{}/AI-Models/escha-subset",
+                std::env::var("HOME").unwrap_or_default()
+            )
+        });
+        let path = std::path::Path::new(&dir).join("model.safetensors");
+        if !path.exists() {
+            eprintln!(
+                "skipping: {} absent (tools/escha_subset.py)",
+                path.display()
+            );
+            return;
+        }
+        let t = Array::load_safetensors(path.to_str().unwrap_or_default()).unwrap();
+        let pfx = "model.language_model.layers.0.mlp.experts.gate_up_proj";
+        let get = |s: &str| t.get(&format!("{pfx}{s}")).unwrap();
+        let group = TrellisGroup {
+            prefix: pfx,
+            code: get(".escha_code"),
+            config: get(".escha_config"),
+            rin: get(".escha_rin"),
+            rout: get(".escha_rout"),
+            s_in: get(".escha_s_in"),
+            s_out: get(".escha_s_out"),
+        };
+
+        let spec = group.spec().unwrap();
+        let target = AffineTarget::default();
+        let parts = convert_trellis(group, 2, target).unwrap();
+        assert_eq!(parts.len(), 2, "fused gate_up yields gate and up");
+
+        let rows = spec.out_features / 2;
+        let reference = dequant_expert(
+            &group.code.index(0),
+            &group.rin.index(0),
+            &group.rout.index(0),
+            &group.s_in.index(0),
+            &group.s_out.index(0),
+            &spec,
+        )
+        .unwrap();
+
+        for (part, [w, s, b]) in parts.iter().enumerate() {
+            assert_eq!(
+                w.shape()[0],
+                spec.num_experts,
+                "part {part} lost the expert axis"
+            );
+
+            let got = ops::dequantize(
+                &w.index(0),
+                &s.index(0),
+                &b.index(0),
+                target.group_size,
+                target.bits,
+            )
+            .unwrap();
+
+            let lo = rows * i32::try_from(part).unwrap();
+            let want = reference.index((lo..lo + rows, ..));
+            assert_eq!(got.shape(), want.shape());
+
+            // The source data has 2 bits, and the result has 4 bits. Thus the
+            // quantization error must be much less than the reference range.
+            let err = got
+                .subtract(&want)
+                .unwrap()
+                .abs()
+                .unwrap()
+                .max(None)
+                .unwrap()
+                .item::<f32>();
+            let scale = want.abs().unwrap().max(None).unwrap().item::<f32>();
+            eprintln!(
+                "part {part}: affine requant err {err:.6} range {scale:.6} rel {:.3e}",
+                err / scale
+            );
+            assert!(
+                err < 0.1 * scale,
+                "part {part}: requantization error {err} vs range {scale}"
+            );
+        }
+    }
+
+    /// Load a real eschamoe checkpoint and do one forward operation.
+    ///
+    /// This test covers the full chain: the format detection, the key change,
+    /// the conversion of the trellis tensors and the int8 tensors, the GDN
+    /// fusion, and the forward code. It stops with no error if the checkpoint
+    /// is not available.
+    #[test]
+    fn eschamoe_checkpoint_loads_and_runs_forward() {
+        let dir = test_model_dir();
+        // A checkpoint can hold one file or a set of shards with an index.
+        let present = dir.join("model.safetensors").exists()
+            || dir.join("model.safetensors.index.json").exists();
+        if !present {
+            eprintln!("skipping: no checkpoint at {}", dir.display());
+            return;
+        }
+        eprintln!("loading {}", dir.display());
+        let mut model = crate::qwen3_next::load_qwen3_5_moe_model(&dir)
+            .unwrap_or_else(|e| panic!("load failed: {e}"));
+
+        let tokens = Array::from_slice(&[1i32, 2, 3, 4], &[1, 4]);
+        let mut cache = model.make_cache();
+        let logits = model
+            .forward(&tokens, None, &mut cache)
+            .unwrap_or_else(|e| panic!("forward failed: {e}"));
+
+        // `forward` returns the logits of the last position only.
+        let vocab = *logits.shape().last().unwrap();
+        assert_eq!(logits.shape(), [1, 1, vocab]);
+        let peak = logits.abs().unwrap().max(None).unwrap().item::<f32>();
+        assert!(peak.is_finite() && peak > 0.0, "logits degenerate: {peak}");
+    }
+
+    #[test]
+    fn convert_trellis_rejects_uneven_split() {
+        let dir = std::env::var("HIGGS_ESCHA_TEST_MODEL").unwrap_or_else(|_| {
+            format!(
+                "{}/AI-Models/escha-subset",
+                std::env::var("HOME").unwrap_or_default()
+            )
+        });
+        let path = std::path::Path::new(&dir).join("model.safetensors");
+        if !path.exists() {
+            return;
+        }
+        let t = Array::load_safetensors(path.to_str().unwrap_or_default()).unwrap();
+        let pfx = "model.language_model.layers.0.mlp.experts.gate_up_proj";
+        let get = |s: &str| t.get(&format!("{pfx}{s}")).unwrap();
+        let group = TrellisGroup {
+            prefix: pfx,
+            code: get(".escha_code"),
+            config: get(".escha_config"),
+            rin: get(".escha_rin"),
+            rout: get(".escha_rout"),
+            s_in: get(".escha_s_in"),
+            s_out: get(".escha_s_out"),
+        };
+        assert!(convert_trellis(group, 0, AffineTarget::default()).is_err());
+        assert!(convert_trellis(group, 3, AffineTarget::default()).is_err());
+    }
+
+    #[test]
+    fn dequant_int8_scales_per_output_row() {
+        let w = Array::from_slice::<i8>(&[1, 2, -3, 4], &[2, 2]);
+        let s = Array::from_slice::<f32>(&[0.5, 2.0], &[2]);
+        let got = dequant_int8(&w, &s).unwrap();
+        assert_eq!(got.as_slice::<f32>(), &[0.5, 1.0, -6.0, 8.0]);
+        // Mismatched scale length must be rejected, not broadcast.
+        assert!(dequant_int8(&w, &Array::from_slice::<f32>(&[0.5], &[1])).is_err());
+    }
+
+    #[test]
+    fn decode_expert_codes_fills_every_slot() {
+        // The decode must write to all positions of all tiles. An error in
+        // the element order leaves some positions at zero.
+        let s = spec(2, 32, 48);
+        let (tk, tn) = s.tiles();
+        let packed = pseudo_random(tk * tn * s.words_per_tile(), 11);
+        let w = decode_expert_codes(&packed, &s);
+
+        assert_eq!(w.len(), (s.in_features * s.out_features) as usize);
+        assert!(
+            w.iter().all(|v| v.to_f32() != 0.0),
+            "unfilled slots present"
+        );
+    }
+
+    #[test]
+    fn decode_expert_codes_places_tiles_by_position() {
+        // Tile (tk, tn) must go to row `16*tk` and column `16*tn`. Thus one
+        // tile with different codes must change only one block of 16 by 16.
+        // The test finds an error in the change from [tk, tn, 16, 16] to
+        // [in, out].
+        let s = spec(2, 32, 32);
+        let words = s.words_per_tile();
+        let mut packed = vec![0u16; 4 * words];
+        packed[words..2 * words].copy_from_slice(&pseudo_random(words, 3)); // tile (0,1)
+        let w = decode_expert_codes(&packed, &s);
+
+        let row_len = s.out_features as usize;
+        let block = |r0: usize, c0: usize| -> Vec<f32> {
+            (0..TILE)
+                .flat_map(|r| (0..TILE).map(move |c| (r, c)))
+                .map(|(r, c)| w[(r0 + r) * row_len + c0 + c].to_f32())
+                .collect()
+        };
+        let uniform = |v: &[f32]| v.iter().all(|x| (x - v[0]).abs() < 1e-6);
+
+        assert!(!uniform(&block(0, 16)), "tile (0,1) should carry the data");
+        for (r0, c0) in [(0, 0), (16, 0), (16, 16)] {
+            assert!(uniform(&block(r0, c0)), "tile at ({r0},{c0}) was disturbed");
+        }
+    }
+
+    /// Test the dense decode path against the expert path.
+    ///
+    /// A dense projection is one matrix. The same data with a leading axis of
+    /// one expert must give the same values. The dense result must have no
+    /// expert axis.
+    #[test]
+    fn convert_trellis_dense_matches_batch_of_one() {
+        let (in_f, out_f) = (HAD_BLOCK, HAD_BLOCK);
+        let dense = synth_group(None, 2, in_f, out_f);
+        let moe = synth_group(Some(1), 2, in_f, out_f);
+        let target = AffineTarget::default();
+
+        let layout = dense.as_group().validate().unwrap();
+        assert_eq!(layout.expert_axis, ExpertAxis::Dense);
+        assert_eq!(layout.scale_len_in, ScaleLen::Logical);
+        assert_eq!(layout.scale_len_out, ScaleLen::Logical);
+
+        let dense_parts = convert_trellis(dense.as_group(), 1, target).unwrap();
+        let moe_parts = convert_trellis(moe.as_group(), 1, target).unwrap();
+        assert_eq!(dense_parts.len(), 1);
+
+        for (i, (d, m)) in dense_parts[0].iter().zip(moe_parts[0].iter()).enumerate() {
+            assert_eq!(d.ndim() + 1, m.ndim(), "tensor {i} kept an expert axis");
+            let err = d
+                .as_dtype(Dtype::Float32)
+                .unwrap()
+                .subtract(m.index(0).as_dtype(Dtype::Float32).unwrap())
+                .unwrap()
+                .abs()
+                .unwrap()
+                .max(None)
+                .unwrap()
+                .item::<f32>();
+            assert!(err < 1e-6, "tensor {i} diverges from batch-of-1: {err}");
+        }
+    }
+
+    /// Test the load checks: the axis agreement, the leading dim, the bit
+    /// budget, and the scale lengths. Each case must fail with an error that
+    /// names the bad value.
+    #[test]
+    fn validate_rejects_axis_budget_and_scale_mismatches() {
+        let base_config = |experts: i32| {
+            Array::from_slice(
+                &[
+                    16, 2, 2, 1, experts, HAD_BLOCK, HAD_BLOCK, HAD_BLOCK, HAD_BLOCK,
+                ],
+                &[9],
+            )
+        };
+
+        // The config gives four experts, but the code tensor has rank 3.
+        let mut claims_experts = synth_group(None, 2, HAD_BLOCK, HAD_BLOCK);
+        claims_experts.config = base_config(4);
+        let axis_msg = claims_experts
+            .as_group()
+            .validate()
+            .unwrap_err()
+            .to_string();
+        assert!(
+            axis_msg.contains("4 experts") && axis_msg.contains("rank 3"),
+            "{axis_msg}"
+        );
+
+        // The config gives zero experts, but the code tensor has rank 4.
+        let mut claims_dense = synth_group(Some(2), 2, HAD_BLOCK, HAD_BLOCK);
+        claims_dense.config = base_config(0);
+        let rank_msg = claims_dense.as_group().validate().unwrap_err().to_string();
+        assert!(
+            rank_msg.contains("0 experts") && rank_msg.contains("rank 4"),
+            "{rank_msg}"
+        );
+
+        // The code leading dim must equal the expert count.
+        let mut wrong_lead = synth_group(Some(2), 2, HAD_BLOCK, HAD_BLOCK);
+        wrong_lead.config = base_config(3);
+        let lead_msg = wrong_lead.as_group().validate().unwrap_err().to_string();
+        assert!(
+            lead_msg.contains("leading dim 2") && lead_msg.contains('3'),
+            "{lead_msg}"
+        );
+
+        // A short code tensor breaks the bit budget.
+        let mut short_code = synth_group(None, 2, HAD_BLOCK, HAD_BLOCK);
+        short_code.code = short_code.code.index((.., .., 0..16));
+        let bits_msg = short_code.as_group().validate().unwrap_err().to_string();
+        assert!(
+            bits_msg.contains("escha_code") && bits_msg.contains("bits"),
+            "{bits_msg}"
+        );
+
+        // A wrong scale length names the vector.
+        let mut long_rin = synth_group(None, 2, HAD_BLOCK, HAD_BLOCK);
+        let len = HAD_BLOCK + TILE_I32;
+        long_rin.rin = Array::from_slice(&vec![1.0f32; len as usize], &[len]);
+        let rin_msg = long_rin.as_group().validate().unwrap_err().to_string();
+        assert!(rin_msg.contains("escha_rin"), "{rin_msg}");
+    }
+
+    /// Test the codebook gate. The flags 0 and 2 exist but have no verified
+    /// decode data. An unknown flag gives a different error.
+    #[test]
+    fn spec_rejects_unverified_and_unknown_codebooks() {
+        for flag in [0, 2] {
+            let msg = EschaSpec::from_config(&[16, 2, 2, flag, 256, 2048, 1024, 2048, 1024])
+                .unwrap_err()
+                .to_string();
+            assert!(msg.contains("unverified"), "flag {flag}: {msg}");
+        }
+        let msg = EschaSpec::from_config(&[16, 2, 2, 7, 256, 2048, 1024, 2048, 1024])
+            .unwrap_err()
+            .to_string();
+        assert!(msg.contains("unknown"), "{msg}");
+    }
+
+    /// Test the `|rout|` mean check. A mean of 1.0 passes. A large deviation
+    /// gives the mean back, and the loader warns without failure.
+    #[test]
+    fn rout_mean_check_warns_and_does_not_fail() {
+        let good = Array::from_slice(&[1.04f32, -0.96, 1.0, -1.0], &[4]);
+        assert!(rout_mean_if_off(&good).unwrap().is_none());
+
+        let bad = Array::from_slice(&[2.0f32; 8], &[8]);
+        let mean = rout_mean_if_off(&bad).unwrap().unwrap();
+        assert!((mean - 2.0).abs() < 1e-6, "reported mean {mean}");
+
+        // The check warns only. A group with a large mean still validates.
+        let mut off = synth_group(None, 2, HAD_BLOCK, HAD_BLOCK);
+        off.rout = Array::from_slice(&vec![2.0f32; HAD_BLOCK as usize], &[HAD_BLOCK]);
+        assert!(off.as_group().validate().is_ok());
+    }
+
+    /// Test the activation-side factorization of the dequant equation.
+    ///
+    /// The reconstruction is `W = (H.Ŵ.H * rin[:,None] * rout[None,:]).T`.
+    /// `H` is symmetric and orthonormal. Thus `y = x @ W.T` factors to:
+    /// scale `x` by `rin*s_in`, apply the blockwise Hadamard, multiply by
+    /// `Ŵ`, apply the blockwise Hadamard again, and scale by `rout*s_out`.
+    /// The Phase 3 kernel uses this form. The Hadamard never touches the
+    /// weights at inference.
+    #[test]
+    fn factored_matvec_matches_dequant_expert() {
+        let (in_f, out_f) = (HAD_BLOCK * 2, HAD_BLOCK);
+        let g = synth_group(None, 2, in_f, out_f);
+        let s = g.as_group().spec().unwrap();
+
+        // The reference: y_ref = x @ W.T with the oracle weight.
+        let w = dequant_expert(&g.code, &g.rin, &g.rout, &g.s_in, &g.s_out, &s).unwrap();
+        let x_vals: Vec<f32> = pseudo_random(in_f as usize, 0xFAC7)
+            .into_iter()
+            .map(|v| f32::from(v) / 32768.0 - 1.0)
+            .collect();
+        let x = Array::from_slice(&x_vals, &[1, in_f]);
+        let y_ref = ops::matmul(&x, ops::swap_axes(&w, 0, 1).unwrap()).unwrap();
+
+        // The factored form. `Ŵ` comes from the same trellis decode.
+        let packed: Vec<u16> = g
+            .code
+            .as_dtype(Dtype::Uint16)
+            .unwrap()
+            .as_slice::<u16>()
+            .to_vec();
+        let w_hat = Array::from_slice(&decode_expert_codes(&packed, &s), &[in_f, out_f]);
+        let su = g
+            .rin
+            .multiply(&g.s_in)
+            .unwrap()
+            .reshape(&[1, in_f])
+            .unwrap();
+        let sv = g
+            .rout
+            .multiply(&g.s_out)
+            .unwrap()
+            .reshape(&[1, out_f])
+            .unwrap();
+        let xh = had_blockwise(&x.multiply(&su).unwrap(), -1).unwrap();
+        let y_pre = ops::matmul(&xh, &w_hat).unwrap();
+        let y = had_blockwise(&y_pre, -1).unwrap().multiply(&sv).unwrap();
+
+        let err = y
+            .subtract(&y_ref)
+            .unwrap()
+            .abs()
+            .unwrap()
+            .max(None)
+            .unwrap()
+            .item::<f32>();
+        let scale = y_ref.abs().unwrap().max(None).unwrap().item::<f32>();
+        eprintln!("factorization: max |y - y_ref| = {err} (scale {scale})");
+        assert!(
+            err <= 2e-3 * scale,
+            "factored form diverges: {err} vs scale {scale}"
+        );
+    }
+
+    /// The native gather forward must match the oracle on both row paths.
+    ///
+    /// The matvec path takes six rows with unsorted ids. The scratch path
+    /// takes 40 sorted rows. Both compare against `dequant_expert` row by
+    /// row.
+    #[test]
+    fn escha_proj_gather_forward_matches_oracle() {
+        let (in_f, out_f) = (HAD_BLOCK * 2, HAD_BLOCK);
+        let g = synth_group(Some(4), 2, in_f, out_f);
+        let s = g.as_group().spec().unwrap();
+        let proj = EschaProj::new(g.code.clone(), &g.rin, &g.rout, &g.s_in, &g.s_out, s).unwrap();
+
+        let slice = |t: &Array, e: u32| {
+            let sel = Array::from_slice(&[e], &[1]);
+            t.take_axis(&sel, 0).unwrap().squeeze_axes(&[0]).unwrap()
+        };
+        let oracle = |x: &Array, ids: &[u32]| {
+            let rows: Vec<Array> = ids
+                .iter()
+                .enumerate()
+                .map(|(i, &e)| {
+                    let w = dequant_expert(
+                        &slice(&g.code, e),
+                        &slice(&g.rin, e),
+                        &slice(&g.rout, e),
+                        &slice(&g.s_in, e),
+                        &slice(&g.s_out, e),
+                        &s,
+                    )
+                    .unwrap();
+                    let sel = Array::from_slice(&[u32::try_from(i).unwrap()], &[1]);
+                    let xi = x.take_axis(&sel, 0).unwrap();
+                    ops::matmul(&xi, ops::swap_axes(&w, 0, 1).unwrap()).unwrap()
+                })
+                .collect();
+            let refs: Vec<&Array> = rows.iter().collect();
+            ops::concatenate_axis(&refs, 0).unwrap()
+        };
+        let check = |ids: &[u32], label: &str| {
+            let n = i32::try_from(ids.len()).unwrap();
+            let x_vals: Vec<f32> = pseudo_random(ids.len() * in_f as usize, 0x9A7E)
+                .into_iter()
+                .map(|v| f32::from(v) / 32768.0 - 1.0)
+                .collect();
+            let x = Array::from_slice(&x_vals, &[n, in_f]);
+            let eids = Array::from_slice(ids, &[n]);
+            let got = proj.gather_forward(&x, &eids).unwrap();
+            assert_eq!(got.shape(), [n, out_f], "{label}");
+            let want = oracle(&x, ids);
+            let err = got
+                .subtract(&want)
+                .unwrap()
+                .abs()
+                .unwrap()
+                .max(None)
+                .unwrap()
+                .item::<f32>();
+            let scale = want.abs().unwrap().max(None).unwrap().item::<f32>();
+            eprintln!("{label}: max |native - oracle| = {err} (scale {scale})");
+            assert!(err <= 2e-3 * scale, "{label}: {err} vs scale {scale}");
+        };
+
+        // Six rows, unsorted ids: the matvec kernel path.
+        check(&[2, 0, 3, 1, 2, 0], "matvec path");
+        // Forty sorted rows: the scratch decode path.
+        let sorted: Vec<u32> = (0..40u32).map(|i| i / 10).collect();
+        check(&sorted, "scratch path");
+    }
+
+    /// Compare the GPU tile decode with the CPU reference for one spec.
+    ///
+    /// The gate is one f16 ULP at the value scale of the reference. The two
+    /// paths round the same f32 value to f16. Thus the expected difference
+    /// is zero.
+    fn assert_kernel_matches_cpu(packed: &[u16], s: &EschaSpec, label: &str) {
+        let code = code_array(packed, s);
+        let want = decode_expert_codes(packed, s);
+        let got = crate::metal_kernel::eschamoe_dequant_tiles(&code, s).unwrap();
+        assert_eq!(got.shape(), [s.in_features, s.out_features], "{label}");
+        assert_eq!(got.dtype(), Dtype::Float16, "{label}");
+
+        let got_v = got.as_slice::<f16>();
+        assert_eq!(got_v.len(), want.len(), "{label}");
+        let diff = got_v
+            .iter()
+            .zip(&want)
+            .map(|(g, w)| (g.to_f32() - w.to_f32()).abs())
+            .fold(0.0f32, f32::max);
+        let scale = want.iter().map(|v| v.to_f32().abs()).fold(0.0f32, f32::max);
+        let ulp = scale * f16::EPSILON.to_f32();
+        eprintln!("{label}: max |gpu - cpu| = {diff} (scale {scale}, one ulp {ulp})");
+        assert!(
+            diff <= ulp,
+            "{label}: diff {diff} exceeds one f16 ULP {ulp}"
+        );
+    }
+
+    /// Compare the GPU decode with the CPU decode on random tiles.
+    #[test]
+    fn eschamoe_dequant_tiles_matches_cpu_for_k2_k3_k4() {
+        for k in [2usize, 3, 4] {
+            let s = spec(k, 32, 48);
+            let (tk, tn) = s.tiles();
+            let packed = pseudo_random(tk * tn * s.words_per_tile(), 0xE5C4 ^ k as u64);
+            assert_kernel_matches_cpu(&packed, &s, &format!("K={k} random"));
+        }
+    }
+
+    /// Compare the GPU decode with the CPU decode on checkpoint data.
+    ///
+    /// The data is expert 0 of `layers.0.mlp.experts.gate_up_proj`. If the
+    /// checkpoint is not available, the test stops with no error.
+    #[test]
+    fn eschamoe_dequant_tiles_matches_cpu_on_checkpoint() {
+        let path = test_model_dir().join("model.safetensors");
+        if !path.exists() {
+            eprintln!("skipping: {} absent", path.display());
+            return;
+        }
+        let t = Array::load_safetensors(path.to_str().unwrap()).unwrap();
+        let pfx = "model.language_model.layers.0.mlp.experts.gate_up_proj";
+        let get = |sfx: &str| t.get(&format!("{pfx}{sfx}")).unwrap();
+
+        let config: Vec<i32> = get(".escha_config")
+            .as_dtype(Dtype::Int32)
+            .unwrap()
+            .as_slice()
+            .to_vec();
+        let s = EschaSpec::from_config(&config).unwrap();
+        let packed: Vec<u16> = get(".escha_code")
+            .index(0)
+            .as_dtype(Dtype::Uint16)
+            .unwrap()
+            .as_slice()
+            .to_vec();
+        assert_kernel_matches_cpu(&packed, &s, "checkpoint expert 0");
+    }
+
+    /// Test the input gate of the GPU decode.
+    ///
+    /// The kernel must refuse an unverified codebook, a wrong shape, and a
+    /// wrong dtype. A refusal is an error, not incorrect output.
+    #[test]
+    fn eschamoe_dequant_tiles_rejects_bad_inputs() {
+        let s = spec(2, 32, 32);
+        let (tk, tn) = s.tiles();
+        let packed = pseudo_random(tk * tn * s.words_per_tile(), 0xBAD);
+        let code = code_array(&packed, &s);
+
+        let mut off_book = s;
+        off_book.mcg = false;
+        assert!(crate::metal_kernel::eschamoe_dequant_tiles(&code, &off_book).is_err());
+
+        let short = code.index((.., .., 0..16));
+        assert!(crate::metal_kernel::eschamoe_dequant_tiles(&short, &s).is_err());
+
+        let wide = code.as_dtype(Dtype::Float32).unwrap();
+        assert!(crate::metal_kernel::eschamoe_dequant_tiles(&wide, &s).is_err());
+    }
+
+    /// Build the transformed row and the CPU product of one expert.
+    ///
+    /// The row is `had(x * rin * s_in)`. The product is `row @ Ŵ`. The
+    /// gather kernel must give the same product.
+    fn factored_row_and_ref(
+        x: &Array,
+        code: &Array,
+        rin: &Array,
+        s_in: &Array,
+        e: i32,
+        s: &EschaSpec,
+    ) -> (Vec<f32>, Vec<f32>) {
+        let in_f = s.in_features;
+        let su = rin
+            .index(e)
+            .multiply(s_in.index(e))
+            .unwrap()
+            .reshape(&[1, in_f])
+            .unwrap();
+        let xh = had_blockwise(&x.multiply(&su).unwrap(), -1).unwrap();
+        let packed: Vec<u16> = code
+            .index(e)
+            .as_dtype(Dtype::Uint16)
+            .unwrap()
+            .as_slice()
+            .to_vec();
+        let w_hat = Array::from_slice(&decode_expert_codes(&packed, s), &[in_f, s.out_features]);
+        let y = ops::matmul(&xh, &w_hat).unwrap();
+        (xh.as_slice::<f32>().to_vec(), y.as_slice::<f32>().to_vec())
+    }
+
+    /// Compare the gather kernel with the factored CPU form.
+    ///
+    /// Four synthetic experts share one token. Each row carries the input
+    /// scales and the input Hadamard of its expert. The expert order is
+    /// not sorted. Thus the test also checks the expert-id indirection.
+    #[test]
+    fn eschamoe_gather_qmv_matches_factored_cpu() {
+        let (in_f, out_f) = (HAD_BLOCK * 2, HAD_BLOCK);
+        let g = synth_group(Some(4), 2, in_f, out_f);
+        let s = g.as_group().spec().unwrap();
+        let ids: [u32; 3] = [3, 0, 2];
+
+        let x_vals: Vec<f32> = pseudo_random(in_f as usize, 0x9A7E)
+            .into_iter()
+            .map(|v| f32::from(v) / 32768.0 - 1.0)
+            .collect();
+        let x = Array::from_slice(&x_vals, &[1, in_f]);
+
+        let mut xh_all = Vec::new();
+        let mut y_ref = Vec::new();
+        for &e in &ids {
+            let (row, y) = factored_row_and_ref(&x, &g.code, &g.rin, &g.s_in, e.cast_signed(), &s);
+            xh_all.extend(row);
+            y_ref.extend(y);
+        }
+        let rows = i32::try_from(ids.len()).unwrap();
+        let xh = Array::from_slice(&xh_all, &[rows, in_f]);
+        let ids_arr = Array::from_slice(&ids, &[rows]);
+
+        let got = crate::metal_kernel::eschamoe_gather_qmv(&xh, &g.code, &ids_arr, &s).unwrap();
+        assert_eq!(got.shape(), [rows, out_f]);
+        let got_v = got.as_slice::<f32>();
+        let diff = got_v
+            .iter()
+            .zip(&y_ref)
+            .map(|(a, b)| (a - b).abs())
+            .fold(0.0f32, f32::max);
+        let scale = y_ref.iter().map(|v| v.abs()).fold(0.0f32, f32::max);
+        eprintln!("gather_qmv synth: max |gpu - cpu| = {diff} (scale {scale})");
+        assert!(
+            diff <= 2e-3 * scale,
+            "gather kernel diverges: {diff} vs scale {scale}"
+        );
+    }
+
+    /// Compare the gather kernel with the CPU form on checkpoint data.
+    ///
+    /// The data is `layers.0.mlp.experts.gate_up_proj`. The rows hold raw
+    /// random activations. Thus the test checks the kernel contract
+    /// `y_pre = xh @ Ŵ` on real trellis bits. If the checkpoint is not
+    /// available, the test stops with no error.
+    #[test]
+    fn eschamoe_gather_qmv_matches_cpu_on_checkpoint() {
+        let path = test_model_dir().join("model.safetensors");
+        if !path.exists() {
+            eprintln!("skipping: {} absent", path.display());
+            return;
+        }
+        let t = Array::load_safetensors(path.to_str().unwrap()).unwrap();
+        let pfx = "model.language_model.layers.0.mlp.experts.gate_up_proj";
+        let get = |sfx: &str| t.get(&format!("{pfx}{sfx}")).unwrap();
+
+        let config: Vec<i32> = get(".escha_config")
+            .as_dtype(Dtype::Int32)
+            .unwrap()
+            .as_slice()
+            .to_vec();
+        let s = EschaSpec::from_config(&config).unwrap();
+        let code = get(".escha_code");
+        let (in_f, out_f) = (s.in_features, s.out_features);
+        let ids: [u32; 3] = [0, 5, 17];
+
+        let x_vals: Vec<f32> = pseudo_random(in_f as usize, 0xC0DE)
+            .into_iter()
+            .map(|v| f32::from(v) / 32768.0 - 1.0)
+            .collect();
+        let x = Array::from_slice(&x_vals, &[1, in_f]);
+
+        let mut xh_all = Vec::new();
+        let mut y_ref: Vec<f32> = Vec::new();
+        for &e in &ids {
+            let packed: Vec<u16> = code
+                .index(e.cast_signed())
+                .as_dtype(Dtype::Uint16)
+                .unwrap()
+                .as_slice()
+                .to_vec();
+            let w_hat = Array::from_slice(&decode_expert_codes(&packed, &s), &[in_f, out_f]);
+            let y = ops::matmul(&x, &w_hat).unwrap();
+            xh_all.extend_from_slice(&x_vals);
+            y_ref.extend(y.as_slice::<f32>());
+        }
+        let rows = i32::try_from(ids.len()).unwrap();
+        let xh = Array::from_slice(&xh_all, &[rows, in_f]);
+        let ids_arr = Array::from_slice(&ids, &[rows]);
+
+        let got = crate::metal_kernel::eschamoe_gather_qmv(&xh, code, &ids_arr, &s).unwrap();
+        assert_eq!(got.shape(), [rows, out_f]);
+        let got_v = got.as_slice::<f32>();
+        let diff = got_v
+            .iter()
+            .zip(&y_ref)
+            .map(|(a, b)| (a - b).abs())
+            .fold(0.0f32, f32::max);
+        let scale = y_ref.iter().map(|v| v.abs()).fold(0.0f32, f32::max);
+        eprintln!("gather_qmv checkpoint: max |gpu - cpu| = {diff} (scale {scale})");
+        assert!(
+            diff <= 2e-3 * scale,
+            "gather kernel diverges: {diff} vs scale {scale}"
+        );
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::print_stderr, clippy::unwrap_used)]
+mod convert_dump {
+    use super::*;
+
+    /// Print the converted tensors of layer 0. Set `HIGGS_ESCHA_DUMP` to run.
+    #[test]
+    fn dump_converted_shapes() {
+        if std::env::var("HIGGS_ESCHA_DUMP").is_err() {
+            return;
+        }
+        let dir: std::path::PathBuf = std::env::var("HIGGS_ESCHA_TEST_MODEL").unwrap().into();
+        let text = std::fs::read_to_string(dir.join("config.json")).unwrap();
+        let cfg: serde_json::Value = serde_json::from_str(&text).unwrap();
+        let out = convert_checkpoint(&dir, cfg.get("quantization")).unwrap();
+        let mut names: Vec<_> = out
+            .iter()
+            .filter(|(k, v)| v.shape() == [256, 64] || k.contains("mtp"))
+            .map(|(k, v)| (k.clone(), v.shape().to_vec()))
+            .collect();
+        names.sort();
+        for (k, s) in names {
+            eprintln!("CONV {k} {s:?}");
+        }
+    }
+}

--- a/crates/higgs-models/src/eschamoe.rs
+++ b/crates/higgs-models/src/eschamoe.rs
@@ -2053,8 +2053,8 @@ mod tests {
             );
 
             let got = ops::dequantize(
-                &w.index(0),
-                &s.index(0),
+                w.index(0),
+                s.index(0),
                 &b.index(0),
                 target.group_size,
                 target.bits,

--- a/crates/higgs-models/src/lib.rs
+++ b/crates/higgs-models/src/lib.rs
@@ -3,6 +3,7 @@ pub mod bonsai_q1;
 pub mod cache;
 pub mod deepseek_v2;
 pub mod error;
+pub mod eschamoe;
 pub mod gemma2;
 pub mod gemma3;
 pub mod gemma4;

--- a/crates/higgs-models/src/metal_kernel.rs
+++ b/crates/higgs-models/src/metal_kernel.rs
@@ -416,12 +416,16 @@ fn check_gather_inputs(
         i32::try_from(tiles_n).unwrap_or(i32::MAX),
         i32::try_from(spec.words_per_tile()).unwrap_or(i32::MAX),
     ];
-    let code_ok = matches!(code.shape(), &[_, a, b, c] if [a, b, c] == tile_dims);
+    // Bind the expert axis: the kernels index `code` by expert id with no
+    // bound check, so a short checkpoint would read out of bounds.
+    let code_ok =
+        matches!(code.shape(), &[e, a, b, c] if e == spec.num_experts && [a, b, c] == tile_dims);
     if code.dtype() != Dtype::Int16 || !code_ok {
         return Err(Exception::custom(format!(
-            "eschamoe_gather_qmv: code {:?} {:?} does not match [E, {tile_dims:?}] int16",
+            "eschamoe_gather_qmv: code {:?} {:?} does not match [{}, {tile_dims:?}] int16",
             code.dtype(),
-            code.shape()
+            code.shape(),
+            spec.num_experts
         )));
     }
     let &[rows, cols] = xh.shape() else {
@@ -454,6 +458,11 @@ fn check_gather_inputs(
 /// carries the input scales and the input Hadamard of its expert. The
 /// input `code` is the full `[experts, tiles_k, tiles_n, 16 * K]` int16
 /// trellis tensor. The input `expert_ids` maps each row to one expert.
+/// The kernel stages the whole activation row in `x_sh[TK * 16]`, which is
+/// static threadgroup memory: Apple GPUs cap it at 32 KiB, so past 8192
+/// floats the kernel stops compiling with an error that names nothing.
+const MAX_THREADGROUP_FLOATS: i32 = 32 * 1024 / 4;
+
 /// The result is `y_pre = xh @ Ŵ` as a `[rows, out]` float32 matrix. The
 /// caller applies the output Hadamard and the output scales.
 #[allow(unsafe_code, dead_code)]
@@ -475,6 +484,12 @@ pub fn eschamoe_gather_qmv(
         )));
     }
     let (rows, tile_dims) = check_gather_inputs(xh, code, expert_ids, spec)?;
+    if spec.in_features > MAX_THREADGROUP_FLOATS {
+        return Err(Exception::custom(format!(
+            "eschamoe_gather_qmv: in_features {} exceeds the {}-float threadgroup staging limit",
+            spec.in_features, MAX_THREADGROUP_FLOATS
+        )));
+    }
 
     let stream = Stream::task_local_or_default();
     let cached = ESCHA_QMV_KERNEL.get_or_init(|| CachedMetalKernel(create_escha_qmv_kernel()));

--- a/crates/higgs-models/src/metal_kernel.rs
+++ b/crates/higgs-models/src/metal_kernel.rs
@@ -20,7 +20,9 @@
 use std::ffi::{CStr, CString, c_char, c_void};
 use std::sync::OnceLock;
 
-use mlx_rs::{Array, Stream, error::Exception};
+use mlx_rs::{Array, Dtype, Stream, error::Exception};
+
+use crate::eschamoe::EschaSpec;
 
 // ---------------------------------------------------------------------------
 // FFI error capture (per-thread, mirrors qwen3_next).
@@ -98,6 +100,454 @@ fn qmv_nsg(k_dim: i32) -> i32 {
 fn cstr_vec(names: &[&CStr]) -> mlx_sys::mlx_vector_string {
     let ptrs: Vec<*const c_char> = names.iter().map(|s| s.as_ptr()).collect();
     unsafe { mlx_sys::mlx_vector_string_new_data(ptrs.as_ptr().cast_mut(), ptrs.len()) }
+}
+
+// ---------------------------------------------------------------------------
+// Eschamoe trellis tile decode (Phase 2: decode only, no matvec).
+//
+// One threadgroup decodes one tile of 16 by 16. Thread t of 128 gives the
+// codes 2t and 2t + 1. The bit math copies `eschamoe::unpack_tile`. The hash
+// copies `eschamoe::decode_code`. The element order comes from the closed
+// form of `eschamoe::tile_perm`. The MSL keeps the closed form because the
+// form is eight lines and needs no table input.
+// ---------------------------------------------------------------------------
+
+// Phase 3 connects this kernel to the forward path. Until then, only the
+// tests use this chain. The allow attributes keep the lib target quiet.
+#[allow(dead_code)]
+const ESCHA_TILE_KERNEL_SOURCE: &str = r"
+// The packed tile holds 8 * K words of 32 bits.
+constexpr int WORDS = 8 * K;
+
+threadgroup uint w_sh[WORDS];
+
+uint tn = threadgroup_position_in_grid.y;
+uint tk = threadgroup_position_in_grid.z;
+uint t = thread_index_in_threadgroup;
+
+// Stage the tile words. Two 16-bit words make one 32-bit word.
+const device short* tile = code + (tk * uint(TN) + tn) * uint(16 * K);
+if (t < uint(WORDS)) {
+    uint lo = uint(ushort(tile[2 * t]));
+    uint hi = uint(ushort(tile[2 * t + 1]));
+    w_sh[t] = lo | (hi << 16);
+}
+threadgroup_barrier(mem_flags::mem_threadgroup);
+
+// The bit offsets copy unpack_tile. The wrap term 256 * K comes before
+// the term -16. Thus the unsigned value stays 0 or more.
+uint b0 = 2u * t * uint(K) + uint(K) + 256u * uint(K) - 16u;
+uint b2 = b0 + uint(K) + 16u;
+uint j0 = b0 / 32u;
+uint j1 = (b2 - 1u) / 32u;
+uint s1 = (j1 + 1u) * 32u - b2;
+
+// The 64-bit funnel makes the shift safe when s1 is 0.
+ulong pair = (ulong(w_sh[j0 % uint(WORDS)]) << 32) | ulong(w_sh[j1 % uint(WORDS)]);
+uint w1 = uint(pair >> s1);
+
+uint pair_codes[2];
+pair_codes[0] = (w1 >> uint(K)) & 0xFFFFu;
+pair_codes[1] = w1 & 0xFFFFu;
+
+uint row_len = uint(TN) * 16u;
+for (uint e = 0u; e < 2u; ++e) {
+    uint i = 2u * t + e;
+
+    // The closed form of tile_perm. Stored element i goes to the
+    // row-major slot (r, c) inside the tile.
+    uint g = i >> 3;
+    uint ii = i & 3u;
+    uint r = (g % 4u) * 2u + (ii & 1u) + 8u * (ii >> 1);
+    uint c = g / 4u + 8u * ((i >> 2) & 1u);
+
+    // The codebook hash. The reduce step adds the two f16 halves. The
+    // four constants come from the cb input: multiply, add, mask, XOR.
+    uint x = pair_codes[e] * cb[0] + cb[1];
+    x = (x & cb[2]) ^ cb[3];
+    half2 h = as_type<half2>(x);
+    float v = float(h.x) + float(h.y);
+
+    dst[(tk * 16u + r) * row_len + tn * 16u + c] = half(v);
+}
+";
+
+#[allow(unsafe_code, dead_code)]
+fn create_escha_tile_kernel() -> mlx_sys::mlx_fast_metal_kernel {
+    let in_vec = cstr_vec(&[c"code", c"cb"]);
+    let out_vec = cstr_vec(&[c"dst"]);
+    let source = CString::new(ESCHA_TILE_KERNEL_SOURCE).unwrap_or_default();
+    unsafe {
+        let kernel = mlx_sys::mlx_fast_metal_kernel_new(
+            c"higgs_eschamoe_dequant_tiles".as_ptr(),
+            in_vec,
+            out_vec,
+            source.as_ptr(),
+            c"".as_ptr(),
+            true,  // The tile pointer math needs a row-contiguous input.
+            false, // atomic_outputs
+        );
+        mlx_sys::mlx_vector_string_free(in_vec);
+        mlx_sys::mlx_vector_string_free(out_vec);
+        kernel
+    }
+}
+
+#[allow(dead_code)]
+static ESCHA_TILE_KERNEL: OnceLock<CachedMetalKernel> = OnceLock::new();
+
+/// Decode the packed trellis tiles of one expert on the GPU.
+///
+/// The input is the `[tiles_k, tiles_n, 16 * K]` int16 code slice of one
+/// expert. The result is the `[in, out]` f16 matrix `Ŵ` in row-major order.
+/// The values equal the CPU decode in [`crate::eschamoe`]. This function
+/// does not apply the Hadamard or the channel scales.
+#[allow(unsafe_code, dead_code)]
+pub fn eschamoe_dequant_tiles(code: &Array, spec: &EschaSpec) -> Result<Array, Exception> {
+    ensure_ffi_error_handler();
+
+    let [mul, add, mask, xor] = crate::eschamoe::gpu_codebook(spec).ok_or_else(|| {
+        Exception::custom("eschamoe_dequant_tiles: the codebook has no verified GPU decode")
+    })?;
+    if code.dtype() != Dtype::Int16 {
+        return Err(Exception::custom(format!(
+            "eschamoe_dequant_tiles: code dtype {:?} is not int16",
+            code.dtype()
+        )));
+    }
+    let k = i32::try_from(spec.k).unwrap_or(0);
+    if !(1..=8).contains(&k) {
+        return Err(Exception::custom(format!(
+            "eschamoe_dequant_tiles: K={k} out of range 1..=8"
+        )));
+    }
+    let (tiles_k, tiles_n) = spec.tiles();
+    let expected = [
+        i32::try_from(tiles_k).unwrap_or(i32::MAX),
+        i32::try_from(tiles_n).unwrap_or(i32::MAX),
+        i32::try_from(spec.words_per_tile()).unwrap_or(i32::MAX),
+    ];
+    if code.shape() != expected {
+        return Err(Exception::custom(format!(
+            "eschamoe_dequant_tiles: code shape {:?} does not match {expected:?}",
+            code.shape()
+        )));
+    }
+
+    let stream = Stream::task_local_or_default();
+    let cached = ESCHA_TILE_KERNEL.get_or_init(|| CachedMetalKernel(create_escha_tile_kernel()));
+    let out_shape = [spec.in_features, spec.out_features];
+    // A template value goes into the generated MSL function name. A negative
+    // value makes that name invalid. Thus the codebook constants travel in a
+    // small uint32 input, and only K and TN are template values.
+    let cb_arr = Array::from_slice(&[mul, add, mask, xor], &[4]);
+
+    unsafe {
+        let config = mlx_sys::mlx_fast_metal_kernel_config_new();
+        mlx_sys::mlx_fast_metal_kernel_config_add_template_arg_int(config, c"K".as_ptr(), k);
+        mlx_sys::mlx_fast_metal_kernel_config_add_template_arg_int(
+            config,
+            c"TN".as_ptr(),
+            expected[1],
+        );
+        // One threadgroup of 128 threads decodes one tile. The grid gives
+        // the total thread count on each axis.
+        mlx_sys::mlx_fast_metal_kernel_config_set_grid(config, 128, expected[1], expected[0]);
+        mlx_sys::mlx_fast_metal_kernel_config_set_thread_group(config, 128, 1, 1);
+        mlx_sys::mlx_fast_metal_kernel_config_add_output_arg(
+            config,
+            out_shape.as_ptr(),
+            out_shape.len(),
+            mlx_sys::mlx_dtype__MLX_FLOAT16,
+        );
+
+        let input_ptrs = [code.as_ptr(), cb_arr.as_ptr()];
+        let inputs_vec = mlx_sys::mlx_vector_array_new_data(input_ptrs.as_ptr(), input_ptrs.len());
+        let mut outputs_vec = mlx_sys::mlx_vector_array_new();
+        let status = mlx_sys::mlx_fast_metal_kernel_apply(
+            &raw mut outputs_vec,
+            cached.0,
+            inputs_vec,
+            config,
+            stream.as_ptr(),
+        );
+
+        let result = if status == 0 {
+            let mut out_ptr = mlx_sys::mlx_array_new();
+            let get_status = mlx_sys::mlx_vector_array_get(&raw mut out_ptr, outputs_vec, 0);
+            if get_status == 0 {
+                Ok(Array::from_ptr(out_ptr))
+            } else {
+                mlx_sys::mlx_array_free(out_ptr);
+                Err(Exception::custom(format!(
+                    "eschamoe_dequant_tiles: output read failed: {}",
+                    take_last_error()
+                )))
+            }
+        } else {
+            Err(Exception::custom(format!(
+                "eschamoe_dequant_tiles failed: {}",
+                take_last_error()
+            )))
+        };
+
+        mlx_sys::mlx_fast_metal_kernel_config_free(config);
+        mlx_sys::mlx_vector_array_free(inputs_vec);
+        mlx_sys::mlx_vector_array_free(outputs_vec);
+        result
+    }
+}
+
+const ESCHA_QMV_KERNEL_SOURCE: &str = r"
+// One simdgroup computes one output element for one selected expert.
+constexpr int WORDS = 8 * K;
+constexpr int IN = TK * 16;
+constexpr int OUT = TN * 16;
+
+threadgroup float x_sh[TK * 16];
+
+uint row = threadgroup_position_in_grid.y;
+uint tid = thread_index_in_threadgroup;
+uint sg = simdgroup_index_in_threadgroup;
+uint lane = thread_index_in_simdgroup;
+
+// Stage the transformed activation row of this expert.
+for (uint i = tid; i < uint(IN); i += 128u) {
+    x_sh[i] = xh[row * uint(IN) + i];
+}
+threadgroup_barrier(mem_flags::mem_threadgroup);
+
+uint o = threadgroup_position_in_grid.x * 4u + sg;
+if (o >= uint(OUT)) {
+    return;
+}
+
+// Split the output index into a tile column and a slot column.
+uint tn = o >> 4;
+uint c = o & 15u;
+uint cb2 = (c >> 3) & 1u;
+uint c7 = c & 7u;
+
+const device short* base =
+    code + ulong(eids[row]) * ulong(TK) * ulong(TN) * ulong(16 * K);
+
+// Each lane owns one code pair. The pair index inverts the closed form
+// of tile_perm for a fixed column. One pair gives two adjacent rows.
+uint q = lane & 3u;
+uint rh = (lane >> 2) & 1u;
+uint t = 4u * (4u * c7 + q) + 2u * cb2 + rh;
+uint r0 = 8u * rh + 2u * q;
+
+// The bit offsets copy unpack_tile. The wrap term 256 * K comes before
+// the term -16. Thus the unsigned value stays 0 or more.
+uint b0 = 2u * t * uint(K) + uint(K) + 256u * uint(K) - 16u;
+uint b2 = b0 + uint(K) + 16u;
+uint i0 = (b0 / 32u) % uint(WORDS);
+uint i1w = (b2 - 1u) / 32u;
+uint s1 = (i1w + 1u) * 32u - b2;
+uint i1 = i1w % uint(WORDS);
+
+float acc = 0.0f;
+for (uint tk = lane >> 3; tk < uint(TK); tk += 4u) {
+    const device short* tile = base + (tk * uint(TN) + tn) * uint(16 * K);
+    uint w0 = uint(ushort(tile[2u * i0])) | (uint(ushort(tile[2u * i0 + 1u])) << 16);
+    uint wb = uint(ushort(tile[2u * i1])) | (uint(ushort(tile[2u * i1 + 1u])) << 16);
+
+    // The 64-bit funnel makes the shift safe when s1 is 0.
+    ulong pair = (ulong(w0) << 32) | ulong(wb);
+    uint w1 = uint(pair >> s1);
+
+    // The codebook hash. Refer to the tile decode kernel. The half cast
+    // repeats the f16 round of the CPU decode.
+    uint x0 = ((w1 >> uint(K)) & 0xFFFFu) * cb[0] + cb[1];
+    x0 = (x0 & cb[2]) ^ cb[3];
+    uint x1 = (w1 & 0xFFFFu) * cb[0] + cb[1];
+    x1 = (x1 & cb[2]) ^ cb[3];
+    half2 h0 = as_type<half2>(x0);
+    half2 h1 = as_type<half2>(x1);
+    float v0 = float(half(float(h0.x) + float(h0.y)));
+    float v1 = float(half(float(h1.x) + float(h1.y)));
+
+    acc = fma(x_sh[tk * 16u + r0], v0, acc);
+    acc = fma(x_sh[tk * 16u + r0 + 1u], v1, acc);
+}
+
+acc = simd_sum(acc);
+if (lane == 0u) {
+    dst[row * uint(OUT) + o] = acc;
+}
+";
+
+#[allow(unsafe_code, dead_code)]
+fn create_escha_qmv_kernel() -> mlx_sys::mlx_fast_metal_kernel {
+    let in_vec = cstr_vec(&[c"xh", c"code", c"eids", c"cb"]);
+    let out_vec = cstr_vec(&[c"dst"]);
+    let source = CString::new(ESCHA_QMV_KERNEL_SOURCE).unwrap_or_default();
+    unsafe {
+        let kernel = mlx_sys::mlx_fast_metal_kernel_new(
+            c"higgs_eschamoe_gather_qmv".as_ptr(),
+            in_vec,
+            out_vec,
+            source.as_ptr(),
+            c"".as_ptr(),
+            true,  // The tile pointer math needs row-contiguous inputs.
+            false, // atomic_outputs
+        );
+        mlx_sys::mlx_vector_string_free(in_vec);
+        mlx_sys::mlx_vector_string_free(out_vec);
+        kernel
+    }
+}
+
+#[allow(dead_code)]
+static ESCHA_QMV_KERNEL: OnceLock<CachedMetalKernel> = OnceLock::new();
+
+/// Check the gather inputs. Give the row count and the tile dims.
+#[allow(dead_code)]
+fn check_gather_inputs(
+    xh: &Array,
+    code: &Array,
+    expert_ids: &Array,
+    spec: &EschaSpec,
+) -> Result<(i32, [i32; 3]), Exception> {
+    let (tiles_k, tiles_n) = spec.tiles();
+    let tile_dims = [
+        i32::try_from(tiles_k).unwrap_or(i32::MAX),
+        i32::try_from(tiles_n).unwrap_or(i32::MAX),
+        i32::try_from(spec.words_per_tile()).unwrap_or(i32::MAX),
+    ];
+    let code_ok = matches!(code.shape(), &[_, a, b, c] if [a, b, c] == tile_dims);
+    if code.dtype() != Dtype::Int16 || !code_ok {
+        return Err(Exception::custom(format!(
+            "eschamoe_gather_qmv: code {:?} {:?} does not match [E, {tile_dims:?}] int16",
+            code.dtype(),
+            code.shape()
+        )));
+    }
+    let &[rows, cols] = xh.shape() else {
+        return Err(Exception::custom(format!(
+            "eschamoe_gather_qmv: xh has shape {:?}, not two dims",
+            xh.shape()
+        )));
+    };
+    if xh.dtype() != Dtype::Float32 || cols != spec.in_features {
+        return Err(Exception::custom(format!(
+            "eschamoe_gather_qmv: xh {:?} {:?} does not match [rows, {}] float32",
+            xh.dtype(),
+            xh.shape(),
+            spec.in_features
+        )));
+    }
+    if expert_ids.dtype() != Dtype::Uint32 || expert_ids.shape() != [rows] {
+        return Err(Exception::custom(format!(
+            "eschamoe_gather_qmv: expert_ids {:?} {:?} does not match [{rows}] uint32",
+            expert_ids.dtype(),
+            expert_ids.shape()
+        )));
+    }
+    Ok((rows, tile_dims))
+}
+
+/// Multiply activation rows with selected expert trellis weights.
+///
+/// The input `xh` is the `[rows, in]` float32 matrix. Each row already
+/// carries the input scales and the input Hadamard of its expert. The
+/// input `code` is the full `[experts, tiles_k, tiles_n, 16 * K]` int16
+/// trellis tensor. The input `expert_ids` maps each row to one expert.
+/// The result is `y_pre = xh @ Ŵ` as a `[rows, out]` float32 matrix. The
+/// caller applies the output Hadamard and the output scales.
+#[allow(unsafe_code, dead_code)]
+pub fn eschamoe_gather_qmv(
+    xh: &Array,
+    code: &Array,
+    expert_ids: &Array,
+    spec: &EschaSpec,
+) -> Result<Array, Exception> {
+    ensure_ffi_error_handler();
+
+    let [mul, add, mask, xor] = crate::eschamoe::gpu_codebook(spec).ok_or_else(|| {
+        Exception::custom("eschamoe_gather_qmv: the codebook has no verified GPU decode")
+    })?;
+    let k = i32::try_from(spec.k).unwrap_or(0);
+    if !(1..=8).contains(&k) {
+        return Err(Exception::custom(format!(
+            "eschamoe_gather_qmv: K={k} out of range 1..=8"
+        )));
+    }
+    let (rows, tile_dims) = check_gather_inputs(xh, code, expert_ids, spec)?;
+
+    let stream = Stream::task_local_or_default();
+    let cached = ESCHA_QMV_KERNEL.get_or_init(|| CachedMetalKernel(create_escha_qmv_kernel()));
+    let out_shape = [rows, spec.out_features];
+    // The codebook constants travel in a small uint32 input. Refer to
+    // the note on template values in eschamoe_dequant_tiles.
+    let cb_arr = Array::from_slice(&[mul, add, mask, xor], &[4]);
+
+    unsafe {
+        let config = mlx_sys::mlx_fast_metal_kernel_config_new();
+        mlx_sys::mlx_fast_metal_kernel_config_add_template_arg_int(config, c"K".as_ptr(), k);
+        mlx_sys::mlx_fast_metal_kernel_config_add_template_arg_int(
+            config,
+            c"TK".as_ptr(),
+            tile_dims[0],
+        );
+        mlx_sys::mlx_fast_metal_kernel_config_add_template_arg_int(
+            config,
+            c"TN".as_ptr(),
+            tile_dims[1],
+        );
+        // One threadgroup holds 4 simdgroups. Each simdgroup computes one
+        // output element. The grid gives total thread counts.
+        let groups_x = (spec.out_features + 3) / 4;
+        mlx_sys::mlx_fast_metal_kernel_config_set_grid(config, groups_x * 128, rows, 1);
+        mlx_sys::mlx_fast_metal_kernel_config_set_thread_group(config, 128, 1, 1);
+        mlx_sys::mlx_fast_metal_kernel_config_add_output_arg(
+            config,
+            out_shape.as_ptr(),
+            out_shape.len(),
+            mlx_sys::mlx_dtype__MLX_FLOAT32,
+        );
+
+        let input_ptrs = [
+            xh.as_ptr(),
+            code.as_ptr(),
+            expert_ids.as_ptr(),
+            cb_arr.as_ptr(),
+        ];
+        let inputs_vec = mlx_sys::mlx_vector_array_new_data(input_ptrs.as_ptr(), input_ptrs.len());
+        let mut outputs_vec = mlx_sys::mlx_vector_array_new();
+        let status = mlx_sys::mlx_fast_metal_kernel_apply(
+            &raw mut outputs_vec,
+            cached.0,
+            inputs_vec,
+            config,
+            stream.as_ptr(),
+        );
+
+        let result = if status == 0 {
+            let mut out_ptr = mlx_sys::mlx_array_new();
+            let get_status = mlx_sys::mlx_vector_array_get(&raw mut out_ptr, outputs_vec, 0);
+            if get_status == 0 {
+                Ok(Array::from_ptr(out_ptr))
+            } else {
+                mlx_sys::mlx_array_free(out_ptr);
+                Err(Exception::custom(format!(
+                    "eschamoe_gather_qmv: output read failed: {}",
+                    take_last_error()
+                )))
+            }
+        } else {
+            Err(Exception::custom(format!(
+                "eschamoe_gather_qmv failed: {}",
+                take_last_error()
+            )))
+        };
+
+        mlx_sys::mlx_fast_metal_kernel_config_free(config);
+        mlx_sys::mlx_vector_array_free(inputs_vec);
+        mlx_sys::mlx_vector_array_free(outputs_vec);
+        result
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/higgs-models/src/qwen3_next.rs
+++ b/crates/higgs-models/src/qwen3_next.rs
@@ -2146,6 +2146,9 @@ pub(crate) struct SwitchMlpWeights {
     down_proj: QLinear,
     /// Lazily fused gate+up weights for `MoE` `gather_qmm` (3→2 calls per layer).
     fused_gate_up: Option<(Array, Array, Array, i32)>,
+    /// Native trellis expert weights. When set, the forward pass uses the
+    /// Escha kernels and skips the three `gather_qmm` calls.
+    escha: Option<crate::eschamoe::EschaSwitchMlp>,
 }
 
 impl SwitchMlpWeights {
@@ -2163,7 +2166,14 @@ impl SwitchMlpWeights {
             up_proj: QLinear::new(up.0, up.1)?,
             down_proj: QLinear::new(down.0, down.1)?,
             fused_gate_up: None,
+            escha: None,
         })
+    }
+
+    /// Install native trellis expert weights. The next forward call uses
+    /// them in place of the affine `gather_qmm` path.
+    pub(crate) fn set_escha(&mut self, escha: crate::eschamoe::EschaSwitchMlp) {
+        self.escha = Some(escha);
     }
 
     /// Apply the full `SwiGLU` `MoE` block for all selected experts in one shot
@@ -2277,6 +2287,34 @@ impl SwitchMlpWeights {
 
         // idx_sorted: [N] — monotonically non-decreasing expert indices
         let idx_sorted = idx_flat.take_axis(&order, 0)?;
+
+        // Native trellis path. It reuses the sort above. Only the three
+        // gather_qmm calls change. Gate and up are one fused dispatch.
+        if let Some(escha) = &self.escha {
+            let x2 = x_sorted.reshape(&[b * l * top_k, d])?;
+            let eids = idx_sorted.as_dtype(Dtype::Uint32)?;
+            let gate_up = escha
+                .gate_up
+                .gather_forward(&x2, &eids)
+                .map_err(|e| Exception::custom(format!("escha gate_up: {e}")))?;
+            // The fused output is [N, 2 * intermediate]. Split it for SwiGLU.
+            let intermediate = escha.gate_up.spec.out_features / 2;
+            let parts = gate_up.split_axis(&[intermediate], Some(-1))?;
+            let gate_out = parts
+                .first()
+                .ok_or_else(|| Exception::custom("escha gate_up split failed"))?;
+            let up_out = parts
+                .get(1)
+                .ok_or_else(|| Exception::custom("escha gate_up split failed"))?;
+            let activated = swiglu(gate_out, up_out)?;
+            let down = escha
+                .down
+                .gather_forward(&activated, &eids)
+                .map_err(|e| Exception::custom(format!("escha down: {e}")))?;
+            let out_flat = down.as_dtype(x.dtype())?;
+            let out_unsorted = out_flat.take_axis(&inv_order, 0)?;
+            return out_unsorted.reshape(&[b, l, top_k, d]);
+        }
 
         // --- gather_qmm with coalesced access ---
         let gate_out = gather_qmm(
@@ -4491,7 +4529,8 @@ fn mtp_weight_layout_from_keys<'a>(keys: impl IntoIterator<Item = &'a str>) -> M
     let mut has_mtp = false;
     let mut has_unprefixed_mtp = false;
     let mut has_quantized_aux = false;
-    let mut has_moe_mlp = false;
+    let mut has_moe_router = false;
+    let mut has_moe_experts = false;
 
     for key in keys {
         if !is_mtp_key(key) {
@@ -4500,13 +4539,23 @@ fn mtp_weight_layout_from_keys<'a>(keys: impl IntoIterator<Item = &'a str>) -> M
         has_mtp = true;
         has_unprefixed_mtp |= key.starts_with("mtp.");
         has_quantized_aux |= key.ends_with(".scales") || key.ends_with(".biases");
-        has_moe_mlp |= key.contains(".mlp.gate.")
-            || key.contains(".mlp.shared_expert")
-            || key.contains(".mlp.switch_mlp")
-            || key.contains(".mlp.experts");
+        // The router and the shared expert show an MoE head. The routed
+        // experts are a different group of tensors.
+        has_moe_router |= key.contains(".mlp.gate.") || key.contains(".mlp.shared_expert");
+        has_moe_experts |= key.contains(".mlp.switch_mlp") || key.contains(".mlp.experts");
     }
 
-    if has_mtp && has_moe_mlp {
+    // Some checkpoints hold an MoE draft head but no routed expert weights.
+    // The eschamoe release of Qwen3.6-35B-A3B is an example: it has
+    // `mtp.layers.0.mlp.gate` and `mtp.layers.0.mlp.shared_expert`, but it has
+    // no `mtp.layers.0.mlp.experts`. The head cannot operate without those
+    // weights. Thus the function reports no MTP head, and the caller stops the
+    // MTP function for this checkpoint.
+    if has_mtp && has_moe_router && !has_moe_experts {
+        return MtpWeightLayout::None;
+    }
+
+    if has_mtp && (has_moe_router || has_moe_experts) {
         MtpWeightLayout::MoeQuantized
     } else if has_quantized_aux {
         MtpWeightLayout::Quantized
@@ -4848,6 +4897,7 @@ pub(crate) fn load_qwen3_5_model_with_args(
     model_path: &Path,
     mut args: Qwen3NextModelArgs,
 ) -> Result<Qwen3NextCausalLM, ModelError> {
+    force_eschamoe_quant_layout(&mut args, model_path)?;
     maybe_disable_mtp_without_checkpoint_weights(&mut args, model_path)?;
 
     tracing::info!(
@@ -4889,6 +4939,7 @@ pub(crate) fn load_qwen3_5_moe_model_with_args(
     model_path: &Path,
     mut args: Qwen3NextModelArgs,
 ) -> Result<Qwen3NextCausalLM, ModelError> {
+    force_eschamoe_quant_layout(&mut args, model_path)?;
     maybe_disable_mtp_without_checkpoint_weights(&mut args, model_path)?;
 
     tracing::info!(
@@ -4927,6 +4978,35 @@ pub(crate) fn load_qwen3_5_moe_model_with_args(
 /// the direct loader. Otherwise try the fused loader; if it reports a mixed-bit
 /// `in_proj_ba` shape mismatch, rebuild the model with separate projections and
 /// retry via the direct loader.
+/// Install the native trellis expert weights on their layers.
+///
+/// The vector comes from [`load_qwen3_5_moe_weights_fused`]. Each entry
+/// names one decoder layer by its index.
+fn apply_escha_natives(
+    model: &mut Qwen3NextCausalLM,
+    natives: Vec<(usize, crate::eschamoe::EschaSwitchMlp)>,
+) -> Result<(), ModelError> {
+    let count = natives.len();
+    for (layer_idx, escha) in natives {
+        let switch = model
+            .model
+            .layers
+            .get_mut(layer_idx)
+            .and_then(|layer| layer.mlp.switch_mlp.as_mut())
+            .ok_or_else(|| {
+                ModelError::ShapeMismatch(format!(
+                    "native expert weights target layer {layer_idx}, but that layer has no \
+                     switch_mlp"
+                ))
+            })?;
+        switch.set_escha(escha);
+    }
+    if count > 0 {
+        tracing::info!(layers = count, "Installed native trellis expert weights");
+    }
+    Ok(())
+}
+
 fn load_qwen3_5_model_with_gdn_fallback(
     model_path: &Path,
     mut args: Qwen3NextModelArgs,
@@ -4950,7 +5030,8 @@ fn load_qwen3_5_model_with_gdn_fallback(
         gdn_dims,
         quantization.as_ref(),
     ) {
-        Ok(()) => {
+        Ok(natives) => {
+            apply_escha_natives(&mut fused_model, natives)?;
             tracing::info!("Using FUSED GDN projections (2 dispatches per layer)");
             Ok(fused_model)
         }
@@ -5301,18 +5382,90 @@ fn load_qwen3_5_moe_weights_direct<M: mlx_rs::module::ModuleParametersExt>(
     Ok(())
 }
 
+/// Set the affine layout that an eschamoe checkpoint gets after conversion.
+///
+/// An eschamoe checkpoint has no MLX `quantization` block, so the argument
+/// code reads its `quantization_config` block. That block gives the trellis
+/// bit rate, for example 2.0. An affine layer cannot use that value. Thus this
+/// function replaces the layout with [`crate::eschamoe::CONVERSION_TARGET`],
+/// which is the layout that the conversion code makes.
+fn force_eschamoe_quant_layout(
+    args: &mut Qwen3NextModelArgs,
+    model_path: &Path,
+) -> Result<(), crate::error::ModelError> {
+    if !crate::eschamoe::is_eschamoe_checkpoint(model_path)? {
+        return Ok(());
+    }
+    // A checkpoint with its own `quantization` block already agrees with the
+    // conversion code, because both read that block. Do not change the
+    // arguments in that case. Only a checkpoint with no such block needs this
+    // correction, because the argument code would then read the eschamoe
+    // `quantization_config` block and get the trellis bit rate.
+    let config: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(model_path.join("config.json"))?)?;
+    if config.get("quantization").is_some() {
+        return Ok(());
+    }
+    let target = crate::eschamoe::CONVERSION_TARGET;
+    let spec = serde_json::json!({ "group_size": target.group_size, "bits": target.bits });
+    args.quantization = serde_json::from_value(spec.clone()).ok();
+    args.gate_quantization = serde_json::from_value(spec).ok();
+    tracing::info!(
+        group_size = target.group_size,
+        bits = target.bits,
+        "eschamoe checkpoint: using the affine layout of the conversion code"
+    );
+    Ok(())
+}
+
+/// Read every checkpoint tensor as `(key, value)` pairs, ready for the loader.
+///
+/// An eschamoe checkpoint needs a change of format first. The function
+/// [`crate::eschamoe::convert_checkpoint`] decodes the trellis tensors and the
+/// int8 tensors, and gives affine tensors with mlx-community key names. A
+/// standard checkpoint gives its safetensors contents with no change, but the
+/// keys of an MTP sidecar file get a prefix.
+///
+/// The second result holds the native expert weights of each layer. It is
+/// empty when `HIGGS_ESCHA_NATIVE=0` selects the affine mode.
+fn checkpoint_tensors(
+    model_path: &Path,
+    quantization: Option<&QuantizationConfig>,
+) -> Result<crate::eschamoe::ConvertedCheckpoint, crate::error::ModelError> {
+    if crate::eschamoe::is_eschamoe_checkpoint(model_path)? {
+        let config = model_path.join("config.json");
+        let text = std::fs::read_to_string(&config)?;
+        let value: serde_json::Value = serde_json::from_str(&text)?;
+        return crate::eschamoe::convert_checkpoint_auto(model_path, value.get("quantization"));
+    }
+
+    let mut out = Vec::new();
+    for file_path in crate::collect_safetensors_files(model_path)? {
+        let loaded = Array::load_safetensors(&file_path)
+            .map_err(|e| crate::error::ModelError::Io(std::io::Error::other(e.to_string())))?;
+        crate::validate_quantized_tensor_widths(&loaded, quantization)?;
+        for (key, value) in loaded {
+            out.push((normalize_sidecar_mtp_key(&file_path, key), value));
+        }
+    }
+    Ok((out, Vec::new()))
+}
+
 /// Rearranges flat (qkv,z,b,a) projections to per-head-grouped (qkvz,ba)
 /// so the model uses the fused 2-dispatch forward path instead of 4 separate.
+///
+/// The result holds the native expert weights from [`checkpoint_tensors`].
+/// The caller installs them on the concrete model type.
 #[allow(clippy::too_many_lines, clippy::shadow_reuse)]
 fn load_qwen3_5_moe_weights_fused<M: mlx_rs::module::ModuleParametersExt>(
     model: &mut M,
     model_path: &Path,
     gdn_dims: &GdnDims,
     quantization: Option<&QuantizationConfig>,
-) -> Result<(), crate::error::ModelError> {
+) -> Result<Vec<(usize, crate::eschamoe::EschaSwitchMlp)>, crate::error::ModelError> {
     use std::collections::HashMap;
 
-    let safetensors_files = crate::collect_safetensors_files(model_path)?;
+    let (tensors, escha_natives) = checkpoint_tensors(model_path, quantization)?;
     let mut params = model.parameters_mut().flatten();
 
     let qkvz_perm = build_qkvz_permutation(gdn_dims)
@@ -5328,47 +5481,39 @@ fn load_qwen3_5_moe_weights_fused<M: mlx_rs::module::ModuleParametersExt>(
         ("in_proj_b", "in_proj_a", "in_proj_ba"),
     ];
 
-    for file_path in &safetensors_files {
-        let loaded = Array::load_safetensors(file_path)
-            .map_err(|e| crate::error::ModelError::Io(std::io::Error::other(e.to_string())))?;
-        crate::validate_quantized_tensor_widths(&loaded, quantization)?;
+    for (key, value) in tensors {
+        let Some(stripped) = qwen35_checkpoint_param_key(&key) else {
+            continue;
+        };
 
-        for (key, value) in loaded {
-            let key = normalize_sidecar_mtp_key(file_path, key);
-            let Some(stripped) = qwen35_checkpoint_param_key(&key) else {
-                continue;
-            };
-
-            let mut handled = false;
-            for &(part_a_name, part_b_name, combined_name) in gdn_remap {
-                for (is_b, split_name) in [(false, part_a_name), (true, part_b_name)] {
-                    let needle = format!(".{split_name}.");
-                    if let Some(pos) = stripped.find(&needle) {
-                        let pfx = &stripped[..pos];
-                        let sfx = &stripped[pos + needle.len()..];
-                        let map_key = format!("{pfx}.{combined_name}.{sfx}");
-                        let entry = gdn_parts.entry(map_key).or_insert((None, None));
-                        if is_b {
-                            entry.1 = Some(value.clone());
-                        } else {
-                            entry.0 = Some(value.clone());
-                        }
-                        handled = true;
-                        break;
+        let mut handled = false;
+        for &(part_a_name, part_b_name, combined_name) in gdn_remap {
+            for (is_b, split_name) in [(false, part_a_name), (true, part_b_name)] {
+                let needle = format!(".{split_name}.");
+                if let Some(pos) = stripped.find(&needle) {
+                    let pfx = &stripped[..pos];
+                    let sfx = &stripped[pos + needle.len()..];
+                    let map_key = format!("{pfx}.{combined_name}.{sfx}");
+                    let entry = gdn_parts.entry(map_key).or_insert((None, None));
+                    if is_b {
+                        entry.1 = Some(value.clone());
+                    } else {
+                        entry.0 = Some(value.clone());
                     }
-                }
-                if handled {
+                    handled = true;
                     break;
                 }
             }
+            if handled {
+                break;
+            }
+        }
 
-            if !handled {
-                if let Some((target_key, dense_mtp_target)) =
-                    qwen35_target_param_key(&params, stripped)
-                {
-                    if let Some(param) = params.get_mut(target_key.as_str()) {
-                        **param = qwen35_loaded_value(stripped, value, dense_mtp_target)?;
-                    }
+        if !handled {
+            if let Some((target_key, dense_mtp_target)) = qwen35_target_param_key(&params, stripped)
+            {
+                if let Some(param) = params.get_mut(target_key.as_str()) {
+                    **param = qwen35_loaded_value(stripped, value, dense_mtp_target)?;
                 }
             }
         }
@@ -5417,9 +5562,14 @@ fn load_qwen3_5_moe_weights_fused<M: mlx_rs::module::ModuleParametersExt>(
         total_pairs = gdn_parts.len(),
         "Fused GDN projections (4→2 dispatches per layer)"
     );
+    // In the native escha mode, the expert affine params get no tensors.
+    // The forward pass uses the native weights in their place. Thus the
+    // completeness check must not flag the `switch_mlp` placeholders.
+    let native_experts = !escha_natives.is_empty();
     ensure_all_model_params_loaded(
         params
             .iter()
+            .filter(|(name, _)| !(native_experts && name.contains(".mlp.switch_mlp.")))
             .map(|(name, value)| (std::rc::Rc::<str>::clone(name), &**value)),
     )?;
 
@@ -5427,7 +5577,7 @@ fn load_qwen3_5_moe_weights_fused<M: mlx_rs::module::ModuleParametersExt>(
         .eval()
         .map_err(|e| crate::error::ModelError::Io(std::io::Error::other(e.to_string())))?;
 
-    Ok(())
+    Ok(escha_natives)
 }
 
 #[allow(
@@ -5666,6 +5816,80 @@ mod tests {
             }"#,
         )
         .unwrap()
+    }
+
+    /// Every key shape an eschamoe checkpoint ships must resolve, after
+    /// [`crate::eschamoe::normalize_key`] and the existing prefix strip, onto a
+    /// real parameter of the constructed model.
+    ///
+    /// The raw keys are verbatim from the published checkpoint's
+    /// `model.safetensors.index.json`; the targets are verbatim from
+    /// `Qwen3NextCausalLM::parameters()`. This is what stops the loader from
+    /// silently dropping tensors — an unmatched key is skipped, not reported,
+    /// so only `ensure_all_model_params_loaded` would catch it, and only then
+    /// as an opaque "N params were not loaded".
+    #[test]
+    fn eschamoe_checkpoint_keys_resolve_to_parameters() {
+        use mlx_rs::module::ModuleParameters;
+
+        use crate::eschamoe::{self, Storage};
+
+        let mut model = Qwen3NextCausalLM::new(valid_causal_lm_args()).unwrap();
+        let params = model.parameters_mut().flatten();
+
+        // Layer 3 is full-attention here (full_attention_interval = 4); layer 0
+        // is a GDN layer, so each carries a different projection set.
+        let direct = [
+            "model.language_model.layers.3.self_attn.q_proj.weight_int8",
+            "model.language_model.layers.3.self_attn.o_proj.weight_scale",
+            "model.language_model.layers.3.self_attn.k_norm.weight",
+            "model.language_model.layers.0.linear_attn.out_proj.weight_int8",
+            "model.language_model.layers.0.linear_attn.conv1d.weight",
+            "model.language_model.layers.0.linear_attn.A_log",
+            "model.language_model.layers.0.mlp.shared_expert.up_proj.weight_int8",
+            "model.language_model.layers.0.mlp.shared_expert_gate.weight",
+            "model.language_model.layers.0.mlp.gate.weight",
+            "model.language_model.layers.0.input_layernorm.weight",
+            "model.language_model.norm.weight",
+            "model.language_model.embed_tokens.weight_int8",
+            "lm_head.weight_int8",
+        ];
+        for raw in direct {
+            let normalized = eschamoe::normalize_key(raw);
+            let stripped = qwen35_checkpoint_param_key(&normalized)
+                .unwrap_or_else(|| panic!("{raw} did not normalize into the loader's namespace"));
+            let (storage, prefix) = eschamoe::classify(stripped);
+            // Dense tensors land on themselves; quantized ones land on the
+            // `.weight` of the QLinear the loader rebuilds.
+            let target = match storage {
+                Storage::Dense => prefix.to_owned(),
+                Storage::Int8 | Storage::Trellis => format!("{prefix}.weight"),
+            };
+            assert!(
+                params.contains_key(target.as_str()),
+                "{raw} -> {target} is not a model parameter"
+            );
+        }
+
+        // The two trellis projections are the exception: escha stores gate and
+        // up fused, while the model wants three separate experts stacks.
+        let (storage, prefix) =
+            eschamoe::classify("model.layers.0.mlp.experts.gate_up_proj.escha_code");
+        assert_eq!(storage, Storage::Trellis);
+        assert_eq!(prefix, "model.layers.0.mlp.experts.gate_up_proj");
+        for target in [
+            "model.layers.0.mlp.switch_mlp.gate_proj.weight",
+            "model.layers.0.mlp.switch_mlp.up_proj.weight",
+            "model.layers.0.mlp.switch_mlp.down_proj.weight",
+        ] {
+            assert!(params.contains_key(target), "{target} missing");
+        }
+
+        // GDN projections are stored split and fused by the existing loader, so
+        // the fused names must exist while the split ones must not.
+        assert!(params.contains_key("model.layers.0.linear_attn.in_proj_qkvz.weight"));
+        assert!(params.contains_key("model.layers.0.linear_attn.in_proj_ba.weight"));
+        assert!(!params.contains_key("model.layers.0.linear_attn.in_proj_qkv.weight"));
     }
 
     #[test]
@@ -8055,6 +8279,7 @@ mod tests {
                     up_proj: make_switch_ql(d, d_inter),
                     down_proj: make_switch_ql(d_inter, d),
                     fused_gate_up: None,
+                    escha: None,
                 },
                 shared_expert: Qwen3NextMLP {
                     gate_proj: make_ql(d, shared_inter * 2, gs, bits),
@@ -15094,6 +15319,115 @@ mod tests {
             tokens.push(tok.item::<u32>());
         }
         tokens
+    }
+
+    /// Give the resident set size of this process in GiB.
+    ///
+    /// The function reads the `rss` column of `ps` for its own pid.
+    fn own_rss_gib() -> f64 {
+        let out = std::process::Command::new("ps")
+            .args(["-o", "rss=", "-p", &std::process::id().to_string()])
+            .output()
+            .expect("ps must run");
+        let kib: f64 = String::from_utf8_lossy(&out.stdout)
+            .trim()
+            .parse()
+            .expect("rss must parse");
+        kib / (1024.0 * 1024.0)
+    }
+
+    /// Give the active and peak MLX buffer memory in GB.
+    ///
+    /// The `ps` value misses the Metal buffers. Thus the footprint gate
+    /// reads the MLX allocator counters.
+    fn mlx_mem_gb() -> (f64, f64) {
+        let mut active: usize = 0;
+        let mut peak: usize = 0;
+        #[allow(unsafe_code)]
+        unsafe {
+            mlx_sys::mlx_get_active_memory(&mut active as *mut _);
+            mlx_sys::mlx_get_peak_memory(&mut peak as *mut _);
+        }
+        (active as f64 / 1e9, peak as f64 / 1e9)
+    }
+
+    /// Load an eschamoe checkpoint and print parity and footprint data.
+    ///
+    /// `HIGGS_ESCHA_NATIVE` selects the load mode. The test sends one fixed
+    /// prompt through the model. Set `HIGGS_ESCHA_LOGITS_OUT` to save the
+    /// logits. Set `HIGGS_ESCHA_LOGITS_REF` to compare against a saved file.
+    /// Run the test once for each mode. The second run prints the max abs
+    /// difference between the two modes.
+    ///
+    /// ```bash
+    /// HIGGS_ESCHA_NATIVE=0 HIGGS_ESCHA_LOGITS_OUT=/tmp/escha_affine.safetensors \
+    ///   cargo test -p higgs-models --release -- escha_native_fixture --ignored --nocapture
+    /// HIGGS_ESCHA_NATIVE=1 HIGGS_ESCHA_LOGITS_REF=/tmp/escha_affine.safetensors \
+    ///   cargo test -p higgs-models --release -- escha_native_fixture --ignored --nocapture
+    /// ```
+    #[test]
+    #[ignore = "requires escha model files on disk"]
+    fn escha_native_fixture() {
+        use mlx_rs::transforms::eval;
+
+        let dir = std::env::var("HIGGS_ESCHA_TEST_MODEL").unwrap_or_else(|_| {
+            format!(
+                "{}/AI-Models/escha-subset",
+                std::env::var("HOME").unwrap_or_default()
+            )
+        });
+        if !std::path::Path::new(&dir).exists() {
+            eprintln!("Skipping: no escha checkpoint at {dir}");
+            return;
+        }
+        eprintln!("mode: native={}", crate::eschamoe::native_mode());
+
+        let t0 = std::time::Instant::now();
+        let mut model = load_qwen3_5_moe_model(&dir).unwrap();
+        let (active, peak) = mlx_mem_gb();
+        eprintln!(
+            "load: {:.1}s rss_after_load={:.2} GiB mlx_active={active:.2} GB mlx_peak={peak:.2} GB",
+            t0.elapsed().as_secs_f64(),
+            own_rss_gib()
+        );
+
+        let vocab = model.args.vocab_size as u32;
+        let tokens: Vec<u32> = (0..16u32).map(|i| (i * 977 + 3) % vocab).collect();
+        let input = Array::from_slice(&tokens, &[1, 16]);
+        let mut cache: Vec<Option<LayerCache>> = Vec::new();
+        let logits = model
+            .forward(&input, None, &mut cache)
+            .unwrap()
+            .as_dtype(Dtype::Float32)
+            .unwrap();
+        eval([&logits]).unwrap();
+        let (active2, peak2) = mlx_mem_gb();
+        eprintln!(
+            "rss_after_forward={:.2} GiB mlx_active={active2:.2} GB mlx_peak={peak2:.2} GB",
+            own_rss_gib()
+        );
+
+        if let Ok(path) = std::env::var("HIGGS_ESCHA_LOGITS_OUT") {
+            let map = std::collections::HashMap::from([("logits".to_string(), logits.clone())]);
+            Array::save_safetensors(&map, None, &std::path::PathBuf::from(&path)).unwrap();
+            eprintln!("saved logits to {path}");
+        }
+        if let Ok(path) = std::env::var("HIGGS_ESCHA_LOGITS_REF") {
+            let refs = Array::load_safetensors(&path).unwrap();
+            let reference = refs.get("logits").expect("ref file must hold logits");
+            let diff = logits
+                .subtract(reference)
+                .unwrap()
+                .abs()
+                .unwrap()
+                .max(None)
+                .unwrap();
+            let scale = reference.abs().unwrap().max(None).unwrap();
+            eval([&diff, &scale]).unwrap();
+            let (d, s) = (diff.item::<f32>(), scale.item::<f32>());
+            eprintln!("logits max abs diff vs {path}: {d:.6}");
+            eprintln!("ref max abs logit: {s:.6}  relative: {:.3e}", d / s);
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/crates/higgs-models/src/qwen3_next.rs
+++ b/crates/higgs-models/src/qwen3_next.rs
@@ -2189,6 +2189,11 @@ impl SwitchMlpWeights {
         indices: &Array,
         sorted: bool,
     ) -> Result<Array, Exception> {
+        // Native trellis weights have no affine gate/up tensors; route through
+        // the native gather path.
+        if self.escha.is_some() {
+            return self.forward_gather_global_sort(x, indices);
+        }
         // Reshape so x batch dims broadcast with the indices shape.
         // x: [B, L, D] -> [B, L, 1, 1, D]
         //   batch = [B, L, 1], M=1, K=D
@@ -2373,6 +2378,11 @@ impl SwitchMlpWeights {
         x: &Array,
         indices: &Array,
     ) -> Result<Array, Exception> {
+        // Native trellis weights replace the affine gate/up/down tensors, so
+        // the fused affine cache cannot be built. Use the native path instead.
+        if self.escha.is_some() {
+            return self.forward_gather_global_sort(x, indices);
+        }
         // Lazy-init: concatenate gate+up weights along axis 1 (intermediate dim).
         // MoE weights are [num_experts, intermediate_packed, hidden].
         if self.fused_gate_up.is_none() {
@@ -4550,8 +4560,10 @@ fn mtp_weight_layout_from_keys<'a>(keys: impl IntoIterator<Item = &'a str>) -> M
     // `mtp.layers.0.mlp.gate` and `mtp.layers.0.mlp.shared_expert`, but it has
     // no `mtp.layers.0.mlp.experts`. The head cannot operate without those
     // weights. Thus the function reports no MTP head, and the caller stops the
-    // MTP function for this checkpoint.
-    if has_mtp && has_moe_router && !has_moe_experts {
+    // MTP function for this checkpoint. The mirror case (routed experts with
+    // no router) is equally unusable: `MoeMtpHead` would build a router no
+    // tensor fills.
+    if has_mtp && (has_moe_router != has_moe_experts) {
         return MtpWeightLayout::None;
     }
 
@@ -5015,7 +5027,22 @@ fn load_qwen3_5_model_with_gdn_fallback(
     let quantization = args.quantization.clone();
     let force_separate =
         args.use_separate_gdn_projections || std::env::var("HIGGS_SEPARATE_GDN_PROJ").is_ok();
+    // The direct loader reads raw safetensors and never runs the escha
+    // conversion, so an eschamoe checkpoint would fail there with a
+    // placeholder report that names nothing. Reject the combination early.
+    let eschamoe = crate::eschamoe::is_eschamoe_checkpoint(model_path)?;
+    let reject_separate_escha = || {
+        ModelError::UnsupportedModel(
+            "HIGGS_SEPARATE_GDN_PROJ / use_separate_gdn_projections is not supported \
+             for eschamoe checkpoints: the direct loader cannot install native \
+             trellis experts. Unset the flag and use the fused path."
+                .to_owned(),
+        )
+    };
     if force_separate {
+        if eschamoe {
+            return Err(reject_separate_escha());
+        }
         args.use_separate_gdn_projections = true;
         let mut model = Qwen3NextCausalLM::new(args)?;
         load_qwen3_5_moe_weights_direct(&mut model, model_path, quantization.as_ref())?;
@@ -5036,6 +5063,9 @@ fn load_qwen3_5_model_with_gdn_fallback(
             Ok(fused_model)
         }
         Err(err) if is_mixed_bit_gdn_ba_fusion_error(&err) => {
+            if eschamoe {
+                return Err(reject_separate_escha());
+            }
             tracing::warn!(
                 error = %err,
                 "Detected mixed-bit GDN BA projection shapes; retrying with separate GDN projections"
@@ -5408,8 +5438,8 @@ fn force_eschamoe_quant_layout(
     }
     let target = crate::eschamoe::CONVERSION_TARGET;
     let spec = serde_json::json!({ "group_size": target.group_size, "bits": target.bits });
-    args.quantization = serde_json::from_value(spec.clone()).ok();
-    args.gate_quantization = serde_json::from_value(spec).ok();
+    args.quantization = Some(serde_json::from_value(spec.clone())?);
+    args.gate_quantization = Some(serde_json::from_value(spec)?);
     tracing::info!(
         group_size = target.group_size,
         bits = target.bits,
@@ -5564,12 +5594,17 @@ fn load_qwen3_5_moe_weights_fused<M: mlx_rs::module::ModuleParametersExt>(
     );
     // In the native escha mode, the expert affine params get no tensors.
     // The forward pass uses the native weights in their place. Thus the
-    // completeness check must not flag the `switch_mlp` placeholders.
-    let native_experts = !escha_natives.is_empty();
+    // completeness check must not flag the `switch_mlp` placeholders — but
+    // only for layers the natives actually cover; an uncovered layer keeps
+    // its placeholders and must still fail validation.
+    let native_layers: std::collections::HashSet<String> = escha_natives
+        .iter()
+        .map(|(layer_idx, _)| format!("model.layers.{layer_idx}.mlp.switch_mlp."))
+        .collect();
     ensure_all_model_params_loaded(
         params
             .iter()
-            .filter(|(name, _)| !(native_experts && name.contains(".mlp.switch_mlp.")))
+            .filter(|(name, _)| !native_layers.iter().any(|p| name.contains(p.as_str())))
             .map(|(name, value)| (std::rc::Rc::<str>::clone(name), &**value)),
     )?;
 
@@ -8210,7 +8245,7 @@ mod tests {
         });
 
         candidates.into_iter().find(|path| {
-            Array::load_safetensors(path).ok().is_some_and(|loaded| {
+            Array::load_safetensors(path).is_ok_and(|loaded| {
                 loaded.keys().any(|key| {
                     key.contains("switch_mlp")
                         && key.contains("gate_proj")

--- a/crates/higgs-models/src/turboquant.rs
+++ b/crates/higgs-models/src/turboquant.rs
@@ -1951,8 +1951,10 @@ mod tests {
             }
             // Reinterpret CPU bytes as u32 words for comparison
             let cpu_words: Vec<u32> = cpu_packed
-                .chunks_exact(4)
-                .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .map(|c| u32::from_le_bytes(*c))
                 .collect();
 
             // GPU pack (outputs u32 words)
@@ -2003,8 +2005,10 @@ mod tests {
             // Reinterpret CPU bytes as u32 words for comparison
             let cpu_words: Vec<u32> = cpu_result
                 .packed_codes
-                .chunks_exact(4)
-                .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .map(|c| u32::from_le_bytes(*c))
                 .collect();
             let gpu_codes_data = gpu_codes.as_slice::<u32>();
             assert_eq!(
@@ -2051,8 +2055,10 @@ mod tests {
             // Reinterpret CPU bytes as u32 words for comparison
             let cpu_code_words: Vec<u32> = cpu_result
                 .packed_codes
-                .chunks_exact(4)
-                .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .map(|c| u32::from_le_bytes(*c))
                 .collect();
             assert_eq!(
                 gpu_codes.as_slice::<u32>(),

--- a/crates/higgs/src/doctor.rs
+++ b/crates/higgs/src/doctor.rs
@@ -446,10 +446,290 @@ fn check_models(config: &HiggsConfig, result: &mut DoctorResult) {
                     ),
                     result,
                 );
+                check_eschamoe_checkpoint(&resolved, &label, result);
             }
             Err(err) => fail(&format!("model {label} not found: {err}"), result),
         }
     }
+}
+
+// -- Eschamoe checkpoint checks --
+
+/// Check an eschamoe checkpoint before the server starts.
+///
+/// The check validates the quantization declaration, estimates the resident
+/// size after conversion, and warns about the slow CPU-bound load.
+fn check_eschamoe_checkpoint(model_dir: &std::path::Path, label: &str, result: &mut DoctorResult) {
+    check_eschamoe_checkpoint_with_ram(
+        model_dir,
+        label,
+        total_system_ram_bytes(),
+        higgs_models::eschamoe::native_mode(),
+        result,
+    );
+}
+
+fn check_eschamoe_checkpoint_with_ram(
+    model_dir: &std::path::Path,
+    label: &str,
+    ram_bytes: Option<u64>,
+    native: bool,
+    result: &mut DoctorResult,
+) {
+    let is_eschamoe = match higgs_models::eschamoe::is_eschamoe_checkpoint(model_dir) {
+        Ok(flag) => flag,
+        Err(err) => {
+            fail(
+                &format!(
+                    "model {label} has a malformed quantization declaration in \
+                     quantize_config.json or config.json (field quant_method): {err}"
+                ),
+                result,
+            );
+            return;
+        }
+    };
+
+    if !check_quant_method_declarations(model_dir, label, result) {
+        return;
+    }
+    if !is_eschamoe {
+        return;
+    }
+
+    let target = higgs_models::eschamoe::CONVERSION_TARGET;
+    if native {
+        pass(
+            &format!(
+                "model {label} is an eschamoe trellis checkpoint; higgs keeps the experts in the \
+                 trellis form and reads them with the Metal kernel. The other weights become MLX \
+                 affine {}-bit (group size {}).",
+                target.bits, target.group_size
+            ),
+            result,
+        );
+    } else {
+        pass(
+            &format!(
+                "model {label} is an eschamoe trellis checkpoint; HIGGS_ESCHA_NATIVE=0 selects \
+                 the affine path, so higgs decodes every expert to MLX affine {}-bit (group size \
+                 {}) in memory at load",
+                target.bits, target.group_size
+            ),
+            result,
+        );
+        warn(
+            &format!(
+                "model {label} is an eschamoe checkpoint on the affine path: the trellis decode \
+                 runs on the CPU at load (~140s for the 35B checkpoint) and the result is about \
+                 twice the resident size of the native path; a long first start is expected, not \
+                 a hang. Unset HIGGS_ESCHA_NATIVE for the native path."
+            ),
+            result,
+        );
+    }
+    match eschamoe_resident_estimate_bytes(model_dir, native) {
+        Some(estimate) => check_eschamoe_memory(estimate, ram_bytes, label, result),
+        None => warn(
+            &format!(
+                "model {label} config.json lacks size fields (num_hidden_layers, num_experts, \
+                 moe_intermediate_size, hidden_size, vocab_size); cannot estimate resident \
+                 memory after eschamoe conversion"
+            ),
+            result,
+        ),
+    }
+}
+
+/// Compare the `quant_method` declarations of the two config files.
+///
+/// A conflict or a bad field type is an error. Return `false` on error.
+fn check_quant_method_declarations(
+    model_dir: &std::path::Path,
+    label: &str,
+    result: &mut DoctorResult,
+) -> bool {
+    let mut methods: Vec<(&str, String)> = Vec::new();
+    for file in ["quantize_config.json", "config.json"] {
+        let Ok(raw) = std::fs::read_to_string(model_dir.join(file)) else {
+            continue;
+        };
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(&raw) else {
+            // `is_eschamoe_checkpoint` already reports files that are not JSON.
+            continue;
+        };
+        if let Some(quant_config) = value.get("quantization_config") {
+            if !quant_config.is_object() {
+                fail(
+                    &format!("model {label} {file} field quantization_config is not a JSON object"),
+                    result,
+                );
+                return false;
+            }
+        }
+        let method = value.get("quant_method").or_else(|| {
+            value
+                .get("quantization_config")
+                .and_then(|qc| qc.get("quant_method"))
+        });
+        match method {
+            Some(serde_json::Value::String(name)) => methods.push((file, name.clone())),
+            Some(_) => {
+                fail(
+                    &format!("model {label} {file} field quant_method is not a string"),
+                    result,
+                );
+                return false;
+            }
+            None => {}
+        }
+    }
+    if let [(file_a, method_a), (file_b, method_b)] = methods.as_slice() {
+        if method_a != method_b {
+            fail(
+                &format!(
+                    "model {label} {file_a} quant_method=\"{method_a}\" conflicts with {file_b} \
+                     quant_method=\"{method_b}\"; the loader obeys {file_a}"
+                ),
+                result,
+            );
+            return false;
+        }
+    }
+    true
+}
+
+/// Estimate the resident bytes of an eschamoe model after conversion.
+///
+/// The estimate counts the expert weights and the vocabulary weights. These
+/// weights dominate the total.
+///
+/// The vocabulary weights always take the affine layout: packed values plus
+/// one fp16 scale and one fp16 bias per group. The expert weights depend on
+/// the mode. The affine path gives them the same layout. The native path
+/// keeps the trellis codes, which hold `K` bits for each weight, and `K`
+/// differs per projection: the 35B release uses 2 bits for `gate_up_proj` and
+/// 3 for `down_proj`. Thus the native estimate reads the rate of each
+/// projection from `quantization_config.layer_meta` and falls back to the
+/// affine estimate when that block is absent.
+fn eschamoe_resident_estimate_bytes(model_dir: &std::path::Path, native: bool) -> Option<u64> {
+    let raw = std::fs::read_to_string(model_dir.join("config.json")).ok()?;
+    let config: serde_json::Value = serde_json::from_str(&raw).ok()?;
+    // A checkpoint with a vision tower nests the text fields under
+    // `text_config`. The released 35B escha checkpoint has that shape, so a
+    // top-level read alone finds nothing and the estimate never runs.
+    let field = |key: &str| -> Option<u64> {
+        config
+            .get(key)
+            .or_else(|| config.get("text_config").and_then(|text| text.get(key)))?
+            .as_u64()
+    };
+    let layers = field("num_hidden_layers")?;
+    let experts = field("num_experts")?;
+    let moe_intermediate = field("moe_intermediate_size")?;
+    let hidden = field("hidden_size")?;
+    let vocab = field("vocab_size")?;
+
+    let target = higgs_models::eschamoe::CONVERSION_TARGET;
+    let bits = u64::try_from(target.bits).ok()?;
+    let group_size = u64::try_from(target.group_size).ok()?;
+    let affine_bytes = |params: u64| params * bits / 8 + params * 4 / group_size;
+
+    // Three projections per expert: gate, up, and down.
+    let expert_params = layers * 3 * experts * moe_intermediate * hidden;
+    let expert_bytes = if native {
+        trellis_expert_bytes(&config).unwrap_or_else(|| affine_bytes(expert_params))
+    } else {
+        affine_bytes(expert_params)
+    };
+
+    // The embedding table and the output head.
+    Some(expert_bytes + affine_bytes(2 * vocab * hidden))
+}
+
+/// Sum the trellis code bytes of every expert projection.
+///
+/// Each entry of `quantization_config.layer_meta` gives the expert count, the
+/// two feature lengths, and the rate `K`. The code holds `K` bits for each
+/// weight. Give `None` when the block is absent or an entry lacks a field, so
+/// the caller can fall back.
+fn trellis_expert_bytes(config: &serde_json::Value) -> Option<u64> {
+    let meta = config
+        .get("quantization_config")?
+        .get("layer_meta")?
+        .as_object()?;
+    if meta.is_empty() {
+        return None;
+    }
+    let mut bits = 0u64;
+    for entry in meta.values() {
+        let field = |key: &str| entry.get(key)?.as_u64();
+        bits +=
+            field("num_experts")? * field("in_features")? * field("out_features")? * field("K")?;
+    }
+    Some(bits / 8)
+}
+
+/// Warn when the resident estimate crowds the memory of the machine.
+///
+/// No public accessor gives the Metal working-set limit to the doctor. Thus
+/// the check uses 75% of the total system RAM as a stand-in and says so.
+fn check_eschamoe_memory(
+    estimate: u64,
+    ram_bytes: Option<u64>,
+    label: &str,
+    result: &mut DoctorResult,
+) {
+    let Some(ram) = ram_bytes else { return };
+    let threshold = ram / 4 * 3;
+    if estimate > threshold {
+        warn(
+            &format!(
+                "model {label} needs an estimated {:.1} GiB resident after eschamoe conversion — \
+                 far more than the on-disk size suggests (the 35B release is 12.3 GB on disk but \
+                 ~20 GB resident). That exceeds 75% of system RAM ({:.1} GiB). No Metal \
+                 working-set accessor is available to doctor, so total RAM is the reference; the \
+                 real Metal limit is lower. Expect memory pressure or an OOM kill",
+                gib(estimate),
+                gib(ram)
+            ),
+            result,
+        );
+    } else {
+        pass(
+            &format!(
+                "model {label} estimated resident size after eschamoe conversion (~{:.1} GiB \
+                 weights) fits in system RAM ({:.1} GiB)",
+                gib(estimate),
+                gib(ram)
+            ),
+            result,
+        );
+    }
+}
+
+/// Convert bytes to GiB for display.
+#[allow(clippy::cast_precision_loss, clippy::as_conversions)]
+const fn gib(bytes: u64) -> f64 {
+    bytes as f64 / (1024.0 * 1024.0 * 1024.0)
+}
+
+/// Read the total system RAM in bytes.
+///
+/// The engine reads the Metal working-set limit through a private helper.
+/// The doctor cannot call it, so the doctor reads the total RAM instead.
+#[cfg(target_os = "macos")]
+fn total_system_ram_bytes() -> Option<u64> {
+    let output = std::process::Command::new("sysctl")
+        .args(["-n", "hw.memsize"])
+        .output()
+        .ok()?;
+    String::from_utf8(output.stdout).ok()?.trim().parse().ok()
+}
+
+#[cfg(not(target_os = "macos"))]
+const fn total_system_ram_bytes() -> Option<u64> {
+    None
 }
 
 fn check_duplicate_models(config: &HiggsConfig, result: &mut DoctorResult) {
@@ -1378,6 +1658,163 @@ mod tests {
         // Should pass for model found, but warn for no descriptions
         assert_eq!(result.passes, 1);
         assert_eq!(result.warnings, 1);
+    }
+
+    // -- Eschamoe checkpoint checks --
+
+    fn write_model_dir(files: &[(&str, &str)]) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        for (name, content) in files {
+            std::fs::write(dir.path().join(name), content).unwrap();
+        }
+        dir
+    }
+
+    /// A small eschamoe model dir. The formula gives 2304 estimate bytes:
+    /// params = 2*3*4*8*16 + 2*32*16 = 4096; 4096*4/8 + 4096*4/64 = 2304.
+    fn eschamoe_model_dir() -> tempfile::TempDir {
+        write_model_dir(&[
+            ("quantize_config.json", r#"{"quant_method":"eschamoe"}"#),
+            (
+                "config.json",
+                r#"{"model_type":"qwen3_5_moe","num_hidden_layers":2,"num_experts":4,
+                    "moe_intermediate_size":8,"hidden_size":16,"vocab_size":32}"#,
+            ),
+        ])
+    }
+
+    #[test]
+    fn test_eschamoe_conflicting_quant_method_fails() {
+        let dir = write_model_dir(&[
+            ("quantize_config.json", r#"{"quant_method":"awq"}"#),
+            (
+                "config.json",
+                r#"{"quantization_config":{"quant_method":"eschamoe"}}"#,
+            ),
+        ]);
+        let mut result = empty_result();
+        check_eschamoe_checkpoint_with_ram(dir.path(), "test", Some(1 << 40), true, &mut result);
+        assert_eq!(result.failures, 1);
+        assert_eq!(result.passes, 0);
+    }
+
+    #[test]
+    fn test_eschamoe_malformed_quantize_config_fails() {
+        let dir = write_model_dir(&[("quantize_config.json", "not json")]);
+        let mut result = empty_result();
+        check_eschamoe_checkpoint_with_ram(dir.path(), "test", Some(1 << 40), true, &mut result);
+        assert_eq!(result.failures, 1);
+    }
+
+    #[test]
+    fn test_eschamoe_exceeds_ram_warns_memory() {
+        let dir = eschamoe_model_dir();
+        // 2304 estimate bytes exceed 75% of 1024 bytes of injected RAM.
+        let mut native = empty_result();
+        check_eschamoe_checkpoint_with_ram(dir.path(), "test", Some(1024), true, &mut native);
+        assert_eq!(native.failures, 0);
+        assert_eq!(native.passes, 1);
+        // The native path warns about the memory estimate and nothing else.
+        assert_eq!(native.warnings, 1);
+
+        let mut affine = empty_result();
+        check_eschamoe_checkpoint_with_ram(dir.path(), "test", Some(1024), false, &mut affine);
+        assert_eq!(affine.failures, 0);
+        assert_eq!(affine.passes, 1);
+        // The affine path adds the slow CPU load warning.
+        assert_eq!(affine.warnings, 2);
+    }
+
+    #[test]
+    fn test_eschamoe_fits_ram_passes_memory_check() {
+        let dir = eschamoe_model_dir();
+        let mut native = empty_result();
+        check_eschamoe_checkpoint_with_ram(dir.path(), "test", Some(1 << 40), true, &mut native);
+        assert_eq!(native.failures, 0);
+        // Detection pass plus memory-fit pass, and no warning.
+        assert_eq!(native.passes, 2);
+        assert_eq!(native.warnings, 0);
+
+        let mut affine = empty_result();
+        check_eschamoe_checkpoint_with_ram(dir.path(), "test", Some(1 << 40), false, &mut affine);
+        assert_eq!(affine.passes, 2);
+        assert_eq!(affine.warnings, 1);
+    }
+
+    /// Test that the size fields are found under `text_config` too. A
+    /// checkpoint with a vision tower nests them there, and the released 35B
+    /// escha checkpoint does. The numbers match the flat fixture, so the
+    /// estimate must agree with it.
+    #[test]
+    fn test_eschamoe_estimate_reads_nested_text_config() {
+        let dir = write_model_dir(&[
+            ("quantize_config.json", r#"{"quant_method":"eschamoe"}"#),
+            (
+                "config.json",
+                r#"{"model_type":"qwen3_5_moe","text_config":{"num_hidden_layers":2,
+                    "num_experts":4,"moe_intermediate_size":8,"hidden_size":16,
+                    "vocab_size":32}}"#,
+            ),
+        ]);
+        assert_eq!(
+            eschamoe_resident_estimate_bytes(dir.path(), false),
+            Some(2304)
+        );
+    }
+
+    /// Test the estimate in both modes. The fixture has no `layer_meta`, so
+    /// the native estimate falls back to the affine one.
+    #[test]
+    fn test_eschamoe_resident_estimate_formula() {
+        let dir = eschamoe_model_dir();
+        assert_eq!(
+            eschamoe_resident_estimate_bytes(dir.path(), false),
+            Some(2304)
+        );
+        assert_eq!(
+            eschamoe_resident_estimate_bytes(dir.path(), true),
+            Some(2304)
+        );
+    }
+
+    /// Test that the native estimate reads the trellis rate of each
+    /// projection. The two entries hold 4*8*16*2 and 4*16*8*3 bits, so the
+    /// codes take (1024 + 1536) / 8 = 320 bytes. The vocabulary adds
+    /// 2*32*16 = 1024 params, which take 1024*4/8 + 1024*4/64 = 576 bytes.
+    #[test]
+    fn test_eschamoe_native_estimate_uses_the_trellis_rate() {
+        let dir = write_model_dir(&[
+            ("quantize_config.json", r#"{"quant_method":"eschamoe"}"#),
+            (
+                "config.json",
+                r#"{"model_type":"qwen3_5_moe","num_hidden_layers":2,"num_experts":4,
+                    "moe_intermediate_size":8,"hidden_size":16,"vocab_size":32,
+                    "quantization_config":{"quant_method":"eschamoe","layer_meta":{
+                      "layers.0.mlp.experts.gate_up_proj":{"K":2,"num_experts":4,
+                        "in_features":8,"out_features":16},
+                      "layers.0.mlp.experts.down_proj":{"K":3,"num_experts":4,
+                        "in_features":16,"out_features":8}}}}"#,
+            ),
+        ]);
+        assert_eq!(
+            eschamoe_resident_estimate_bytes(dir.path(), true),
+            Some(320 + 576)
+        );
+        // The affine path ignores `layer_meta` and keeps the old formula.
+        assert_eq!(
+            eschamoe_resident_estimate_bytes(dir.path(), false),
+            Some(2304)
+        );
+    }
+
+    #[test]
+    fn test_non_eschamoe_dir_is_silent() {
+        let dir = write_model_dir(&[("config.json", r#"{"model_type":"llama"}"#)]);
+        let mut result = empty_result();
+        check_eschamoe_checkpoint_with_ram(dir.path(), "test", Some(1 << 40), true, &mut result);
+        assert_eq!(result.passes, 0);
+        assert_eq!(result.warnings, 0);
+        assert_eq!(result.failures, 0);
     }
 
     // -- Provider reachability --

--- a/crates/higgs/src/doctor.rs
+++ b/crates/higgs/src/doctor.rs
@@ -585,7 +585,10 @@ fn check_quant_method_declarations(
         }
     }
     if let [(file_a, method_a), (file_b, method_b)] = methods.as_slice() {
-        if method_a != method_b {
+        // Only an eschamoe-related disagreement concerns this check; other
+        // quantization families (awq vs gptq, say) load fine and are outside
+        // its scope.
+        if method_a != method_b && (method_a == "eschamoe" || method_b == "eschamoe") {
             fail(
                 &format!(
                     "model {label} {file_a} quant_method=\"{method_a}\" conflicts with {file_b} \

--- a/docs/models.md
+++ b/docs/models.md
@@ -57,7 +57,7 @@ Other supported architectures still serve normally in simple mode, but Higgs now
 | Qwen3.5 MoE | `NexVeridian/Qwen3.5-35B-A3B-3bit` |
 | Qwen3.6 MoE | `mlx-community/Qwen3.6-35B-A3B-4bit` |
 | Qwen3.8 dense | `mlx-community/Qwen3.8-27B-4bit` |
-| Qwen3.6 MoE (eschamoe) | `EschaLabs/Qwen3.6-35B-A3B-Escha-W2` (converted at load; see below) |
+| Qwen3.6 MoE (eschamoe) | `EschaLabs/Qwen3.6-35B-A3B-Escha-W2` (trellis experts read natively; see below) |
 | DeepSeek-V2 | `mlx-community/DeepSeek-Coder-V2-Lite-Instruct-4bit-mlx` |
 
 ## Qwen 3.5+ Adapter and Version Notes
@@ -127,8 +127,8 @@ path = "EschaLabs/Qwen3.6-35B-A3B-Escha-W2"
 
 - Local models can be referenced by Hugging Face model ID or local path.
 - The model must be in MLX `safetensors` format. EschaLabs `eschamoe` trellis
-  checkpoints are the exception; Higgs converts them in memory at load (see
-  above).
+  checkpoints are the exception; Higgs reads the trellis experts natively and
+  converts only the remaining weights in memory at load (see above).
 - The checkpoint must use a supported `config.json` `model_type`.
 - macOS local serving requires `mlx.metallib` next to the executable. Release artifacts bundle it, and source builds restore it from Cargo build output when possible.
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -57,6 +57,7 @@ Other supported architectures still serve normally in simple mode, but Higgs now
 | Qwen3.5 MoE | `NexVeridian/Qwen3.5-35B-A3B-3bit` |
 | Qwen3.6 MoE | `mlx-community/Qwen3.6-35B-A3B-4bit` |
 | Qwen3.8 dense | `mlx-community/Qwen3.8-27B-4bit` |
+| Qwen3.6 MoE (eschamoe) | `EschaLabs/Qwen3.6-35B-A3B-Escha-W2` (converted at load; see below) |
 | DeepSeek-V2 | `mlx-community/DeepSeek-Coder-V2-Lite-Instruct-4bit-mlx` |
 
 ## Qwen 3.5+ Adapter and Version Notes
@@ -68,10 +69,66 @@ Other supported architectures still serve normally in simple mode, but Higgs now
 - The cached-model smoke matrix covered `mlx-community/Qwen3.6-35B-A3B-4bit` plus `mlx-community/Llama-3.2-1B-Instruct-4bit`, `mlx-community/Qwen2.5-3B-Instruct-4bit`, `mlx-community/Qwen3-1.7B-4bit`, and `mlx-community/Qwen3-Coder-Next-4bit`.
 - OpenAI-style chat requests use non-thinking mode by default for `Qwen3.6` unless the request explicitly opts into reasoning.
 
+## EschaLabs `eschamoe` Checkpoints
+
+Higgs loads EschaLabs trellis-quantized (`eschamoe`) checkpoints, for example
+`EschaLabs/Qwen3.6-35B-A3B-Escha-W2` (a 2-bit trellis release of
+Qwen3.6-35B-A3B). No config field is needed — detection is automatic:
+
+- A checkpoint is treated as `eschamoe` when `quantize_config.json` declares
+  `quant_method: "eschamoe"`, or, as a fallback, when `config.json` declares it
+  under `quantization_config.quant_method`. `quantize_config.json` wins when
+  both files are present.
+- `model_type` stays `qwen3_5_moe`, so the model serves through the existing
+  Qwen3.5/3.6-MoE path.
+
+### Native and affine paths
+
+Higgs has two ways to load these checkpoints. The native path is the default.
+
+**Native (default).** The expert projections stay in their trellis form and a
+Metal kernel decodes them during the forward pass. Only the non-expert weights
+convert, to MLX affine 4-bit (group size 64). The 35B release holds about
+11 GB and loads in a few seconds.
+
+**Affine (`HIGGS_ESCHA_NATIVE=0`).** Every expert decodes on the CPU and
+requantizes in memory to MLX affine 4-bit — the same layout as
+`mlx-community/Qwen3.6-35B-A3B-4bit`. The same 35B release then holds about
+22 GB and takes roughly 140 s to start, so it needs a machine with memory to
+spare. The path stays available for comparing the kernel against a plain
+affine baseline.
+
+`higgs doctor` estimates the resident size for whichever mode is active and
+warns when it crowds system RAM. On the native path it reads the trellis rate
+of each projection from `quantization_config.layer_meta`; note that the rate
+varies per projection, so a checkpoint named `W2` is not uniformly 2-bit — the
+35B release uses 2 bits for `gate_up_proj` and 3 for `down_proj`.
+
+**Memory: the on-disk size is misleading on the affine path.** The 2-bit
+trellis download is 12.3 GB for the 35B release; converted, it is roughly
+22 GB. Size the machine for the resident number, not the download.
+
+**Limitations.**
+
+- Support is currently text-only.
+- The MTP draft head in the published checkpoint is not usable: it ships the
+  MoE router and shared expert but no routed expert weights, so Higgs disables
+  MTP for this checkpoint and decodes without speculation.
+
+Worked config entry:
+
+```toml
+[[models]]
+name = "qwen36-escha"
+path = "EschaLabs/Qwen3.6-35B-A3B-Escha-W2"
+```
+
 ## Model Input Requirements
 
 - Local models can be referenced by Hugging Face model ID or local path.
-- The model must be in MLX `safetensors` format.
+- The model must be in MLX `safetensors` format. EschaLabs `eschamoe` trellis
+  checkpoints are the exception; Higgs converts them in memory at load (see
+  above).
 - The checkpoint must use a supported `config.json` `model_type`.
 - macOS local serving requires `mlx.metallib` next to the executable. Release artifacts bundle it, and source builds restore it from Cargo build output when possible.
 

--- a/tools/escha_forensics.py
+++ b/tools/escha_forensics.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""Plausibility floor for the escha decode: our decoded weight vs naive RTN
+baselines applied to the *same* base tensor, plus residual structure tests.
+
+Reuses tools/escha_ref.py verbatim for loading + reconstruction; the escha
+side is served from the local LM Studio cache, the base side over HTTP byte
+ranges (one expert slice, a few MB).
+
+    python3 tools/escha_forensics.py [layer] [proj] [expert]
+"""
+
+from __future__ import annotations
+
+import sys
+
+import numpy as np
+
+sys.path.insert(0, "/Users/peppi/Dev/higgs/tools")
+import escha_ref as E  # noqa: E402
+
+LOCAL_ESCHA = "/Users/peppi/.cache/lm-studio/models/EschaLabs/Qwen3.6-35B-A3B-Escha-W2"
+
+_orig_hf_url = E.hf_url
+
+
+def hf_url(repo: str, filename: str) -> str:
+    if repo == E.ESCHA_REPO:
+        return f"{LOCAL_ESCHA}/{filename}"
+    return _orig_hf_url(repo, filename)
+
+
+E.hf_url = hf_url
+
+
+def weight_map(repo: str):
+    if repo not in E._INDEX:
+        if repo == E.ESCHA_REPO:
+            import json
+            with open(f"{LOCAL_ESCHA}/model.safetensors.index.json") as f:
+                E._INDEX[repo] = json.load(f)["weight_map"]
+        else:
+            return _orig_weight_map(repo)
+    return E._INDEX[repo]
+
+
+_orig_weight_map = E.weight_map
+E.weight_map = weight_map
+
+
+# ---------------------------------------------------------------------------
+# naive RTN baselines, applied to the BASE tensor
+# ---------------------------------------------------------------------------
+
+def rtn_sym(w: np.ndarray, bits: int, group: int | None) -> np.ndarray:
+    """Symmetric absmax RTN over `w` [out, in].
+
+    group=None -> one scale per output channel (row).
+    group=g    -> one scale per contiguous run of g input channels within a row.
+    Levels: {-2^(b-1) .. 2^(b-1)-1}, s = absmax / 2^(b-1).
+    """
+    out, inn = w.shape
+    g = inn if group is None else group
+    assert inn % g == 0
+    x = w.reshape(out, inn // g, g)
+    qmax = 2 ** (bits - 1)
+    s = np.abs(x).max(axis=-1, keepdims=True) / qmax
+    s = np.where(s == 0, 1.0, s)
+    q = np.clip(np.rint(x / s), -qmax, qmax - 1)
+    return (q * s).reshape(out, inn)
+
+
+def rtn_asym(w: np.ndarray, bits: int, group: int | None) -> np.ndarray:
+    """Asymmetric min/max RTN (the usual GPTQ/AWQ baseline), same grouping."""
+    out, inn = w.shape
+    g = inn if group is None else group
+    assert inn % g == 0
+    x = w.reshape(out, inn // g, g)
+    lo = x.min(axis=-1, keepdims=True)
+    hi = x.max(axis=-1, keepdims=True)
+    s = (hi - lo) / (2 ** bits - 1)
+    s = np.where(s == 0, 1.0, s)
+    q = np.clip(np.rint((x - lo) / s), 0, 2 ** bits - 1)
+    return (q * s + lo).reshape(out, inn)
+
+
+# ---------------------------------------------------------------------------
+# residual structure tests
+# ---------------------------------------------------------------------------
+
+def mod_profile(v: np.ndarray, keep: np.ndarray, stride: int) -> np.ndarray:
+    """Mean of `v` grouped by index mod `stride`, over live channels only.
+
+    `v` is indexed in the ORIGINAL (unmasked) channel space so that `i % 16` and
+    `i % 128` still mean tile row and Hadamard-block lane; `keep` marks which
+    entries of `v` are meaningful.
+    """
+    idx = np.arange(len(v)) % stride
+    num = np.bincount(idx[keep], weights=v[keep], minlength=stride)
+    den = np.bincount(idx[keep], minlength=stride)
+    return num[den > 0] / den[den > 0]
+
+
+def structure(name: str, r: np.ndarray, ref: np.ndarray,
+              rows: np.ndarray, cols: np.ndarray) -> dict:
+    """r, ref are FULL [out, in]; rows/cols are the live masks (index space kept)."""
+    live = np.ix_(rows, cols)
+    a = np.zeros_like(ref)
+    w = np.zeros_like(ref)
+    a[live] = np.abs(r[live])
+    w[live] = np.abs(ref[live])
+    nr, nc = rows.sum(), cols.sum()
+    # per-channel RELATIVE error: |R| profile normalised by the base tensor's own
+    # per-channel magnitude, so a channel that is simply large in W does not read
+    # as "structure". Structure = the decode being worse on some channels.
+    ch = (a.sum(axis=1) / nc) / (w.sum(axis=1) / nc + 1e-30)   # per output channel
+    ci = (a.sum(axis=0) / nr) / (w.sum(axis=0) / nr + 1e-30)   # per input channel
+    rl, rf = r[live], ref[live]
+    d = {"name": name, "rel_fro": float(np.linalg.norm(rl) / np.linalg.norm(rf))}
+    for tag, prof, keep in (("out", ch, rows), ("in", ci, cols)):
+        live_prof = prof[keep]
+        d[f"{tag}_min"] = float(live_prof.min())
+        d[f"{tag}_max"] = float(live_prof.max())
+        d[f"{tag}_ratio"] = float(live_prof.max() / (live_prof.min() + 1e-30))
+        d[f"{tag}_cv"] = float(live_prof.std() / (live_prof.mean() + 1e-30))
+        for stride in (16, 128):
+            p = mod_profile(prof, keep, stride)
+            d[f"{tag}_mod{stride}"] = float(p.max() / (p.min() + 1e-30))
+    return d
+
+
+def fmt_struct(d: dict) -> str:
+    return (f"  {d['name']:<26} relF={d['rel_fro']:.4f}  "
+            f"|R| per-out ch min/max/ratio = {d['out_min']:.3e}/{d['out_max']:.3e}/"
+            f"{d['out_ratio']:8.2f}  cv={d['out_cv']:.3f}\n"
+            f"  {'':<26} |R| per-in  ch min/max/ratio = {d['in_min']:.3e}/{d['in_max']:.3e}/"
+            f"{d['in_ratio']:8.2f}  cv={d['in_cv']:.3f}\n"
+            f"  {'':<26} mod-16 peak/trough: out={d['out_mod16']:.3f} in={d['in_mod16']:.3f}   "
+            f"mod-128: out={d['out_mod128']:.3f} in={d['in_mod128']:.3f}")
+
+
+def runs(idx: np.ndarray) -> list[tuple[int, int]]:
+    """Contiguous runs in a sorted index array, as (start, length)."""
+    if len(idx) == 0:
+        return []
+    brk = np.where(np.diff(idx) != 1)[0]
+    starts = np.r_[0, brk + 1]
+    ends = np.r_[brk, len(idx) - 1]
+    return [(int(idx[s]), int(e - s + 1)) for s, e in zip(starts, ends)]
+
+
+def dead(layer: int = 0, expert: int = 0) -> int:
+    """What does our decode put in the structurally-dead channels?
+
+    Every cosine in the table above was live-MASKED. This measures the part that
+    was masked out, and asks whether the checkpoint itself signals deadness.
+    """
+    print(f"===== layer {layer}, expert {expert} =====")
+    info = {}
+    for proj in ("gate_up_proj", "down_proj"):
+        prefix = E.prefix_for(layer, proj)
+        k = E.escha_k(prefix)
+        cfg = E.shard_for(E.ESCHA_REPO, f"{prefix}.escha_config").get(
+            f"{prefix}.escha_config").tolist()
+        t = E.load_expert(prefix, expert)
+        ours = E.reconstruct(t, k, "both_outside").astype(np.float32)
+        ref = E.base_ref(prefix, expert, ours).astype(np.float32)
+        rows, cols = E.live_mask(ref)          # <- derived from the BASE tensor
+        dr = np.where(~rows)[0]
+        dc = np.where(~cols)[0]
+
+        # NOTE cfg layout: [tile, K, bits, mcg, num_experts, in, out, in_p, out_p]
+        print(f"\n{proj}  shape={list(ours.shape)} [out, in]  K={k}")
+        print(f"  escha_config in={cfg[5]} out={cfg[6]} in_p={cfg[7]} out_p={cfg[8]}"
+              f"   -> padded? in:{cfg[7] != cfg[5]}  out:{cfg[8] != cfg[6]}")
+        print(f"  live rows(out) {rows.sum()}/{len(rows)}   dead {len(dr)}")
+        print(f"  live cols(in)  {cols.sum()}/{len(cols)}   dead {len(dc)}")
+
+        # (2) magnitude of OUR decode in the dead output rows
+        for tag, idx, ax in (("row(out)", dr, 1), ("col(in)", dc, 0)):
+            if len(idx) == 0:
+                continue
+            keep = np.ones(ours.shape[1 - ax], dtype=bool)  # unused axis, all
+            o_rms = np.sqrt((ours ** 2).mean(axis=ax))
+            live_idx = np.setdiff1d(np.arange(len(o_rms)), idx)
+            dmean = float(o_rms[idx].mean())
+            lmean = float(o_rms[live_idx].mean())
+            print(f"  OURS dead {tag}: RMS mean={dmean:.4e} max={o_rms[idx].max():.4e}"
+                  f"  | live RMS mean={lmean:.4e}  -> dead/live = {dmean / (lmean + 1e-30):.4f}")
+            print(f"       dead {tag} exactly zero? {np.all(np.take(ours, idx, axis=1 - ax) == 0)}"
+                  f"   max|ours| on dead = {np.abs(np.take(ours, idx, axis=1 - ax)).max():.4e}")
+            # (3) what the BASE holds there
+            b = np.take(ref, idx, axis=1 - ax)
+            print(f"       BASE on dead {tag}: all exact zero? {np.all(b == 0)}"
+                  f"   max|base| = {np.abs(b).max():.4e}")
+
+        # (4) does the checkpoint signal deadness?
+        for nm in ("r_out", "s_out", "r_in", "s_in"):
+            v = np.asarray(t[nm]).astype(np.float32)
+            nz = int((v == 0).sum())
+            print(f"  escha {nm:5} len={len(v):5}  #exact-zero={nz:5}"
+                  f"  min|nonzero|={np.abs(v[v != 0]).min() if nz < len(v) else 0:.3e}")
+        rz = np.where(np.asarray(t["r_out"]).astype(np.float32) == 0)[0]
+        if len(dr):
+            print(f"  r_out zero-set == dead out-row set? "
+                  f"{len(rz) == len(dr) and bool(np.all(rz == dr))}  "
+                  f"(|r_out==0|={len(rz)}, |dead rows|={len(dr)})")
+        info[proj] = (ours.shape, dr, dc, rows, cols)
+
+    # (5) index pattern / gate-up split arithmetic
+    gu_shape, gu_dr, _, _, _ = info["gate_up_proj"]
+    _, _, dp_dc, _, dp_cols = info["down_proj"]
+    half = gu_shape[0] // 2
+    g_dead = gu_dr[gu_dr < half]
+    u_dead = gu_dr[gu_dr >= half] - half
+    print(f"\n-- index pattern --")
+    print(f"  gate_up out={gu_shape[0]} -> gate[0:{half}] + up[{half}:{gu_shape[0]}]"
+          f"   moe_intermediate_size={half}")
+    print(f"  dead in gate half: {len(g_dead)}   dead in up half: {len(u_dead)}")
+    print(f"  gate-dead set == up-dead set? {len(g_dead) == len(u_dead) and bool(np.all(g_dead == u_dead))}")
+    print(f"  down_proj dead in-cols: {len(dp_dc)}   == gate-dead set? "
+          f"{len(dp_dc) == len(g_dead) and bool(np.all(dp_dc == g_dead))}")
+    print(f"  first 24 dead gate idx: {g_dead[:24].tolist()}")
+    print(f"  contiguous runs (start,len), first 8: {runs(g_dead)[:8]}   total runs={len(runs(g_dead))}")
+    if len(g_dead):
+        print(f"  dead idx mod 16 histogram: {np.bincount(g_dead % 16, minlength=16).tolist()}")
+    return 0
+
+
+def main(layer: int = 0, proj: str = "gate_up_proj", expert: int = 0) -> int:
+    prefix = E.prefix_for(layer, proj)
+    k = E.escha_k(prefix)
+    cfg = E.shard_for(E.ESCHA_REPO, f"{prefix}.escha_config").get(f"{prefix}.escha_config")
+    ours = E.reconstruct(E.load_expert(prefix, expert), k, "both_outside")
+    ref = E.base_ref(prefix, expert, ours)
+    print(f"tensor: {prefix}  expert={expert}  K={k}  bits={cfg.tolist()[2]}  shape={list(ours.shape)}")
+    print(f"escha_config = {cfg.tolist()}")
+
+    rows, cols = E.live_mask(ref)
+    live = np.ix_(rows, cols)
+    print(f"live: {rows.sum()}/{len(rows)} out rows, {cols.sum()}/{len(cols)} in cols")
+
+    ref = ref.astype(np.float32)
+    refl = ref[live]
+    full = {
+        "escha decode (ours)": ours.astype(np.float32),
+        "RTN 2-bit, per-out-ch (absmax)": rtn_sym(ref, 2, None),
+        "RTN 2-bit, group-64 (absmax)": rtn_sym(ref, 2, 64),
+        "RTN 2-bit, per-out-ch (asym)": rtn_asym(ref, 2, None),
+        "RTN 2-bit, group-64 (asym)": rtn_asym(ref, 2, 64),
+        "RTN 4-bit, group-64 (absmax)": rtn_sym(ref, 4, 64),
+        "RTN 4-bit, group-64 (asym)": rtn_asym(ref, 4, 64),
+        "RTN 8-bit, group-64 (asym)": rtn_asym(ref, 8, 64),
+    }
+    cands = {k2: v[live] for k2, v in full.items()}
+
+    print("\n  method                          cosine    per-row   rel.fro  sqrt(1-rel^2)  <R,W>/|R||W|")
+    for name, a in cands.items():
+        glob = float((a * refl).sum() / (np.linalg.norm(a) * np.linalg.norm(refl) + 1e-12))
+        na = np.linalg.norm(a, axis=1)
+        nb = np.linalg.norm(refl, axis=1)
+        per_row = float(((a * refl).sum(axis=1) / (na * nb + 1e-12)).mean())
+        r = refl - a
+        rel = float(np.linalg.norm(r) / np.linalg.norm(refl))
+        orth = float((r * refl).sum() / (np.linalg.norm(r) * np.linalg.norm(refl) + 1e-12))
+        print(f"  {name:<32} {glob:+.4f}   {per_row:+.4f}   {rel:.4f}   "
+              f"{np.sqrt(max(0.0, 1 - rel * rel)):.4f}        {orth:+.4f}")
+    print(f"\n  Gaussian rate-distortion bound at R bits: rel.fro = 2^-R  ->  "
+          f"R=2: 0.2500   R=3: 0.1250   (this tensor's trellis rate K={k})")
+
+    print("\nresidual structure  (R = base - method)")
+    for name in ("escha decode (ours)", "RTN 2-bit, group-64 (absmax)"):
+        print(fmt_struct(structure(name, ref - full[name], ref, rows, cols)))
+    return 0
+
+
+if __name__ == "__main__":
+    a = [int(x) if x.lstrip("-").isdigit() else x for x in sys.argv[1:]]
+    if a and a[0] == "dead":
+        sys.exit(dead(*a[1:]))
+    sys.exit(main(*a))

--- a/tools/escha_forensics.py
+++ b/tools/escha_forensics.py
@@ -11,14 +11,19 @@ ranges (one expert slice, a few MB).
 
 from __future__ import annotations
 
+import os
 import sys
+from pathlib import Path
 
 import numpy as np
 
-sys.path.insert(0, "/Users/peppi/Dev/higgs/tools")
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 import escha_ref as E  # noqa: E402
 
-LOCAL_ESCHA = "/Users/peppi/.cache/lm-studio/models/EschaLabs/Qwen3.6-35B-A3B-Escha-W2"
+LOCAL_ESCHA = os.environ.get(
+    "ESCHA_LOCAL_MODEL",
+    "/Users/peppi/.cache/lm-studio/models/EschaLabs/Qwen3.6-35B-A3B-Escha-W2",
+)
 
 _orig_hf_url = E.hf_url
 

--- a/tools/escha_nonexpert.py
+++ b/tools/escha_nonexpert.py
@@ -2,24 +2,36 @@
 """Non-expert forensics: escha (int8/bf16) vs mlx-community 4-bit, tensor by tensor.
 
 Offline, numpy only, one tensor at a time via safetensors byte ranges.
-Reuses tools/escha_ref.py's Shard reader.
+Reuses tools/escha_ref.py's Shard reader. Import-only helper code — run the
+analysis by importing and calling :func:`cos_table` / :func:`layout` from a
+REPL or script.
 
-    python3 tools/escha_nonexpert.py cos        # cosine table
-    python3 tools/escha_nonexpert.py layout     # conv1d / gate / lm_head traps
+Environment:
+    ESCHA_LOCAL_MODEL   path to the eschamoe checkpoint
+                        (default: the EschaLabs Qwen3.6-35B-A3B-Escha-W2 cache)
+    BASE_LOCAL_MODEL    path to the reference 4-bit checkpoint
 """
 
 from __future__ import annotations
 
 import json
+import os
 import sys
+from pathlib import Path
 
 import numpy as np
 
-sys.path.insert(0, "/Users/peppi/Dev/higgs/tools")
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 import escha_ref as E  # noqa: E402
 
-ESCHA = "/Users/peppi/.cache/lm-studio/models/EschaLabs/Qwen3.6-35B-A3B-Escha-W2"
-BASE = "/Users/peppi/.cache/lm-studio/models/mlx-community/Qwen3.6-35B-A3B-4bit"
+ESCHA = os.environ.get(
+    "ESCHA_LOCAL_MODEL",
+    "/Users/peppi/.cache/lm-studio/models/EschaLabs/Qwen3.6-35B-A3B-Escha-W2",
+)
+BASE = os.environ.get(
+    "BASE_LOCAL_MODEL",
+    "/Users/peppi/.cache/lm-studio/models/mlx-community/Qwen3.6-35B-A3B-4bit",
+)
 
 E._DTYPES.setdefault("U32", np.dtype("<u4"))
 E._DTYPES.setdefault("U16", np.dtype("<u2"))
@@ -76,14 +88,24 @@ def raw_get(root: str, key: str, rows: slice | None = None) -> np.ndarray:
     return np.frombuffer(raw, dtype=dt).reshape(shape)
 
 
-QCFG = json.load(open(f"{BASE}/config.json"))["quantization"]
+_QCFG: dict | None = None
+
+
+def _qcfg() -> dict:
+    """Load the reference checkpoint's quantization block on first use, so an
+    import needs no checkpoint on disk."""
+    global _QCFG
+    if _QCFG is None:
+        _QCFG = json.load(open(f"{BASE}/config.json"))["quantization"]
+    return _QCFG
 
 
 def qbits(module: str) -> tuple[int, int]:
-    v = QCFG.get(module)
+    v = _qcfg().get(module)
     if isinstance(v, dict):
         return int(v["group_size"]), int(v["bits"])
-    return int(QCFG["group_size"]), int(QCFG["bits"])
+    cfg = _qcfg()
+    return int(cfg["group_size"]), int(cfg["bits"])
 
 
 def deq_affine(root: str, module: str, rows: slice | None = None) -> np.ndarray:

--- a/tools/escha_nonexpert.py
+++ b/tools/escha_nonexpert.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Non-expert forensics: escha (int8/bf16) vs mlx-community 4-bit, tensor by tensor.
+
+Offline, numpy only, one tensor at a time via safetensors byte ranges.
+Reuses tools/escha_ref.py's Shard reader.
+
+    python3 tools/escha_nonexpert.py cos        # cosine table
+    python3 tools/escha_nonexpert.py layout     # conv1d / gate / lm_head traps
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import numpy as np
+
+sys.path.insert(0, "/Users/peppi/Dev/higgs/tools")
+import escha_ref as E  # noqa: E402
+
+ESCHA = "/Users/peppi/.cache/lm-studio/models/EschaLabs/Qwen3.6-35B-A3B-Escha-W2"
+BASE = "/Users/peppi/.cache/lm-studio/models/mlx-community/Qwen3.6-35B-A3B-4bit"
+
+E._DTYPES.setdefault("U32", np.dtype("<u4"))
+E._DTYPES.setdefault("U16", np.dtype("<u2"))
+
+_IDX: dict[str, dict] = {}
+_SH: dict[tuple[str, str], E.Shard] = {}
+
+
+def wmap(root: str) -> dict[str, str]:
+    if root not in _IDX:
+        _IDX[root] = json.load(open(f"{root}/model.safetensors.index.json"))["weight_map"]
+    return _IDX[root]
+
+
+def shard(root: str, key: str) -> E.Shard:
+    fn = wmap(root)[key]
+    if (root, fn) not in _SH:
+        _SH[(root, fn)] = E.Shard(f"{root}/{fn}")
+    return _SH[(root, fn)]
+
+
+def get(root: str, key: str, rows: slice | None = None) -> np.ndarray:
+    """Read a tensor, optionally only `rows` of the leading axis."""
+    s = shard(root, key)
+    meta = s.header[key]
+    dt = E._DTYPES[meta["dtype"]]
+    shape = list(meta["shape"])
+    begin, end = meta["data_offsets"]
+    if rows is not None:
+        stride = int(np.prod(shape[1:])) * dt.itemsize
+        lo, hi, _ = rows.indices(shape[0])
+        begin, end = begin + lo * stride, begin + hi * stride
+        shape[0] = hi - lo
+    raw = s._read(s.data_start + begin, end - begin)
+    a = np.frombuffer(raw, dtype=dt).reshape(shape)
+    if meta["dtype"] == "BF16":
+        a = (a.astype(np.uint32) << 16).view(np.float32)
+    return a.astype(np.float32) if a.dtype != np.float32 else a
+
+
+def raw_get(root: str, key: str, rows: slice | None = None) -> np.ndarray:
+    """Same but keeps the on-disk integer dtype (for packed uint32 / int8)."""
+    s = shard(root, key)
+    meta = s.header[key]
+    dt = E._DTYPES[meta["dtype"]]
+    shape = list(meta["shape"])
+    begin, end = meta["data_offsets"]
+    if rows is not None:
+        stride = int(np.prod(shape[1:])) * dt.itemsize
+        lo, hi, _ = rows.indices(shape[0])
+        begin, end = begin + lo * stride, begin + hi * stride
+        shape[0] = hi - lo
+    raw = s._read(s.data_start + begin, end - begin)
+    return np.frombuffer(raw, dtype=dt).reshape(shape)
+
+
+QCFG = json.load(open(f"{BASE}/config.json"))["quantization"]
+
+
+def qbits(module: str) -> tuple[int, int]:
+    v = QCFG.get(module)
+    if isinstance(v, dict):
+        return int(v["group_size"]), int(v["bits"])
+    return int(QCFG["group_size"]), int(QCFG["bits"])
+
+
+def deq_affine(root: str, module: str, rows: slice | None = None) -> np.ndarray:
+    """MLX affine dequant: w = q * scale + bias, groups along the last axis."""
+    g, b = qbits(module)
+    packed = raw_get(root, f"{module}.weight", rows).view(np.uint32)
+    scales = get(root, f"{module}.scales", rows)
+    biases = get(root, f"{module}.biases", rows)
+    per = 32 // b
+    shifts = (np.arange(per, dtype=np.uint32) * b)
+    q = (packed[..., None] >> shifts) & np.uint32((1 << b) - 1)
+    q = q.reshape(*packed.shape[:-1], packed.shape[-1] * per).astype(np.float32)
+    n = q.shape[-1]
+    q = q.reshape(*q.shape[:-1], n // g, g)
+    w = q * scales[..., None] + biases[..., None]
+    return w.reshape(*packed.shape[:-1], n)
+
+
+def deq_int8(root: str, module: str, rows: slice | None = None) -> np.ndarray:
+    q = raw_get(root, f"{module}.weight_int8", rows).astype(np.float32)
+    s = get(root, f"{module}.weight_scale", rows)
+    return q * s.reshape(-1, *([1] * (q.ndim - 1)))
+
+
+def cos(a: np.ndarray, b: np.ndarray) -> float:
+    a = a.ravel().astype(np.float64)
+    b = b.ravel().astype(np.float64)
+    return float(a @ b / (np.linalg.norm(a) * np.linalg.norm(b) + 1e-30))
+
+
+def rowcos(a: np.ndarray, b: np.ndarray) -> float:
+    a = a.reshape(a.shape[0], -1).astype(np.float64)
+    b = b.reshape(b.shape[0], -1).astype(np.float64)
+    n = np.linalg.norm(a, axis=1) * np.linalg.norm(b, axis=1)
+    ok = n > 0
+    return float(((a * b).sum(axis=1)[ok] / n[ok]).mean()) if ok.any() else 0.0
+
+
+def escha_key(module: str) -> str:
+    """De-normalize back to the escha checkpoint's own naming."""
+    if module.startswith("language_model.model."):
+        return "model.language_model." + module[len("language_model.model."):]
+    if module.startswith("language_model.lm_head"):
+        return module[len("language_model."):]
+    return module
+
+
+def escha_side(module: str, rows: slice | None = None) -> tuple[np.ndarray, str]:
+    k = escha_key(module)
+    wm = wmap(ESCHA)
+    if f"{k}.weight_int8" in wm:
+        return deq_int8(ESCHA, k, rows), "int8"
+    if f"{k}.weight" in wm:
+        return get(ESCHA, f"{k}.weight", rows), "f16"
+    return get(ESCHA, k, rows), "f16"
+
+
+def base_side(module: str, rows: slice | None = None) -> tuple[np.ndarray, str]:
+    wm = wmap(BASE)
+    if f"{module}.scales" in wm:
+        g, b = qbits(module)
+        return deq_affine(BASE, module, rows), f"q{b}g{g}"
+    if f"{module}.weight" in wm:
+        return get(BASE, f"{module}.weight", rows), "bf16"
+    return get(BASE, module, rows), "bf16"

--- a/tools/escha_ref.py
+++ b/tools/escha_ref.py
@@ -1,0 +1,464 @@
+#!/usr/bin/env python3
+"""NumPy reference decoder for EschaLabs' `eschamoe` weight format.
+
+Phase 0 oracle for native eschamoe support in higgs. This is deliberately slow
+and dependency-light (numpy only) -- it exists to pin the format and to serve as
+ground truth for the Metal kernel, not to run a model.
+
+The trellis layout is exllamav3's EXL3 (MIT), batched over experts:
+
+  escha_code  I16 [E, in/16, out/16, 16*K]   <- EXL3 `trellis`
+  escha_rin   F16 [E, in]                    <- EXL3 `suh`
+  escha_rout  F16 [E, out]                   <- EXL3 `svh`
+  escha_s_in  F32 [E, in]                    escha addition
+  escha_s_out F32 [E, out]                   escha addition
+  escha_config I32 [9]                       escha addition
+
+Bit packing and the tile permutation are ported literally from
+exllamav3_ext/quant/pack.cu (`unpack_trellis_kernel`) and
+exl3_lib/quantize.py (`tensor_core_perm`). The 3INST codebook is
+codebook.cuh `decode_3inst<1>`.
+
+Pinned empirically against the unquantized `Qwen/Qwen3.6-35B-A3B`, by scoring
+every plausible ordering (`probe`) rather than reversing the shipped wheel --
+the right one wins by a landslide (0.97 vs 0.00 cosine):
+
+  escha_config = [tile=16, K, bits, mcg, num_experts, in, out, in_p, out_p]
+  W[out, in]   = (Had_128 . Ŵ . Had_128 * r_in[:,None] * r_out[None,:]).T
+                 with tiles decoding to [in, out]; both scales OUTSIDE the
+                 Hadamard.
+  escha_s_in / escha_s_out are identically 1.0 in this checkpoint -- carried
+  through anyway, since nothing guarantees that for future ones.
+
+Verified over layers {0,1,3,20,39} x experts {0,7} x both projections
+(K=2 and K=3): global cosine 0.945 - 0.990 against the base model.
+
+Usage:
+    python3 tools/escha_ref.py gate [layers] [experts]        # Phase 0 gate
+    python3 tools/escha_ref.py probe [layer] [proj] [expert]  # score orderings
+    python3 tools/escha_ref.py dump <layer> <proj> <expert> <out.npy>
+
+`layers` and `experts` are comma-separated index specs, each item a single
+index or an inclusive range: `0-39`, `0,7,15`, `0-3,20`. Both default to the
+sample above.
+
+All three read the checkpoints over HTTP with byte ranges, so a run costs a few
+MB rather than a full shard download.
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+import sys
+import urllib.request
+
+import numpy as np
+
+ESCHA_REPO = "EschaLabs/Qwen3.6-35B-A3B-Escha-W2"
+BASE_REPO = "Qwen/Qwen3.6-35B-A3B"
+
+MCG_MULT = np.uint32(0xCBAC1FED)
+LOP3_AND = np.uint32(0x8FFF8FFF)
+LOP3_XOR = np.uint32(0x3B603B60)
+HAD_BLOCK = 128
+
+
+# ---------------------------------------------------------------------------
+# safetensors reading (header parse + byte ranges; no dependency, works on both
+# a local file and an HTTP URL so the Phase 0 gate needs ~10MB, not 3GB)
+# ---------------------------------------------------------------------------
+
+_DTYPES = {
+    "F64": np.dtype("<f8"), "F32": np.dtype("<f4"), "F16": np.dtype("<f2"),
+    "I64": np.dtype("<i8"), "I32": np.dtype("<i4"), "I16": np.dtype("<i2"),
+    "I8": np.dtype("<i1"), "U8": np.dtype("<u1"), "BOOL": np.dtype("?"),
+    "BF16": np.dtype("<u2"),  # widened to f32 on read
+}
+
+
+class Shard:
+    """Random-access reader for one safetensors file, local path or URL."""
+
+    def __init__(self, src: str):
+        self.src = src
+        self.remote = src.startswith("http")
+        n = struct.unpack("<Q", self._read(0, 8))[0]
+        self.header = json.loads(self._read(8, n))
+        self.data_start = 8 + n
+
+    def _read(self, offset: int, length: int) -> bytes:
+        if not self.remote:
+            with open(self.src, "rb") as f:
+                f.seek(offset)
+                return f.read(length)
+        req = urllib.request.Request(
+            self.src, headers={"Range": f"bytes={offset}-{offset + length - 1}"}
+        )
+        with urllib.request.urlopen(req) as r:
+            return r.read()
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.header
+
+    def keys(self):
+        return [k for k in self.header if k != "__metadata__"]
+
+    def get(self, key: str, index: int | None = None) -> np.ndarray:
+        """Read a tensor. `index` slices the leading (expert) axis, so only that
+        slice is transferred -- the point of the whole range-read design."""
+        meta = self.header[key]
+        dt = _DTYPES[meta["dtype"]]
+        shape = list(meta["shape"])
+        begin, end = meta["data_offsets"]
+
+        if index is not None:
+            stride = int(np.prod(shape[1:])) * dt.itemsize
+            begin += index * stride
+            end = begin + stride
+            shape = shape[1:]
+
+        raw = self._read(self.data_start + begin, end - begin)
+        arr = np.frombuffer(raw, dtype=dt).reshape(shape)
+        if meta["dtype"] == "BF16":
+            arr = (arr.astype(np.uint32) << 16).view(np.float32)
+        return arr
+
+
+def hf_url(repo: str, filename: str) -> str:
+    return f"https://huggingface.co/{repo}/resolve/main/{filename}"
+
+
+_INDEX: dict[str, dict[str, str]] = {}
+_SHARDS: dict[tuple[str, str], "Shard"] = {}
+
+
+def weight_map(repo: str) -> dict[str, str]:
+    if repo not in _INDEX:
+        with urllib.request.urlopen(hf_url(repo, "model.safetensors.index.json")) as r:
+            _INDEX[repo] = json.load(r)["weight_map"]
+    return _INDEX[repo]
+
+
+def shard_for(repo: str, key: str) -> "Shard":
+    """The shard holding `key`. A single module's tensors can straddle a shard
+    boundary, so this must be resolved per tensor, not per prefix."""
+    fn = weight_map(repo)[key]
+    if (repo, fn) not in _SHARDS:
+        _SHARDS[(repo, fn)] = Shard(hf_url(repo, fn))
+    return _SHARDS[(repo, fn)]
+
+
+def resolve_shard(repo: str, key: str) -> str:
+    return hf_url(repo, weight_map(repo)[key])
+
+
+# ---------------------------------------------------------------------------
+# Trellis unpack -- literal port of exllamav3_ext/quant/pack.cu
+# ---------------------------------------------------------------------------
+
+def unpack_trellis(packed: np.ndarray, k: int) -> np.ndarray:
+    """(..., 16*K) int16 -> (..., 256) uint16 tail-biting trellis codes.
+
+    Each code is a 16-bit window into a circular 256*K-bit stream at stride K;
+    consecutive codes overlap by 16-K bits. Thread `t` of the CUDA kernel emits
+    codes 2t and 2t+1, so this vectorizes over t in [0, 128).
+    """
+    assert packed.shape[-1] == 16 * k, f"expected last dim {16 * k}, got {packed.shape[-1]}"
+    lead = packed.shape[:-1]
+    u32 = packed.reshape(-1, 16 * k).view(np.uint32)  # (N, 8*K)
+    n_words = k * 256 // 32
+
+    t = np.arange(128)
+    b0 = t * 2 * k + k - 16 + 256 * k
+    b2 = b0 + k + 16
+    i0 = b0 // 32
+    i1 = (b2 - 1) // 32
+    s1 = (i1 + 1) * 32 - b2
+
+    a = u32[:, i0 % n_words].astype(np.uint64)
+    b = u32[:, i1 % n_words].astype(np.uint64)
+
+    # __funnelshift_r(lo=b, hi=a, s1): bits [s1+31:s1] of the 64-bit {a, b}
+    w1 = (((a << np.uint64(32)) | b) >> s1.astype(np.uint64)).astype(np.uint32)
+    w0 = (w1 >> np.uint32(k)) & np.uint32(0xFFFF)
+    w1 = w1 & np.uint32(0xFFFF)
+
+    codes = np.empty((u32.shape[0], 256), dtype=np.uint16)
+    codes[:, 0::2] = w0
+    codes[:, 1::2] = w1
+    return codes.reshape(*lead, 256)
+
+
+def tensor_core_perm() -> np.ndarray:
+    """256-entry 16x16 tile permutation (exl3_lib/quantize.py)."""
+    perm = np.empty(256, dtype=np.int64)
+    for t in range(32):
+        r0 = (t % 4) * 2
+        c0 = t // 4
+        rows = (r0, r0 + 1, r0 + 8, r0 + 9)
+        for j, c in enumerate((c0, c0 + 8)):
+            for i, r in enumerate(rows):
+                perm[t * 8 + j * 4 + i] = r * 16 + c
+    return perm
+
+
+PERM = tensor_core_perm()
+
+
+def decode_3inst(codes: np.ndarray) -> np.ndarray:
+    """codebook.cuh decode_3inst<1>: MCG multiply, mask/xor into two fp16 lanes,
+    sum them. `lop3.b32 ... 0x6a` is (a & b) ^ c."""
+    x = codes.astype(np.uint32) * MCG_MULT
+    x = (x & LOP3_AND) ^ LOP3_XOR
+    halves = x.view(np.uint16).reshape(*x.shape, 2).astype(np.uint16)
+    return halves.view(np.float16).astype(np.float32).sum(axis=-1)
+
+
+def decode_tiles(code: np.ndarray, k: int) -> np.ndarray:
+    """[tk, tn, 16*K] int16 -> [tk*16, tn*16] float32, permutation undone."""
+    tk, tn = code.shape[0], code.shape[1]
+    vals = decode_3inst(unpack_trellis(code, k))          # [tk, tn, 256]
+    tiles = np.empty_like(vals)
+    tiles[..., PERM] = vals                                # scatter to row-major
+    return tiles.reshape(tk, tn, 16, 16).transpose(0, 2, 1, 3).reshape(tk * 16, tn * 16)
+
+
+def had128(x: np.ndarray, axis: int) -> np.ndarray:
+    """Orthonormal blockwise Sylvester Hadamard over `axis` in 128-wide blocks."""
+    x = np.moveaxis(x, axis, -1)
+    shape = x.shape
+    y = x.reshape(-1, shape[-1] // HAD_BLOCK, HAD_BLOCK).astype(np.float32)
+    h = 1
+    while h < HAD_BLOCK:
+        y = y.reshape(y.shape[0], y.shape[1], -1, 2, h)
+        lo, hi = y[..., 0, :], y[..., 1, :]
+        y = np.stack([lo + hi, lo - hi], axis=-2)
+        h *= 2
+    y = y.reshape(shape) / np.sqrt(HAD_BLOCK)
+    return np.moveaxis(y, -1, axis)
+
+
+# ---------------------------------------------------------------------------
+# Reconstruction
+# ---------------------------------------------------------------------------
+
+# (name, fp16 scale inside the Hadamard?, fp32 scale inside?)
+VARIANTS = [
+    ("both_outside", False, False),
+    ("r_inside", True, False),
+    ("both_inside", True, True),
+    ("s_inside", False, True),
+]
+
+
+def reconstruct(t: dict[str, np.ndarray], k: int, variant: str) -> np.ndarray:
+    """Rebuild one expert's weight as [out, in] float32.
+
+    Tiles decode to [in, out]; scales are per-input-channel (`*_in`) and
+    per-output-channel (`*_out`). The Hadamard is blockwise-128 on both axes.
+    """
+    _, r_inside, s_inside = next(v for v in VARIANTS if v[0] == variant)
+    w = decode_tiles(t["code"], k)                                     # [in, out]
+
+    def sc(inside: bool, which: str) -> np.ndarray:
+        keys = [key for key, ins in (("r", r_inside), ("s", s_inside)) if ins == inside]
+        out = np.ones(w.shape[0 if which == "in" else 1], dtype=np.float32)
+        for key in keys:
+            out = out * t[f"{key}_{which}"].astype(np.float32)
+        return out
+
+    w = w * sc(True, "in")[:, None] * sc(True, "out")[None, :]
+    w = had128(had128(w, axis=0), axis=1)
+    w = w * sc(False, "in")[:, None] * sc(False, "out")[None, :]
+    return w.T
+
+
+TENSORS = (("code", "code"), ("r_in", "rin"), ("r_out", "rout"),
+           ("s_in", "s_in"), ("s_out", "s_out"))
+
+
+def load_expert(prefix: str, expert: int, repo: str = ESCHA_REPO) -> dict[str, np.ndarray]:
+    return {
+        short: shard_for(repo, f"{prefix}.escha_{name}").get(
+            f"{prefix}.escha_{name}", index=expert
+        )
+        for short, name in TENSORS
+    }
+
+
+def escha_k(prefix: str, repo: str = ESCHA_REPO) -> int:
+    key = f"{prefix}.escha_code"
+    return int(shard_for(repo, key).header[key]["shape"][-1]) // 16
+
+
+def live_mask(ref: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Rows/columns of `ref` that are not structurally dead.
+
+    Qwen3.6's experts have pruned intermediate channels: whole `gate_up` output
+    rows are exactly zero, and so are the matching `down_proj` input columns
+    (280 of 512 in layer 0 expert 0). Escha only encodes the dead structure on
+    the output side, via exact zeros in `escha_rout` -- on the input side the
+    trellis codes for dead columns are unconstrained don't-cares, because the
+    activation feeding them is exactly zero at inference (SwiGLU of a zero row).
+    Scoring that garbage would report a correct decode as broken.
+    """
+    return np.linalg.norm(ref, axis=1) > 0, np.linalg.norm(ref, axis=0) > 0
+
+
+def cosine(a: np.ndarray, b: np.ndarray) -> tuple[float, float]:
+    """(global cosine, mean per-row cosine), both over live entries of `b`."""
+    rows, cols = live_mask(b)
+    a, b = a[np.ix_(rows, cols)], b[np.ix_(rows, cols)]
+    if b.size == 0:
+        return 0.0, 0.0
+    glob = float((a * b).sum() / (np.linalg.norm(a) * np.linalg.norm(b) + 1e-12))
+    na, nb = np.linalg.norm(a, axis=1), np.linalg.norm(b, axis=1)
+    per_row = float(((a * b).sum(axis=1) / (na * nb + 1e-12)).mean())
+    return glob, per_row
+
+
+# ---------------------------------------------------------------------------
+
+def prefix_for(layer: int, proj: str) -> str:
+    return f"model.language_model.layers.{layer}.mlp.experts.{proj}"
+
+
+def base_ref(prefix: str, expert: int, like: np.ndarray) -> np.ndarray:
+    """The unquantized expert, oriented to match `like`. The base checkpoint
+    stores stacked experts under the bare module name (no `.weight`)."""
+    ref = shard_for(BASE_REPO, prefix).get(prefix, index=expert)
+    return ref.T if ref.shape != like.shape else ref
+
+
+def score(layer: int, proj: str, expert: int, variant: str = "both_outside"):
+    prefix = prefix_for(layer, proj)
+    w = reconstruct(load_expert(prefix, expert), escha_k(prefix), variant)
+    ref = base_ref(prefix, expert, w)
+    glob, rows = cosine(w, ref)
+    live = np.ix_(*live_mask(ref))
+    rel = float(np.linalg.norm(w[live] - ref[live]) / (np.linalg.norm(ref[live]) + 1e-12))
+    return glob, rows, rel
+
+
+def probe(layer: int = 0, proj: str = "gate_up_proj", expert: int = 0) -> int:
+    """Pin the scale/Hadamard ordering: score every variant against the
+    unquantized base model. Only the correct ordering scores high."""
+    prefix = prefix_for(layer, proj)
+    cfg = shard_for(ESCHA_REPO, f"{prefix}.escha_config").get(f"{prefix}.escha_config")
+    print(f"{prefix}\nescha_config = {cfg.tolist()}   K = {escha_k(prefix)}")
+
+    print("\n  variant         global   per-row   rel.fro")
+    best = ("", -1.0)
+    for name, _, _ in VARIANTS:
+        glob, rows, rel = score(layer, proj, expert, name)
+        print(f"  {name:<14}  {glob:+.4f}  {rows:+.4f}   {rel:.4f}")
+        if glob > best[1]:
+            best = (name, glob)
+    print(f"\nbest: {best[0]}  global cosine={best[1]:+.4f}")
+    return 0 if best[1] >= 0.9 else 1
+
+
+GATE_LAYERS = (0, 1, 3, 20, 39)
+GATE_EXPERTS = (0, 7)
+
+
+def index_set(spec: str, default: tuple[int, ...]) -> tuple[int, ...]:
+    """Parse an index spec: comma-separated items, each a single index `N` or
+    an inclusive range `A-B`. An empty spec keeps `default`."""
+    if not spec:
+        return default
+    out: list[int] = []
+    for item in spec.split(","):
+        lo, _, hi = item.partition("-")
+        out.extend(range(int(lo), int(hi or lo) + 1))
+    return tuple(out)
+
+
+def gate(layers: str = "", experts: str = "") -> int:
+    """Phase 0 gate: decode must track the unquantized base model everywhere.
+
+    `layers` and `experts` are index specs (see `index_set`). Each empty one
+    keeps the sample the format was pinned on: layers {0,1,3,20,39} x experts
+    {0,7}. A run costs two range reads per cell, so a wide sweep is slow but
+    still cheap in bytes.
+    """
+    print("layer  expert  gate_up   down")
+    worst, worst_at = 1.0, ""
+    for layer in index_set(layers, GATE_LAYERS):
+        for expert in index_set(experts, GATE_EXPERTS):
+            cols = [score(layer, proj, expert)[0] for proj in ("gate_up_proj", "down_proj")]
+            print(f"  {layer:3}  {expert:5}   {cols[0]:+.4f}  {cols[1]:+.4f}")
+            for proj, c in zip(("gate_up_proj", "down_proj"), cols):
+                if c < worst:
+                    worst, worst_at = c, f"L{layer}.{proj}.e{expert}"
+    print(f"\nworst: {worst:+.4f} at {worst_at}")
+    if worst >= 0.9:
+        print("GATE PASS")
+        return 0
+    print("GATE FAIL (need >= 0.9)")
+    return 1
+
+
+def write_safetensors(path: str, tensors: dict[str, np.ndarray]) -> None:
+    """Minimal safetensors writer (the `safetensors` package is not a dep here)."""
+    rev = {v: k for k, v in _DTYPES.items() if k != "BF16"}
+    header, blobs, offset = {}, [], 0
+    for name, arr in tensors.items():
+        arr = np.ascontiguousarray(arr)
+        header[name] = {
+            "dtype": rev[arr.dtype],
+            "shape": list(arr.shape),
+            "data_offsets": [offset, offset + arr.nbytes],
+        }
+        offset += arr.nbytes
+        blobs.append(arr.tobytes())
+    blob = json.dumps(header).encode()
+    pad = (-len(blob)) % 8
+    with open(path, "wb") as f:
+        f.write(struct.pack("<Q", len(blob) + pad))
+        f.write(blob + b" " * pad)
+        for b in blobs:
+            f.write(b)
+
+
+def fixture(out: str = "/tmp/escha_fixture.safetensors", layer: int = 0,
+            proj: str = "gate_up_proj", expert: int = 0) -> int:
+    """Dump one expert plus its expected dequantization, for the Rust test to
+    check `dequant_expert` against this validated reference end to end."""
+    prefix = prefix_for(layer, proj)
+    t = load_expert(prefix, expert)
+    w = reconstruct(t, escha_k(prefix), "both_outside")
+    write_safetensors(out, {
+        "code": t["code"].astype("<i2"),
+        "rin": t["r_in"].astype("<f2"), "rout": t["r_out"].astype("<f2"),
+        "s_in": t["s_in"].astype("<f4"), "s_out": t["s_out"].astype("<f4"),
+        "expected": w.astype("<f4"),
+    })
+    glob, _ = cosine(w, base_ref(prefix, expert, w))
+    print(f"wrote {out}  expected{list(w.shape)}  (cosine vs base {glob:+.4f})")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    cmd = argv[1] if len(argv) > 1 else ""
+    args = [int(a) if a.lstrip("-").isdigit() else a for a in argv[2:]]
+    if cmd == "probe":
+        return probe(*args)
+    if cmd == "gate":
+        return gate(*argv[2:])
+    if cmd == "fixture":
+        return fixture(*args)
+    if cmd == "dump" and len(args) == 4:
+        layer, proj, expert, out = args
+        prefix = prefix_for(layer, proj)
+        w = reconstruct(load_expert(prefix, expert), escha_k(prefix), "both_outside")
+        np.save(out, w)
+        print(f"wrote {out} {list(w.shape)}")
+        return 0
+    print(__doc__)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tools/escha_ref.py
+++ b/tools/escha_ref.py
@@ -91,12 +91,22 @@ class Shard:
         if not self.remote:
             with open(self.src, "rb") as f:
                 f.seek(offset)
-                return f.read(length)
+                data = f.read(length)
+            if len(data) != length:
+                raise OSError(f"short read: {len(data)} != {length}")
+            return data
         req = urllib.request.Request(
             self.src, headers={"Range": f"bytes={offset}-{offset + length - 1}"}
         )
-        with urllib.request.urlopen(req) as r:
-            return r.read()
+        # HTTPS only: the repo URL is fixed, but a redirected or spoofed
+        # scheme would otherwise pass straight through to urlopen.
+        if not req.full_url.startswith("https://"):
+            raise ValueError(f"refusing non-https URL: {req.full_url}")
+        with urllib.request.urlopen(req, timeout=120) as r:
+            data = r.read()
+        if len(data) != length:
+            raise OSError(f"short range read: {len(data)} != {length}")
+        return data
 
     def __contains__(self, key: str) -> bool:
         return key in self.header
@@ -113,6 +123,10 @@ class Shard:
         begin, end = meta["data_offsets"]
 
         if index is not None:
+            if not 0 <= index < shape[0]:
+                raise IndexError(
+                    f"{key}: index {index} out of range for axis 0 of {shape[0]}"
+                )
             stride = int(np.prod(shape[1:])) * dt.itemsize
             begin += index * stride
             end = begin + stride

--- a/tools/escha_subset.py
+++ b/tools/escha_subset.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Assemble a small but real eschamoe checkpoint for loader/forward testing.
+
+The published checkpoint is 12.3GB, which is more disk than a dev box
+necessarily has spare. Almost none of it is needed to exercise the loader: the
+layers are homogeneous and the experts are interchangeable. This builds a
+truncated checkpoint holding the first N layers (enough to cover both a GDN
+layer and a full-attention one) with the expert axis sliced down, plus the
+embeddings, final norm and lm_head.
+
+Every tensor is copied verbatim, so the trellis codes, scales and int8 weights
+are real data in the real layout -- only the counts shrink. Output is a few
+hundred MB.
+
+The expert axis is leading on every per-expert tensor, so slicing it is a
+contiguous byte prefix: a subset costs one ranged GET per tensor and no
+server-side work.
+
+Usage:
+    python3 tools/escha_subset.py <out_dir> [layers] [experts] [source_dir]
+
+Give `source_dir` to read a local copy of the full checkpoint. Then the tool
+makes the subset with no network.
+
+Defaults to 4 layers (indices 0-3, so `full_attention_interval=4` yields three
+GDN layers and one full-attention layer) and 32 experts.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import struct
+import sys
+import urllib.request
+
+from escha_ref import ESCHA_REPO, hf_url, weight_map
+
+# Per-expert tensors: leading axis is the expert, so a subset is a byte prefix.
+EXPERT_AXIS_KEYS = (".escha_code", ".escha_rin", ".escha_rout",
+                    ".escha_s_in", ".escha_s_out", ".mlp.gate.weight")
+# Index of `num_experts` within the 9-element escha_config vector.
+CONFIG_NUM_EXPERTS = 4
+
+DTYPE_SIZE = {"F64": 8, "F32": 4, "F16": 2, "BF16": 2,
+              "I64": 8, "I32": 4, "I16": 2, "I8": 1, "U8": 1, "BOOL": 1}
+
+TOKENIZER_FILES = ("tokenizer.json", "tokenizer_config.json", "vocab.json",
+                   "merges.txt", "generation_config.json", "chat_template.jinja")
+
+
+class Source:
+    """A checkpoint on a local disk or on the Hugging Face hub.
+
+    A local directory is much faster. Use it when the full checkpoint is
+    already available. The tool then makes the subset with no network.
+    """
+
+    def __init__(self, root: str | None = None):
+        self.root = os.path.expanduser(root) if root else None
+        self._headers: dict[str, tuple[dict, int]] = {}
+
+    @property
+    def local(self) -> bool:
+        return self.root is not None
+
+    def index(self) -> dict[str, str]:
+        """Give the map from a tensor name to its shard file."""
+        if not self.local:
+            return weight_map(ESCHA_REPO)
+        with open(os.path.join(self.root, "model.safetensors.index.json")) as f:
+            return json.load(f)["weight_map"]
+
+    def text(self, name: str) -> bytes:
+        """Read a small file, for example `config.json`."""
+        if not self.local:
+            with urllib.request.urlopen(hf_url(ESCHA_REPO, name)) as r:
+                return r.read()
+        with open(os.path.join(self.root, name), "rb") as f:
+            return f.read()
+
+    def header(self, filename: str) -> tuple[dict, int]:
+        """Give the safetensors header and the start of the data."""
+        if filename not in self._headers:
+            size = struct.unpack("<Q", self.read(filename, 0, 8))[0]
+            header = json.loads(self.read(filename, 8, size))
+            self._headers[filename] = (header, 8 + size)
+        return self._headers[filename]
+
+    def read(self, filename: str, start: int, length: int) -> bytes:
+        """Read `length` bytes at offset `start`.
+
+        The function tries the read four times. A short read makes an
+        incorrect tensor, and the error is difficult to find later.
+        """
+        if self.local:
+            with open(os.path.join(self.root, filename), "rb") as f:
+                f.seek(start)
+                data = f.read(length)
+            if len(data) != length:
+                raise OSError(f"short read: {len(data)} != {length}")
+            return data
+
+        url = hf_url(ESCHA_REPO, filename)
+        for attempt in range(4):
+            try:
+                req = urllib.request.Request(
+                    url, headers={"Range": f"bytes={start}-{start + length - 1}"}
+                )
+                data = urllib.request.urlopen(req, timeout=120).read()
+                if len(data) == length:
+                    return data
+                raise OSError(f"short read: {len(data)} != {length}")
+            except Exception as exc:  # noqa: BLE001 - the code tries again
+                if attempt == 3:
+                    raise
+                print(f"    retry {attempt + 1} ({exc})", file=sys.stderr)
+        raise AssertionError("unreachable")
+
+
+def rewrite_config_experts(data: bytes, experts: int) -> bytes:
+    """Clamp `num_experts` inside a packed 9-element escha_config vector."""
+    vals = list(struct.unpack(f"<{len(data) // 4}i", data))
+    vals[CONFIG_NUM_EXPERTS] = min(vals[CONFIG_NUM_EXPERTS], experts)
+    return struct.pack(f"<{len(vals)}i", *vals)
+
+
+def wanted(key: str, layers: int) -> bool:
+    if key.startswith("mtp."):
+        return False  # partial head in this checkpoint; the loader disables it
+    if ".layers." not in key:
+        return True
+    index = int(key.split(".layers.")[1].split(".")[0])
+    return index < layers
+
+
+def subset(out_dir: str, layers: int = 4, experts: int = 32,
+           source: str | None = None) -> int:
+    src = Source(source)
+    os.makedirs(out_dir, exist_ok=True)
+    print(f"source: {src.root or ESCHA_REPO}")
+    wmap = src.index()
+    keys = sorted(k for k in wmap if wanted(k, layers))
+    print(f"{len(keys)} tensors from {len(set(wmap[k] for k in keys))} shards")
+
+    # Plan every tensor first: the safetensors header carries all offsets, so it
+    # must be complete before a single byte of payload is written.
+    plan, offset = [], 0
+    for key in keys:
+        filename = wmap[key]
+        header, data_start = src.header(filename)
+        meta = header[key]
+        shape = list(meta["shape"])
+        begin, end = meta["data_offsets"]
+        nbytes = end - begin
+
+        if any(key.endswith(s) for s in EXPERT_AXIS_KEYS) and shape[0] > experts:
+            nbytes = nbytes * experts // shape[0]
+            shape[0] = experts
+
+        plan.append({
+            "key": key, "dtype": meta["dtype"], "shape": shape,
+            "src": (filename, data_start + begin, nbytes),
+            "data_offsets": [offset, offset + nbytes],
+        })
+        offset += nbytes
+
+    header = {p["key"]: {"dtype": p["dtype"], "shape": p["shape"],
+                         "data_offsets": p["data_offsets"]} for p in plan}
+    blob = json.dumps(header).encode()
+    pad = (-len(blob)) % 8
+    total = offset
+
+    out_path = os.path.join(out_dir, "model.safetensors")
+    print(f"writing {out_path} ({total / 2**30:.2f} GiB payload)")
+    with open(out_path, "wb") as f:
+        f.write(struct.pack("<Q", len(blob) + pad))
+        f.write(blob + b" " * pad)
+        for i, p in enumerate(plan, 1):
+            filename, start, nbytes = p["src"]
+            data = src.read(filename, start, nbytes)
+            if p["key"].endswith(".escha_config"):
+                # Rewrite num_experts so the spec matches the sliced tensors.
+                # (`p["shape"]` here is the config vector's own length, not an
+                # expert count -- it must not be used for this.)
+                data = rewrite_config_experts(data, experts)
+            f.write(data)
+            if i % 25 == 0 or i == len(plan):
+                print(f"  {i}/{len(plan)}")
+
+    write_configs(out_dir, layers, experts, src)
+    return 0
+
+
+def write_configs(out_dir: str, layers: int, experts: int,
+                  src: "Source | None" = None) -> None:
+    src = src or Source()
+    cfg = json.loads(src.text("config.json"))
+
+    text = cfg["text_config"]
+    text["num_hidden_layers"] = layers
+    text["layer_types"] = text["layer_types"][:layers]
+    text["num_experts"] = experts
+    text["num_experts_per_tok"] = min(text["num_experts_per_tok"], experts)
+    # No `mtp.layers.*` survive the subset, so don't advertise a draft head.
+    text["mtp_num_hidden_layers"] = 0
+    # Text-only: the published checkpoint ships no vision weights anyway.
+    cfg.pop("vision_config", None)
+    cfg["architectures"] = ["Qwen3_5MoeForCausalLM"]
+
+    quant = cfg.get("quantization_config", {})
+    if "layer_meta" in quant:
+        quant["layer_meta"] = {
+            k: v for k, v in quant["layer_meta"].items() if wanted(k, layers)
+        }
+        for meta in quant["layer_meta"].values():
+            meta["num_experts"] = min(meta.get("num_experts", experts), experts)
+    if "global_config" in quant:
+        quant["global_config"]["num_experts"] = experts
+
+    # Target the same affine layout as the reference build
+    # (mlx-community/Qwen3.6-35B-A3B-4bit): 4-bit g=64 throughout, with the two
+    # router gates per layer at 8-bit. The loader dequantizes the trellis and
+    # requantizes into this, so a Phase-1 build is layout-identical to the
+    # baseline and any quality delta is attributable to escha's 2-bit source.
+    quantization = {"group_size": 64, "bits": 4, "mode": "affine"}
+    for layer in range(layers):
+        for gate in ("mlp.gate", "mlp.shared_expert_gate"):
+            quantization[f"language_model.model.layers.{layer}.{gate}"] = {
+                "group_size": 64,
+                "bits": 8,
+            }
+    cfg["quantization"] = quantization
+
+    with open(os.path.join(out_dir, "config.json"), "w") as f:
+        json.dump(cfg, f, indent=2)
+    with open(os.path.join(out_dir, "quantize_config.json"), "w") as f:
+        json.dump({"quant_method": "eschamoe", "bits": 2.0}, f, indent=2)
+
+    for name in TOKENIZER_FILES:
+        try:
+            body = src.text(name)
+        except Exception:  # noqa: BLE001 - these files are optional
+            continue
+        with open(os.path.join(out_dir, name), "wb") as f:
+            f.write(body)
+
+    print(f"wrote config for {layers} layers x {experts} experts -> {out_dir}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(__doc__)
+        sys.exit(2)
+    args = [int(a) if a.isdigit() else a for a in sys.argv[1:]]
+    sys.exit(subset(*args))

--- a/tools/escha_subset.py
+++ b/tools/escha_subset.py
@@ -154,9 +154,15 @@ def subset(out_dir: str, layers: int = 4, experts: int = 32,
         begin, end = meta["data_offsets"]
         nbytes = end - begin
 
-        if any(key.endswith(s) for s in EXPERT_AXIS_KEYS) and shape[0] > experts:
-            nbytes = nbytes * experts // shape[0]
-            shape[0] = experts
+        if any(key.endswith(s) for s in EXPERT_AXIS_KEYS):
+            # Track the true expert count the tensors hold: a requested
+            # `experts` above the checkpoint's count would make config.json
+            # advertise experts the payload does not have, and escha_config
+            # would disagree with it.
+            experts = min(experts, shape[0])
+            if shape[0] > experts:
+                nbytes = nbytes * experts // shape[0]
+                shape[0] = experts
 
         plan.append({
             "key": key, "dtype": meta["dtype"], "shape": shape,


### PR DESCRIPTION
## Summary
- Load EschaLabs trellis-quantized Qwen3.5-MoE checkpoints, including `EschaLabs/Qwen3.6-35B-A3B-Escha-W2`.
- Convert the released expert representation to verified affine tensors and install native Metal trellis expert weights by default.
- Normalize checkpoint quantization at the shared loader entry point so adapter-routed and direct loads behave identically.
- Add doctor/residency validation, model documentation, and conversion/reference tooling.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy -p higgs-models -- -D warnings`
- `cargo clippy -p higgs --lib -- -D warnings`
- `cargo test -p higgs eschamoe --lib` (8 passed)
- `cargo test -p higgs-models eschamoe --lib` (34 passed)
- `cargo test -p higgs-models test_load_qwen35 --lib` (7 passed)
- Real-GPU release E2E: load `Qwen3.6-35B-A3B-Escha-W2` with native trellis enabled; a chat request returned exactly `PINEAPPLE` (19 prompt / 4 completion tokens).

`HIGGS_ESCHA_NATIVE=0` retains the affine conversion fallback for diagnostics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for EschaLabs `eschamoe` trellis-quantized Qwen3.6 MoE checkpoints.
  - Checkpoints are detected automatically and support native or converted loading paths.
  - Added native Apple Silicon support with memory estimates and configuration guidance.
  - Added `higgs doctor` checks for quantization validity, memory requirements, and CPU or memory pressure.
  - Added utilities for analyzing and creating reduced Eschamoe checkpoints.

- **Documentation**
  - Documented setup, conversion requirements, supported loading paths, limitations, and Apple Silicon recommendations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->