### PR TITLE
fix: resolve new clippy lints from stable toolchain update

### DIFF
--- a/crates/higgs-models/src/bonsai_q1.rs
+++ b/crates/higgs-models/src/bonsai_q1.rs
@@ -1219,8 +1219,10 @@ fn load_packed(
     }
 
     let w_packed: Vec<u32> = w_bytes
-        .chunks_exact(4)
-        .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .map(|c| u32::from_le_bytes(*c))
         .collect();
     let scales = bytes_to_f16_vec(s_bytes);
     let biases = bytes_to_f16_vec(b_bytes);
@@ -1240,8 +1242,10 @@ fn load_f16(tensors: &SafeTensors<'_>, name: &str) -> Result<Vec<f16>, String> {
 }
 
 fn bytes_to_f16_vec(b: &[u8]) -> Vec<f16> {
-    b.chunks_exact(2)
-        .map(|c| f16::from_bits(u16::from_le_bytes([c[0], c[1]])))
+    b.as_chunks::<2>()
+        .0
+        .iter()
+        .map(|c| f16::from_bits(u16::from_le_bytes(*c)))
         .collect()
 }
 

--- a/crates/higgs-models/src/qwen3_next.rs
+++ b/crates/higgs-models/src/qwen3_next.rs
@@ -7986,7 +7986,7 @@ mod tests {
         });
 
         candidates.into_iter().find(|path| {
-            Array::load_safetensors(path).ok().is_some_and(|loaded| {
+            Array::load_safetensors(path).is_ok_and(|loaded| {
                 loaded.keys().any(|key| {
                     key.contains("switch_mlp")
                         && key.contains("gate_proj")

--- a/crates/higgs-models/src/turboquant.rs
+++ b/crates/higgs-models/src/turboquant.rs
@@ -1951,8 +1951,10 @@ mod tests {
             }
             // Reinterpret CPU bytes as u32 words for comparison
             let cpu_words: Vec<u32> = cpu_packed
-                .chunks_exact(4)
-                .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .map(|c| u32::from_le_bytes(*c))
                 .collect();
 
             // GPU pack (outputs u32 words)
@@ -2003,8 +2005,10 @@ mod tests {
             // Reinterpret CPU bytes as u32 words for comparison
             let cpu_words: Vec<u32> = cpu_result
                 .packed_codes
-                .chunks_exact(4)
-                .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .map(|c| u32::from_le_bytes(*c))
                 .collect();
             let gpu_codes_data = gpu_codes.as_slice::<u32>();
             assert_eq!(
@@ -2051,8 +2055,10 @@ mod tests {
             // Reinterpret CPU bytes as u32 words for comparison
             let cpu_code_words: Vec<u32> = cpu_result
                 .packed_codes
-                .chunks_exact(4)
-                .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .map(|c| u32::from_le_bytes(*c))
                 .collect();
             assert_eq!(
                 gpu_codes.as_slice::<u32>(),


### PR DESCRIPTION
A newer stable clippy enabled two lints that the workspace now trips, failing the CI `Lint` job on `main` and consequently on every open pull request:

- `clippy::chunks_exact_to_as_chunks` -- 5 sites in `higgs-models` (`bonsai_q1.rs`, `turboquant.rs`)
- `clippy::manual_is_variant_and` -- 1 site in `qwen3_next.rs`

`as_chunks::<N>().0` yields only the complete chunks and discards the remainder, matching the previous `chunks_exact` behavior exactly, so tail handling is unchanged at every site.

This unblocks the open Renovate PRs (#277, #278, #279, #281, #282, #285), all of which currently fail `Lint` for this reason alone while `Test` and `Build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DsFAXPsdsNLL6EnFtAhTuT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined internal binary decoding and byte-conversion logic without changing behavior.
  - Improved test helper readability and efficiency while preserving existing results.
  - Updated GPU-versus-CPU comparison tests to use equivalent array-based conversions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->