### PR TITLE
ci(release): use the non-deprecated cask depends_on form

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -330,7 +330,7 @@ jobs:
             desc "Desktop dashboard and chat UI for the Higgs inference server; bundles the higgs CLI"
             homepage "https://github.com/panbanda/higgs"
 
-            depends_on macos: ">= :sonoma"
+            depends_on macos: :sonoma
             depends_on arch: :arm64
 
             app "Higgs.app"


### PR DESCRIPTION
Homebrew prints a deprecation warning for `depends_on macos: ">= :sonoma"` when installing the cask; the symbol form `depends_on macos: :sonoma` expresses the same minimum version without the warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Homebrew installation requirement to target macOS Sonoma specifically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->